### PR TITLE
fix(#288): per-session WS proxy returns 503 (not 404) for an offline owning Director

### DIFF
--- a/src/CcDirector.Gateway.Tests/SessionWsProxyEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionWsProxyEndpointsTests.cs
@@ -12,11 +12,13 @@ namespace CcDirector.Gateway.Tests;
 /// over loopback HTTP and pin the resolution contract the Cockpit relies on:
 ///   - an unknown session id returns 404 (no owning Director across the fleet);
 ///   - the new sid-scoped routes are explicit endpoints, so they win over the fallback Cockpit
-///     proxy (they never fall through to the "Cockpit starting" interstitial).
+///     proxy (they never fall through to the "Cockpit starting" interstitial);
+///   - a session whose owner is KNOWN (recorded in <see cref="SessionOwnerCache"/>) but whose
+///     Director is offline returns 503 (owner offline), not 404 - issue #288 / #268 AC4.
 ///
-/// A genuine WebSocket upgrade to a live owning Director (and the 503 unreachable-Director path)
-/// is exercised end-to-end in the cross-machine proof run; here, with no Directors registered,
-/// the resolution leg is what is observable, which is the part that decides 404 vs proxy.
+/// A genuine WebSocket upgrade to a live owning Director is exercised end-to-end in the
+/// cross-machine proof run; here, with no Directors registered, the resolution leg is what is
+/// observable, which is the part that decides 404 vs 503 vs proxy.
 /// </summary>
 public sealed class SessionWsProxyEndpointsTests : IAsyncLifetime
 {
@@ -73,6 +75,34 @@ public sealed class SessionWsProxyEndpointsTests : IAsyncLifetime
 
         Assert.NotEqual(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
         Assert.DoesNotContain("Cockpit starting", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Theory]
+    [InlineData("stream")]
+    [InlineData("dictate")]
+    public async Task Known_session_with_offline_owner_returns_503_not_404(string leg)
+    {
+        // The aggregator (or a prior successful forward) recorded this session's owner, but no live
+        // Director answers ownership now (none registered). That is "owner went offline", which must
+        // be 503 - not 404 (unknown session) and not the dead-cockpit 503 interstitial. Issue #288.
+        var sid = "11111111-1111-1111-1111-111111111111";
+        _gateway.SessionOwners.Remember(sid, "dead-director-id");
+
+        var resp = await _http.GetAsync($"sessions/{sid}/{leg}");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("offline", body, StringComparison.OrdinalIgnoreCase);
+        // It is OUR owner-offline 503, not the fallback Cockpit interstitial.
+        Assert.DoesNotContain("Cockpit starting", body);
+    }
+
+    [Fact]
+    public async Task Unknown_uncached_session_still_returns_404()
+    {
+        // Belt-and-suspenders: a session NOT in the owner cache and owned by no live Director stays 404.
+        var resp = await _http.GetAsync("sessions/22222222-2222-2222-2222-222222222222/stream");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
     private static int FreePort()

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -36,7 +36,8 @@ internal static class GatewayEndpoints
         Action<string, string, string>? onSessionState = null, Func<string, string?>? assessedStateFor = null,
         Func<string, (string BriefingState, string? RailLine)>? briefStampFor = null,
         Func<string, (string? RailLine, string? Headline)>? interruptedBriefFor = null,
-        Func<string, List<TurnBriefDto>>? briefHistoryFor = null)
+        Func<string, List<TurnBriefDto>>? briefHistoryFor = null,
+        SessionOwnerCache? owners = null)
     {
         // Graceful exit for the self-update helper: answer first (so the caller gets its 200),
         // then hand off to the host's shutdown handler shortly after. 501 when the hosting
@@ -379,6 +380,9 @@ internal static class GatewayEndpoints
                     s.MachineName = d.MachineName;
                     s.User = d.User;
                     s.TailnetEndpoint = baseUrl;
+                    // Issue #288: remember who owns this session so the WS proxy answers 503 (owner
+                    // offline) instead of 404 once this Director goes dark.
+                    owners?.Remember(s.SessionId, d.DirectorId);
                     // Issue #186: stamp the GATEWAY-owned assessedState. Suppressed while
                     // the session is mechanically working (raw activity always wins there);
                     // the Director's own annotation (if any) is overwritten - the Gateway

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -33,7 +33,7 @@ internal static class SessionWsProxyEndpoints
     /// <paramref name="registry"/> via <paramref name="client"/>; 404 when the session is
     /// unknown across the fleet, 503 when the owning Director cannot be reached.
     /// </summary>
-    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client)
+    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client, SessionOwnerCache owners)
     {
         var forwarder = app.ServiceProvider.GetRequiredService<IHttpForwarder>();
         var proxy = new SessionWsForwarder(forwarder);
@@ -41,33 +41,50 @@ internal static class SessionWsProxyEndpoints
         // Live terminal stream: forward to the owning Director's /sessions/{sid}/stream .
         app.MapGet("/sessions/{sid}/stream", async (string sid, HttpContext ctx) =>
         {
-            await ProxyAsync(ctx, sid, "stream", $"/sessions/{sid}/stream", registry, client, proxy);
+            await ProxyAsync(ctx, sid, "stream", $"/sessions/{sid}/stream", registry, client, proxy, owners);
         });
 
         // Dictation: the Gateway exposes a sid-scoped path; the Director's own endpoint is /dictate .
         app.MapGet("/sessions/{sid}/dictate", async (string sid, HttpContext ctx) =>
         {
-            await ProxyAsync(ctx, sid, "dictate", "/dictate", registry, client, proxy);
+            await ProxyAsync(ctx, sid, "dictate", "/dictate", registry, client, proxy, owners);
         });
     }
 
     /// <summary>
     /// Resolve the owning Director and reverse-proxy the WS upgrade to <paramref name="directorPath"/>
-    /// on that Director. 404 unknown session; 503 unreachable owning Director.
+    /// on that Director. 404 only for a session no Director has ever been seen to own; 503 when the
+    /// owning Director is known (cached) but currently offline/unreachable, or when the forward fails.
     /// </summary>
     private static async Task ProxyAsync(HttpContext ctx, string sid, string leg, string directorPath,
-        DirectorRegistry registry, DirectorEndpointClient client, SessionWsForwarder proxy)
+        DirectorRegistry registry, DirectorEndpointClient client, SessionWsForwarder proxy, SessionOwnerCache owners)
     {
         FileLog.Write($"[SessionWsProxy] open leg={leg} sid={sid} client={ctx.Connection.RemoteIpAddress}");
 
         var director = await LocateOwningDirectorAsync(registry, client, sid);
         if (director is null)
         {
-            FileLog.Write($"[SessionWsProxy] leg={leg} sid={sid} -> 404 (no owning director across the fleet)");
+            // Live resolution could not reach any Director that owns this session. If we have EVER
+            // recorded its owner (the fleet aggregator or a prior successful forward did), the session
+            // is real and its Director is simply offline/unreachable now -> 503, not 404. This is what
+            // distinguishes "unknown session" from "owner went dark" (issue #288; issue #268 AC4).
+            var knownOwner = owners.OwnerOf(sid);
+            if (knownOwner is not null)
+            {
+                FileLog.Write($"[SessionWsProxy] leg={leg} sid={sid} -> 503 (known owner {knownOwner} offline/unreachable)");
+                ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await ctx.Response.WriteAsJsonAsync(new { error = "owning director offline" });
+                return;
+            }
+
+            FileLog.Write($"[SessionWsProxy] leg={leg} sid={sid} -> 404 (no owning director across the fleet, none cached)");
             ctx.Response.StatusCode = StatusCodes.Status404NotFound;
             await ctx.Response.WriteAsJsonAsync(new { error = "session not found across any director" });
             return;
         }
+
+        // Record the owner so a later offline state for this session resolves to 503, not 404.
+        owners.Remember(sid, director.DirectorId);
 
         var destination = ForwardDestination(director);
         if (destination is null)

--- a/src/CcDirector.Gateway/Discovery/SessionOwnerCache.cs
+++ b/src/CcDirector.Gateway/Discovery/SessionOwnerCache.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+
+namespace CcDirector.Gateway.Discovery;
+
+/// <summary>
+/// Remembers which Director last owned each session id, so the per-session WebSocket proxy can tell
+/// "unknown session" (404) apart from "known session whose owning Director has gone offline /
+/// unreachable" (503).
+///
+/// Issue #288: live ownership resolution (the <c>GetSessionAsync</c> fan-out in
+/// <see cref="Api.SessionWsProxyEndpoints"/>) only confirms ownership by reaching the owning
+/// Director, so an OFFLINE Director makes resolution fail and every per-session WS request collapse
+/// to 404 - contradicting issue #268's AC4 ("offline owning Director -> 503"). This cache breaks the
+/// tie: the fleet aggregator (<c>GET /sessions</c>) records every session it observes, and the WS
+/// proxy records every session it successfully forwards, so any session the Cockpit has seen
+/// resolves to a 503 - not a 404 - once its Director goes dark.
+///
+/// In-memory only; it rebuilds from the next aggregation after a Gateway restart. Session ids are
+/// GUIDs and never reused, so a stale entry can only point at a Director that is itself gone, which
+/// is exactly the 503 case. Bounded in practice by the number of sessions the fleet has run.
+/// </summary>
+public sealed class SessionOwnerCache
+{
+    private readonly ConcurrentDictionary<string, string> _ownerBySession = new();
+
+    /// <summary>Record (or refresh) the Director that owns <paramref name="sessionId"/>. No-op on empty input.</summary>
+    public void Remember(string sessionId, string directorId)
+    {
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(directorId)) return;
+        _ownerBySession[sessionId] = directorId;
+    }
+
+    /// <summary>The Director id last seen owning <paramref name="sessionId"/>, or null if never observed.</summary>
+    public string? OwnerOf(string sessionId)
+        => !string.IsNullOrEmpty(sessionId) && _ownerBySession.TryGetValue(sessionId, out var id) ? id : null;
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -32,6 +32,13 @@ public sealed class GatewayHost : IAsyncDisposable
     public DirectorRegistry Registry { get; }
     public bool AuthEnabled { get; }
 
+    /// <summary>
+    /// Issue #288: which Director last owned each session, so the per-session WS proxy can answer
+    /// 503 (owner offline) instead of 404 (unknown session). Populated by the /sessions aggregator
+    /// and the WS proxy; read by the WS proxy.
+    /// </summary>
+    public SessionOwnerCache SessionOwners { get; } = new();
+
     /// <summary>When this host was constructed - the Cockpit Settings page reads it for uptime.</summary>
     public DateTime StartedAtUtc { get; } = DateTime.UtcNow;
 
@@ -336,13 +343,16 @@ public sealed class GatewayHost : IAsyncDisposable
             // Issue #212 W4: the restore endpoint builds its continuation context from the
             // full brief history; the store outlives the dead Director, so this serves
             // sessions whose owner is gone.
-            briefHistoryFor: sid => _turnBriefStore.List(sid));
+            briefHistoryFor: sid => _turnBriefStore.List(sid),
+            // Issue #288: record session->Director ownership as the fleet is aggregated, so the WS
+            // proxy can return 503 (owner offline) rather than 404 for a session whose Director went dark.
+            owners: SessionOwners);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and
         // never needs a Director's own (possibly loopback) address. Mapped endpoints win over the
         // fallback Cockpit proxy below.
