### PR TITLE
fix(cockpit): Cockpit.razor fails to compile - relational-pattern switch breaks Razor parser

### DIFF
--- a/src/CcDirector.Cockpit/Components/Pages/Cockpit.razor
+++ b/src/CcDirector.Cockpit/Components/Pages/Cockpit.razor
@@ -1754,12 +1754,16 @@
         return match?.NewTokens;
     }
 
-    private static string FmtTokens(long n) => n switch
+    // NOTE: written as an if-ladder, NOT a `switch` with relational patterns. Inside a Razor
+    // @code block the parser reads a line-leading `<` (as in `< 1_000 => ...`) as the start of an
+    // HTML tag, which throws the tokenizer out of code mode and cascades into dozens of bogus
+    // RZ9980/RZ1006 errors across the whole file. Keep leading `<` out of @code expressions.
+    private static string FmtTokens(long n)
     {
-        < 1_000 => n.ToString(),
-        < 1_000_000 => (n / 1_000.0).ToString("0.#") + "k",
-        _ => (n / 1_000_000.0).ToString("0.##") + "M",
-    };
+        if (n < 1_000) return n.ToString();
+        if (n < 1_000_000) return (n / 1_000.0).ToString("0.#") + "k";
+        return (n / 1_000_000.0).ToString("0.##") + "M";
+    }
 
     // ----- D7 brief feedback ("this brief is wrong" -> labeled example on the Director) -----
     private List<TurnBriefDto>? _turnTimeline;


### PR DESCRIPTION
## Problem

`CcDirector.Cockpit` did not compile on `main`. `FmtTokens` in `Components/Pages/Cockpit.razor` used a `switch` expression with C# **relational patterns**:

```csharp
private static string FmtTokens(long n) => n switch
{
    < 1_000     => n.ToString(),
    < 1_000_000 => (n / 1_000.0).ToString("0.#") + "k",
    _           => (n / 1_000_000.0).ToString("0.##") + "M",
};
```

Inside a Razor `@code` block the parser reads the line-leading `<` (at `< 1_000`) as the start of an HTML tag, falls out of code mode, and cascades into ~75 bogus `RZ9980`/`RZ1006` errors across the whole file — headline `RZ1006: code block missing closing "}"` reported back at the `@code {` opener (line 911). Downstream generics (`List<TurnBriefDto>`, `List<TurnSummary>`, `List<FanoutResult>`, …) get misparsed as component tags.

## Why it went unnoticed

No test project references the Cockpit Blazor web app, so the test build (`dotnet test`) stays green while the Razor compile never runs. The break only surfaces when building `CcDirector.Cockpit.csproj` (or the full `cc-director.sln`) or launching the UI.

## Fix

Rewrite `FmtTokens` as an `if`-ladder — the existing idiom in this file (cf. `RelativeTime`) — so no `<` leads an `@code` expression. Added a comment so it doesn't regress.

## Verification

- `dotnet build src/CcDirector.Cockpit/CcDirector.Cockpit.csproj` → **0 errors, 0 warnings** (was 75 errors)
- `dotnet build cc-director.sln` → **0 errors, 0 warnings**

This unblocks launching the Cockpit UI, which is needed for the two-box cross-machine QA of #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)