### PR TITLE
[CenCon] #276 product-agent skill appends a ready-for-dev item to a named work list over REST

### DIFF
--- a/.claude/skills/product-agent/skill.md
+++ b/.claude/skills/product-agent/skill.md
@@ -91,15 +91,59 @@ gh issue create --repo thefrederiksen/cc-director \
   --label "flow:ready-dev" --label "<bug|enhancement>"
 ```
 
-### Step 4: Report
+### Step 4: Optionally append the item to a named work list (#276)
+
+After the issue carries `flow:ready-dev`, you MAY also append it to a named work list on the
+Gateway so it enters an ordered queue the queue runner (#274) drains. This is the producer side of
+epic #270. It is **opt-in and additive**: the `flow:ready-dev` label remains the single source of
+truth for the item's STATUS; the list append only sets its ORDER / queue membership. An item that is
+never appended still flows through the method exactly as before (the loop's no-argument selection
+still picks it up).
+
+**When you append:** only when a list name was given to you explicitly (a `--list <name>` style
+argument, or a list name the human named in the request). There is NO built-in default list and you
+NEVER invent or auto-create one. If no list name was specified, you do NOT append - you leave the
+item label-only and say so in the report. (`flow:ready-dev` alone is a complete, working state.)
+
+The list must already exist (created by a human or the Cockpit). The append targets the shipped
+named-work-list REST surface from #273 (`src/CcDirector.Gateway/Api/WorkListEndpoints.cs`); a
+missing list returns 404 and you do NOT create it - report that the named list does not exist and
+stop appending. You never create the list (`POST /lists`) yourself; creating queues is not your job.
+
+**The append call.** Resolve the Gateway base URL from `config.json` `gateway.url` (or the explicit
+URL the human gave); when the Gateway has auth enabled, send `Authorization: Bearer <token>` with
+the Gateway token (`%LOCALAPPDATA%\cc-director\<gateway-token-file>` via `GatewayAuth`). Because this
+skill files GitHub issues, the ref is ALWAYS `source = "github"` and `id` is the issue number as a
+string; `area` is optional - set it from the issue's area prefix (e.g. `Gateway`, `Cockpit`) or omit
+it. POST exactly the structured ref - never a status field (the list stores order, not status):
+
+```bash
+# <BASE> = gateway base url (e.g. http://127.0.0.1:7878). Add -H "Authorization: Bearer <token>"
+# only when the Gateway runs with auth enabled. <NAME> is the explicitly-chosen list name.
+curl -s -X POST "<BASE>/lists/<NAME>/items" \
+  -H "Content-Type: application/json" \
+  -d '{"source":"github","id":"<issue#>","area":"<area-or-omit>"}'
+# 200 -> { "name": "<NAME>", "appended": { "source": "github", "id": "<issue#>", "area": "..." } }
+# 400 -> source or id was empty/missing (a code defect here, since both are always set)
+# 404 -> no such list (you do NOT create it; report and stop appending)
+```
+
+Then confirm the ref landed in order with `GET /lists/<NAME>` (`WorkListDto` =
+`{ name, items: [{ source, id, area? }, ...], consumer }`). Note the payload carries NO status field,
+so the append can never duplicate or shadow the `flow:ready-dev` status - that is structural in the
+shipped contract.
+
+### Step 5: Report
 
 Always report: issue number, kind, the `flow:ready-dev` label, a direct link, and a one-line reason
-it is ready. (Standing rule: always give link + why.)
+it is ready. (Standing rule: always give link + why.) When you appended to a list, name the list and
+the resulting order; when you did NOT (no list specified), say the item is label-only.
 
 ```
 Created issue #NNN: [Area] <title>
 - Label: flow:ready-dev  (Developer Agent can pick this up)
 - DoR: 7/7 PASS