-        SessionWsProxyEndpoints.Map(_app, Registry, _client);
+        SessionWsProxyEndpoints.Map(_app, Registry, _client, SessionOwners);
 
         // Central key vault (docs/architecture/gateway/GATEWAY_KEY_VAULT.md): set keys once
         // here (via the Cockpit Keys page); Directors pull them on demand. Inherits the


### PR DESCRIPTION
Closes #288.

## Problem
#268's AC4 specifies *"a session whose owning Director is offline → 503"*. In practice it returned **404**: `SessionWsProxyEndpoints` resolves ownership with a live `GetSessionAsync` fan-out, which **fails when the Director is offline**, so "owner went dark" and "unknown session" both collapse to 404. The 503 branch was effectively unreachable (and not unit-covered — the test deferred it to the proof run).

## Fix (option 2 from #288)
Add a `SessionOwnerCache` (sessionId → directorId):
- The **fleet aggregator** (`GET /sessions`) records ownership on every poll (it already stamps `directorId` on each session).
- The **WS proxy** records ownership on every successful forward.
- When live resolution finds no owner **but the session is in the cache**, the owner is known-but-unreachable → **503**. Only a session the fleet has *never* seen stays **404**.

In-memory; rebuilt from the next aggregation after a Gateway restart. Session ids are GUIDs (never reused), so a stale entry can only point at a gone Director — which is exactly the 503 case.

## Files
- `Discovery/SessionOwnerCache.cs` (new)
- `Api/GatewayEndpoints.cs` — `Remember(sid, directorId)` at the aggregator stamp point
- `Api/SessionWsProxyEndpoints.cs` — 503 on cache-hit-with-no-live-owner; `Remember` on success
- `GatewayHost.cs` — owns the cache, threads it to both maps
- `SessionWsProxyEndpointsTests.cs` — **known-owner-offline → 503** (stream + dictate); uncached → still 404

## Verification
- Gateway tests **404 → 407** (3 new), full `cc-director.sln` builds clean (0/0).
- This makes #268 AC4 truthfully pass: an offline owning Director now returns 503, and the Cockpit's loud-failure message (which keys off a failed upgrade) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)