+- Work list: appended to "<NAME>" at position <k>  (or: none specified - label-only)
 - Link: https://github.com/thefrederiksen/cc-director/issues/NNN
 - Ready because: <one line>
 ```
@@ -135,10 +179,18 @@ Use a short bracketed area: `[Cockpit]`, `[Desktop]`, `[Gateway]`, `[ControlApi]
 - You do not move issues past `flow:ready-dev` (that is the Developer Agent's and QA Agent's job).
 - You do not close issues.
 - You do not commit or push.
+- You do not invent, auto-create, or guess a work-list name, and you do not `POST /lists` to create
+  one. If no list was named, the item stays label-only (Step 4).
 
 ---
 
-**Skill Version:** 0.1 (DRAFT - first of the four CenCon agents, cc-director)
+**Skill Version:** 0.2 (DRAFT - first of the four CenCon agents, cc-director)
 **Implements:** Product Agent role in docs/cencon/DEVELOPMENT_METHOD.md
 **Builds on:** enter-issue (gh creation mechanics)
 **Created:** 2026-06-09
+**Changes in 0.2 (#276):** Added the optional, opt-in work-list append step (Step 4) - after labeling
+`flow:ready-dev`, the skill may append the issue to an EXPLICITLY NAMED work list via the #273
+`POST /lists/{name}/items` surface as `{ source: "github", id: "<issue#>", area? }`, entering the
+ordered queue the #274 runner drains. No default list and never auto-creates one (a missing list is a
+404 it reports, not creates); label-only items are unchanged. The report (now Step 5) names the list
+and order or says label-only.

--- a/docs/cencon/proof/issue-276/qa-report.html
+++ b/docs/cencon/proof/issue-276/qa-report.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #276 - QA Agent Proof Report</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --ink: #e6e8ec; --muted: #9aa3b2;
+    --accent: #1d76db; --ok: #2ea043; --warn: #d29922; --line: #2a2f3a; --mono: #0b0d11;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; line-height: 1.5; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 32px 24px 64px; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 16px; margin: 32px 0 10px; padding-bottom: 6px; border-bottom: 1px solid var(--line); }
+  .sub { color: var(--muted); font-size: 13px; }
+  .meta { display: flex; flex-wrap: wrap; gap: 8px 20px; margin: 14px 0 0; font-size: 13px; color: var(--muted); }
+  .meta b { color: var(--ink); font-weight: 600; }
+  .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px 18px; margin: 12px 0; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; vertical-align: top; padding: 9px 10px; border-bottom: 1px solid var(--line); }
+  th { color: var(--muted); font-weight: 600; }
+  .pill { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+  .pass { background: rgba(46,160,67,.15); color: #6fd082; border: 1px solid rgba(46,160,67,.4); }
+  code, pre { font-family: "Cascadia Code", Consolas, monospace; }
+  pre { background: var(--mono); border: 1px solid var(--line); border-radius: 8px; padding: 14px 16px;
+    overflow-x: auto; font-size: 12.5px; color: #cdd3dc; }
+  .tag { font-family: monospace; background: rgba(29,118,219,.16); color: #76b3ef; padding: 1px 6px; border-radius: 4px; }
+  .done { background: rgba(46,160,67,.12); border: 1px solid rgba(46,160,67,.5); border-radius: 8px;
+    padding: 14px 18px; margin-top: 24px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Issue #276 - product-agent skill appends a ready-for-dev item to a named work list over REST</h1>
+  <div class="sub">CenCon Development Method - QA Agent INDEPENDENT proof report. Child 5 of epic #270.</div>
+  <div class="meta">
+    <span><b>Issue:</b> #276</span>
+    <span><b>PR:</b> #285</span>
+    <span><b>Branch:</b> issue-276-product-append</span>
+    <span><b>Verdict:</b> <span class="pill pass">VERIFIED - all 4 acceptance criteria met</span></span>
+  </div>
+
+  <div class="panel">
+    <b>How QA verified independently.</b> The QA Agent did NOT reuse the Developer Agent's binary,
+    port (7950), or transcript. It built the named-work-list REST surface
+    (<code>WorkListEndpoints</code> + <code>WorkListStore</code>) directly from the PR-branch source
+    and booted ONLY that surface on a fresh loopback port (<code>http://127.0.0.1:7951</code>, no auth,
+    fresh in-memory store) - the exact code production maps via
+    <code>GatewayHost.StartAsync() -> WorkListEndpoints.Map(_app, _workLists)</code>. It then drove the
+    documented skill append path with its own real curl HTTP calls and read every response.
+    <br><br>
+    <b>Contract conformance.</b> The skill (<code>.claude/skills/product-agent/skill.md</code> Step 4)
+    documents ONLY the shipped #273 endpoints - <code>POST /lists/{name}/items</code> and
+    <code>GET /lists/{name}</code> - and explicitly forbids <code>POST /lists</code> auto-create / any
+    default list. This matches <code>src/CcDirector.Gateway/Api/WorkListEndpoints.cs</code> exactly
+    (200 -> { name, appended }; 400 on empty source/id; 404 on missing list, no create;
+    GET -> WorkListDto { name, items[], consumer } with NO status field). No invented endpoint.
+  </div>
+
+  <h2>Acceptance criteria (Expected vs Actual)</h2>
+  <table>
+    <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA observed)</th><th>Result</th></tr>
+    <tr>
+      <td>1</td>
+      <td>After flow:ready-dev, append issue via POST /lists/{name}/items as { source:"github", id, area? }; GET shows it in order, source=github.</td>
+      <td>POST -> 200 { name, appended }; GET lists refs in append order with source=github.</td>
+      <td>POST 276 -> 200 { "appended": { "source":"github","id":"276","area":"CenCon" } }; POST 311 -> 200; GET -> items [276(CenCon), 311(Gateway)] in append order, source=github both.</td>
+      <td><span class="pill pass">PASS</span></td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>Skill never creates/guesses a list; with no list specified, item stays label-only; missing list is not auto-created.</td>
+      <td>Append to non-existent list -> 404, GET /lists stays empty (no auto-create); skill forbids POST /lists.</td>
+      <td>POST /lists/qa-ready-dev/items (no such list) -> 404 { "error":"no such list" }; GET /lists -> { "lists": [] } (nothing created). Skill text bans auto-create / default list (lines 104-111, 182).</td>
+      <td><span class="pill pass">PASS</span></td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>Append does not change/duplicate status; list stores only the ref/order; flow:ready-dev unchanged.</td>
+      <td>List payload has NO status field; only source/id/area per item; label untouched (labels live in GitHub, not the list).</td>
+      <td>GET payload keys = [consumer, items, name]; each item keys = [area, id, source]; grep "status" -> NONE. Append touches no GitHub label (separate system). area is optional: POST without area -> "area": null.</td>
+      <td><span class="pill pass">PASS</span></td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>A label-only item (never appended) still flows through the method unchanged (append is opt-in).</td>
+      <td>An un-appended item never appears in any list; nothing forces it in.</td>
+      <td>Label-only id 999 is absent from the list (list ids = [276, 311, 500]); only refs the producer chose to append exist. Append is purely additive.</td>
+      <td><span class="pill pass">PASS</span></td>
+    </tr>
+  </table>
+
+  <h2>Raw QA HTTP transcript (own curl calls against PR-branch surface)</h2>
+  <pre>QA harness: http://127.0.0.1:7951  (real WorkListEndpoints + WorkListStore, PR branch source, no auth)
+
+# CRITERION 2 - append to a list that does NOT exist
+POST /lists/qa-ready-dev/items  {"source":"github","id":"276","area":"CenCon"}
+  -> HTTP 404  {"error":"no such list","name":"qa-ready-dev"}
+GET  /lists
+  -> {"lists":[]}                 (no auto-create)
+
+# Setup (human/Cockpit creates list - NOT the skill's job)
+POST /lists  {"name":"qa-ready-dev"}  -> 200 {"name":"qa-ready-dev"}
+
+# CRITERION 1 - skill append path + order
+POST /lists/qa-ready-dev/items  {"source":"github","id":"276","area":"CenCon"}
+  -> 200 {"name":"qa-ready-dev","appended":{"source":"github","id":"276","area":"CenCon"}}
+POST /lists/qa-ready-dev/items  {"source":"github","id":"311","area":"Gateway"}
+  -> 200 {"name":"qa-ready-dev","appended":{"source":"github","id":"311","area":"Gateway"}}
+GET  /lists/qa-ready-dev
+  -> {"name":"qa-ready-dev","items":[{"source":"github","id":"276","area":"CenCon"},
+        {"source":"github","id":"311","area":"Gateway"}],"consumer":null}
+
+# CRITERION 3 - no status field; area optional
+GET top-level keys = ['consumer', 'items', 'name']
+GET item keys       = ['area', 'id', 'source']   (x2)   grep "status" -> NONE
+POST /lists/qa-ready-dev/items  {"source":"github","id":"500"}   (no area)
+  -> 200 {"appended":{"source":"github","id":"500","area":null}}
+
+# Documented 400 contract (skill says 400 on empty/missing source|id)
+POST {"source":"","id":"276"}    -> HTTP 400
+POST {"source":"github"}         -> HTTP 400
+
+# CRITERION 4 - label-only item never forced into a list
+list ids = ['276','311','500']   ;  label-only id 999 present? False</pre>
+
+  <h2>Regression / method sweep</h2>
+  <div class="panel">
+    <ul>
+      <li>Skill references ONLY shipped endpoints (POST /lists/{name}/items, GET /lists/{name}); no invented endpoint; explicitly bans POST /lists auto-create and any default list.</li>
+      <li>Documented contract (200 { name, appended }; 400 empty source/id; 404 missing list, no create; GET WorkListDto with no status field) matches WorkListEndpoints.cs / WorkListItemRef.cs / WorkListDto.cs on the PR branch exactly.</li>
+      <li>No .NET production code changed by this PR (skill .md + proof docs only); Gateway project still builds clean (Build succeeded, 0 errors, 0 warnings).</li>
+      <li>CenCon: no architecture/security drift - skill-only change, reuses an existing shipped REST surface; no DT rule touched.</li>
+    </ul>
+  </div>
+
+  <div class="done">
+    <b>VERIFIED - all acceptance criteria met.</b> 4 of 4 criteria PASS, independently reproduced by
+    QA against the PR-branch named-work-list surface with QA's own HTTP calls. The documented skill
+    contract matches what #273 actually exposes (no invented endpoint, no auto-create of lists).
+  </div>
+</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-276/report.html
+++ b/docs/cencon/proof/issue-276/report.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #276 - Developer Agent Proof Report</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --ink: #e6e8ec; --muted: #9aa3b2;
+    --accent: #1d76db; --ok: #2ea043; --warn: #d29922; --line: #2a2f3a; --mono: #0b0d11;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; line-height: 1.5; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 32px 24px 64px; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 16px; margin: 32px 0 10px; padding-bottom: 6px; border-bottom: 1px solid var(--line); }
+  .sub { color: var(--muted); font-size: 13px; }
+  .meta { display: flex; flex-wrap: wrap; gap: 8px 20px; margin: 14px 0 0; font-size: 13px; color: var(--muted); }
+  .meta b { color: var(--ink); font-weight: 600; }
+  .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px 18px; margin: 12px 0; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; vertical-align: top; padding: 9px 10px; border-bottom: 1px solid var(--line); }
+  th { color: var(--muted); font-weight: 600; }
+  .pill { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+  .pass { background: rgba(46,160,67,.15); color: #6fd082; border: 1px solid rgba(46,160,67,.4); }
+  code, pre { font-family: "Cascadia Code", Consolas, monospace; }
+  pre { background: var(--mono); border: 1px solid var(--line); border-radius: 8px; padding: 14px 16px;
+    overflow-x: auto; font-size: 12.5px; color: #cdd3dc; }
+  .tag { font-family: monospace; background: rgba(29,118,219,.16); color: #76b3ef; padding: 1px 6px; border-radius: 4px; }
+  .done { background: rgba(46,160,67,.12); border: 1px solid rgba(46,160,67,.5); border-radius: 8px;
+    padding: 14px 18px; margin-top: 24px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Issue #276 - product-agent skill appends a ready-for-dev item to a named work list over REST</h1>
+  <div class="sub">CenCon Development Method - Developer Agent proof report. Child 5 of epic #270.</div>
+  <div class="meta">
+    <span><b>Issue:</b> #276</span>
+    <span><b>Branch:</b> issue-276-product-append</span>
+    <span><b>Build:</b> dotnet build cc-director.sln - Build succeeded, 0 Error(s), 0 Warning(s)</span>
+    <span><b>Gateway proven:</b> 0.6.22+05e11c2 (current main, has /lists)</span>
+    <span><b>Date:</b> 2026-06-10</span>
+  </div>
+
+  <h2>What was implemented</h2>
+  <div class="panel">
+    A skill-only change to <span class="tag">.claude/skills/product-agent/skill.md</span>. After the
+    Product Agent labels an issue <span class="tag">flow:ready-dev</span>, it may now ALSO append that
+    issue to an explicitly-named work list via the shipped #273 surface
+    <span class="tag">POST /lists/{name}/items</span>, sending the structured ref
+    <code>{ "source": "github", "id": "&lt;issue#&gt;", "area"? }</code>, so the item enters the
+    ordered queue the #274 runner drains. The append is opt-in and additive: the
+    <span class="tag">flow:ready-dev</span> label stays the single source of STATUS truth; the list
+    only sets ORDER / queue membership. The skill NEVER invents, auto-creates, or guesses a list name
+    (no default list; a missing list returns 404 and is reported, not created). Label-only items flow
+    through the method unchanged. No .NET code was touched - per the issue's Note to the Developer
+    Agent, this is proven by exercising the skill's REST path against a running Gateway, not by
+    <code>dotnet build</code> (which was still run, and is clean, to confirm nothing regressed).
+  </div>
+
+  <h2>Acceptance criteria - Expected vs Actual</h2>
+  <table>
+    <thead><tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (live Gateway 127.0.0.1:7950)</th><th>Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>After labeling flow:ready-dev, append via POST /lists/{name}/items; GET shows issue in order, source=github.</td>
+        <td>POST returns 200 with the appended ref; GET lists the refs in append order with source=github.</td>
+        <td>POST #276 -> 200 <code>{"appended":{"source":"github","id":"276","area":"CenCon"}}</code>; POST #312 -> 200; GET -> <code>items:[{github,276,CenCon},{github,312,Gateway}]</code> in append order.</td>
+        <td><span class="pill pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Never creates or guesses a list; with no list specified, item stays label-only (no invented list).</td>
+        <td>Append to a non-existent list -> error, list NOT auto-created; "no list specified" leaves item label-only.</td>
+        <td>POST to non-existent list -> 404 <code>{"error":"no such list"}</code>; GET /lists -> <code>{"lists":[]}</code> (nothing auto-created). Skill documents NO default list -> no list arg means no append. (area also optional: append without area -> 200.)</td>
+        <td><span class="pill pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Append does not change/duplicate status; list stores only ref/order, no status field; label unchanged.</td>
+        <td>List + item payload carry NO status field; flow:ready-dev label untouched by the append.</td>
+        <td>List keys = <code>[consumer, items, name]</code>; item keys = <code>[area, id, source]</code> - no status field anywhere. The append is pure order; status remains solely the GitHub label.</td>
+        <td><span class="pill pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>A label-only item (never appended) still flows through the existing method unchanged (append is opt-in).</td>
+        <td>An item with no list entry is still pickable by the loop's no-arg selection; nothing forces an item into a list.</td>
+        <td>The list holds ONLY refs the producer chose to append; an un-appended flow:ready-dev item never appears in any list and stays selectable by status alone. Skill documents the append as opt-in, not required.</td>
+        <td><span class="pill pass">PASS</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Live REST proof (raw transcript)</h2>
+  <div class="sub">Full transcript also committed beside this report as <span class="tag">rest-proof-transcript.txt</span>. Gateway was a dev console host built from this branch on isolated port 7950 with CC_GATEWAY_NO_TAILSCALE=1; auth was off (loopback), so no Bearer header was needed for the run.</div>
+  <pre>=== CRITERION 2: append to a list that does NOT exist -> 404, NOT auto-created ===
+POST /lists/ready-dev-queue/items {source:github,id:99001,area:CenCon}
+  HTTP 404  {"error":"no such list","name":"ready-dev-queue"}
+GET /lists  ->  {"lists":[]}        (nothing auto-created)
+
+=== Setup: human/Cockpit creates the named list (NOT the product skill's job) ===
+POST /lists {name:ready-dev-queue}  ->  HTTP 200  {"name":"ready-dev-queue"}
+
+=== CRITERION 1: append refs, then GET shows them in order, source=github ===
+POST /lists/ready-dev-queue/items {source:github,id:276,area:CenCon}
+  HTTP 200  {"name":"ready-dev-queue","appended":{"source":"github","id":"276","area":"CenCon"}}
+POST /lists/ready-dev-queue/items {source:github,id:312,area:Gateway}
+  HTTP 200  {"name":"ready-dev-queue","appended":{"source":"github","id":"312","area":"Gateway"}}
+GET /lists/ready-dev-queue
+  {"name":"ready-dev-queue","items":[{"source":"github","id":"276","area":"CenCon"},
+                                     {"source":"github","id":"312","area":"Gateway"}],"consumer":null}
+
+=== CRITERION 3: payload has NO status field ===
+list keys: ['consumer', 'items', 'name']
+item keys: ['area', 'id', 'source']   (x2)
+
+=== CRITERION 2 (positive): area optional - append WITHOUT area still works ===
+POST /lists/ready-dev-queue/items {source:github,id:500}
+  HTTP 200  {"name":"ready-dev-queue","appended":{"source":"github","id":"500","area":null}}</pre>
+
+  <h2>CenCon impact</h2>
+  <div class="panel">
+    <b>No drift.</b> No change to <span class="tag">architecture_manifest.yaml</span> or
+    <span class="tag">security_profile.yaml</span>. The /lists REST surface and its Gateway container
+    record shipped under #273/#274/#275 and are unchanged here. This issue edits only a skill prompt
+    document. No new container, no security-posture change, no blocking security rule (DT-*) touched.
+    ASCII-only, no fallback logic, no embedded credentials (the Bearer token is a documented
+    placeholder).
+  </div>
+
+  <div class="done">
+    <b>I believe this is finished.</b> The product-agent skill now documents and exercises the
+    opt-in work-list append against the shipped #273 contract; all four acceptance criteria were
+    proven Expected == Actual against a live Gateway built from current main; the full solution builds
+    clean. Ready for QA.
+  </div>
+</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-276/rest-proof-transcript.txt
+++ b/docs/cencon/proof/issue-276/rest-proof-transcript.txt
@@ -1,0 +1,42 @@
+=== ISSUE #276 PROOF - product-agent work-list append over REST ===
+Gateway: http://127.0.0.1:7950  version=0.6.22+05e11c2bdc2495843cf2ce9473791c6ad84fcea3
+Date: 2026-06-10T19:23:46Z
+
+=== CRITERION 2: skill never invents a list. Append to a list that does NOT exist -> 404, NOT auto-created ===
+-- POST /lists/ready-dev-queue/items for a NON-existent list (simulating: skill must NOT create it):
+HTTP 404
+Body: {"error":"no such list","name":"ready-dev-queue"}
+-- GET /lists confirms NO list was auto-created by that failed append:
+{"lists":[]}
+
+=== Setup: a human/Cockpit creates the named list (NOT the product skill's job) ===
+HTTP 200
+Body: {"name":"ready-dev-queue"}
+
+=== CRITERION 1: skill path - after labeling flow:ready-dev, append issue ref, then GET shows it in order ===
+-- append issue 276 (source=github, id as string, area from prefix):
+HTTP 200
+Body: {"name":"ready-dev-queue","appended":{"source":"github","id":"276","area":"CenCon"}}
+-- append a second issue to prove ORDER is preserved:
+HTTP 200
+Body: {"name":"ready-dev-queue","appended":{"source":"github","id":"312","area":"Gateway"}}
+-- GET /lists/ready-dev-queue shows both refs in append order, source=github:
+{"name":"ready-dev-queue","items":[{"source":"github","id":"276","area":"CenCon"},{"source":"github","id":"312","area":"Gateway"}],"consumer":null}
+
+=== CRITERION 3: list payload carries NO status field (append cannot duplicate flow status) ===
+-- keys present in each item ref (must be only source/id/area, never status):
+list keys: ['consumer', 'items', 'name']
+item keys: ['area', 'id', 'source']
+item keys: ['area', 'id', 'source']
+
+=== CRITERION 2 (positive): area is OPTIONAL - append WITHOUT area still works (skill may omit) ===
+HTTP 200
+Body: {"name":"ready-dev-queue","appended":{"source":"github","id":"500","area":null}}
+
+=== CRITERION 4: a label-only item (never appended) is independent of any list ===
+Issue #276 in the list does NOT change its GitHub label state; the list is order-only,
+and an item with no list entry simply never appears here - it remains pickable by the
+loop's no-arg selection (flow:ready-dev). Demonstrated structurally: the list holds only
+refs the producer chose to append; nothing forces an item into a list.
+
+=== PROOF COMPLETE ===


### PR DESCRIPTION
## Release Notes
The Product Agent skill can now optionally append a `flow:ready-dev` issue to an explicitly-named work list over REST, entering the ordered queue the #274 runner drains. Closes the producer side of epic #270 (child 5 of 5).

## Changes
- `.claude/skills/product-agent/skill.md`: new opt-in **Step 4 - append to a named work list** using the shipped #273 `POST /lists/{name}/items` with `{ source: "github", id: "<issue#>", area? }`; report moved to Step 5 (names the list/order, or says label-only). Documented that there is NO default list and the skill never invents/auto-creates one (a missing list is a 404 it reports). Bumped to v0.2 with a changelog entry.
- `docs/cencon/proof/issue-276/`: HTML report + raw REST transcript.

## How to Test
Run a Gateway from main (has `/lists`), create a named list, then exercise the skill's REST path:
```
POST /lists/{name}/items  {"source":"github","id":"276","area":"CenCon"}
GET  /lists/{name}
```

## Expected Result
- Append to a non-existent list -> 404, list NOT auto-created (criterion 2).
- After append, `GET /lists/{name}` shows the refs in append order with `source=github` (criterion 1).
- List/item payload carries only `source/id/area` - no status field (criterion 3).
- Label-only items never appear in a list and stay status-selectable (criterion 4).

## Before / After
- Before: Product Agent could only set `flow:ready-dev`; ordering relied on label creation order.
- After: Product Agent can additionally append the item to a chosen ordered queue, without changing how status works.

Proof: docs/cencon/proof/issue-276/report.html

This is a skill + REST change (no .NET artifact); proven against a live Gateway per the issue's Note, and `dotnet build cc-director.sln` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)