### PR TITLE
[Installer] Launch tray Gateway with UseShellExecute=true so piped CLI callers do not hang (#175)

### DIFF
--- a/docs/cencon/proof/issue-175/qa-report.html
+++ b/docs/cencon/proof/issue-175/qa-report.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #175 (PR #302)</title>
+<style>
+body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; }
+h1 { border-bottom: 3px solid #2563eb; padding-bottom: .4rem; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+th { background: #f1f5f9; }
+.pass { color: #15803d; font-weight: bold; }
+.mono { font-family: Consolas, monospace; font-size: .9em; }
+.verdict { background: #dcfce7; border: 1px solid #15803d; padding: 1rem; font-weight: bold; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #175</h1>
+<p><strong>Issue:</strong> [Installer] GatewayTrayInstaller inherits stdio - piped CLI callers hang forever<br>
+<strong>PR:</strong> #302 (branch loop/175-installer-stdio)<br>
+<strong>QA identity:</strong> independent QA Agent (CenCon implementation loop) - did NOT see the Developer's reasoning<br>
+<strong>Date:</strong> 2026-06-10</p>
+
+<h2>Independent verification</h2>
+<p>The PR branch was checked out fresh in worktree cc-director-wt-175 and verified without
+reusing the Developer's binaries or screenshots.</p>
+
+<table>
+<tr><th>Acceptance Criterion</th><th>Expected</th><th>Actual (my own proof)</th><th>Result</th></tr>
+<tr>
+<td>1. Piping the setup CLI's gateway-install output returns to the prompt instead of hanging.</td>
+<td>A piped reader of the launch reaches EOF promptly while the child is still alive.</td>
+<td>Ran <span class="mono">PipedCaller_ReturnsWithFix_AndWouldHangWithoutIt</span> myself. The test reproduces the hang at the OS-handle level using an inheritable anonymous pipe: OLD config (UseShellExecute=false) inherits the write handle, reader never reaches EOF within 3s (oldReachedEof==false); NEW config (BuildTrayLaunchInfo) does not inherit it, reader reaches EOF within window while child still alive (newReachedEof==true). Both halves asserted in one pass. Test PASSED.</td>
+<td class="pass">PASS</td>
+</tr>
+<tr>
+<td>2. The tray Gateway still launches and registers after install.</td>
+<td>Exe, args, working dir and health-wait unchanged; Gateway healthy.</td>
+<td>Diff confirms only the UseShellExecute flag changed inside InstallAsync (same FileName=InstalledArguments, WorkingDirectory, health-wait). Live fleet Gateway GET /healthz on 7878 -> 200. Asserted by BuildTrayLaunchInfo_UsesShellExecute_NoRedirection (FileName/Arguments/WorkingDir intact).</td>
+<td class="pass">PASS</td>
+</tr>
+<tr>
+<td>3. The tray-launch ProcessStartInfo sets UseShellExecute=true.</td>
+<td>UseShellExecute=true, no RedirectStandard*.</td>
+<td>GatewayTrayInstaller.cs line 152 sets UseShellExecute=true; grep confirms no RedirectStandard* in the seam. Asserted by BuildTrayLaunchInfo_UsesShellExecute_NoRedirection.</td>
+<td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Precedent claim verified</h2>
+<p>The fix claims to mirror GatewayApp self-update relaunch. Independently confirmed:
+<span class="mono">src/CcDirector.GatewayApp/Program.cs</span> startGateway uses
+<span class="mono">UseShellExecute=true</span> with the identical documented rationale (inherited stdout
+pipe keeps caller's pipe open -> hang). The new code comment correctly cites #175 and that precedent.</p>
+
+<h2>Regression and method checks</h2>
+<ul>
+<li>Targeted tests: 4/4 GatewayTrayInstaller tests PASS.</li>
+<li>Full setup-engine suite: 147/147 PASS, 0 failed.</li>
+<li>Solution build (dotnet build cc-director.sln): Build succeeded, 0 Warning(s), 0 Error(s).</li>
+<li>Change surface: a single ProcessStartInfo flag flip extracted into a tested static seam. No adjacent behavior altered (OUT items - WPF wizard log-file tailing, other installer steps - untouched).</li>
+<li>CenCon: no security/architecture change; no DT rule affected. No docs drift introduced.</li>
+<li>Live fleet (Gateway 7878, Cockpit 7470, Director 7887) confirmed healthy and untouched throughout.</li>
+</ul>
+
+<div class="verdict">VERIFIED - all acceptance criteria met. Clean pass.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-175/report.html
+++ b/docs/cencon/proof/issue-175/report.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #175 - Developer Agent Proof</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1b1f23; }
+  h1 { border-bottom: 2px solid #d0d7de; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; border-bottom: 1px solid #e1e4e8; padding-bottom: .3rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f6f8fa; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px; padding: .8rem; overflow-x: auto; }
+  .pass { color: #1a7f37; font-weight: 600; }
+  .meta { color: #57606a; font-size: .9rem; }
+</style>
+</head>
+<body>
+<h1>Issue #175 - GatewayTrayInstaller inherits stdio: piped CLI callers hang forever</h1>
+<p class="meta">Role: Developer Agent (CenCon Development Method) &middot; Repo: thefrederiksen/cc-director &middot; Branch: loop/175-installer-stdio</p>
+
+<h2>1. What was implemented</h2>
+<p>
+  The Gateway tray-app launch in <code>tools/cc-director-setup-engine/GatewayTrayInstaller.cs</code>
+  (step 4 of <code>InstallAsync</code>) started the long-lived tray Gateway with
+  <code>UseShellExecute=false</code>, so the Gateway inherited the setup CLI's stdout/stderr handles
+  and held them open for its whole lifetime. Any caller that PIPES the CLI
+  (<code>... | Select-Object</code>, <code>... | tail</code>) therefore hung forever after the CLI
+  itself had exited (the live v0.6.6 90-minute phantom hang).
+</p>
+<p>
+  The fix extracts the launch <code>ProcessStartInfo</code> into a testable static seam
+  <code>BuildTrayLaunchInfo(gatewayExe, workingDirectory)</code> and sets
+  <code>UseShellExecute=true</code> (with NO <code>RedirectStandard*</code>), exactly mirroring the
+  already-proven fix on the GatewayApp self-update relaunch path
+  (<code>src/CcDirector.GatewayApp/Program.cs</code> <code>startGateway</code>). A code comment
+  references issue #175 and that precedent.
+</p>
+
+<h2>2. The change (diff)</h2>
+<pre>// tools/cc-director-setup-engine/GatewayTrayInstaller.cs - step 4
+-            var psi = new ProcessStartInfo
+-            {
+-                FileName = gatewayExe,
+-                Arguments = InstalledArguments,
+-                WorkingDirectory = _layout.GatewayDir,
+-                UseShellExecute = false,
+-            };
++            var psi = BuildTrayLaunchInfo(gatewayExe, _layout.GatewayDir);
+
+// new static seam (UseShellExecute=true, no redirection; see issue #175):
++    public static ProcessStartInfo BuildTrayLaunchInfo(string gatewayExe, string workingDirectory)
++    {
++        ArgumentException.ThrowIfNullOrWhiteSpace(gatewayExe);
++        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
++        return new ProcessStartInfo
++        {
++            FileName = gatewayExe,
++            Arguments = InstalledArguments,
++            WorkingDirectory = workingDirectory,
++            UseShellExecute = true,
++        };
++    }</pre>
+
+<h2>3. Acceptance criteria - how each is met and proven</h2>
+<table>
+  <tr><th>Acceptance criterion</th><th>How the code satisfies it</th><th>Proof</th></tr>
+  <tr>
+    <td>Piping the gateway-install output returns to the prompt after the CLI exits instead of hanging.</td>
+    <td>The Gateway is launched with <code>UseShellExecute=true</code>, so it does not inherit the
+        caller's stdout pipe; the pipe closes when the CLI exits even though the Gateway keeps running.</td>
+    <td>Deterministic end-to-end test
+        <code>PipedCaller_ReturnsWithFix_AndWouldHangWithoutIt</code>: with the OLD config a piped
+        reader BLOCKS for the full window (hang reproduced); with the production
+        <code>BuildTrayLaunchInfo</code> config it reaches EOF promptly while the child is still
+        alive. <span class="pass">PASS</span></td>
+  </tr>
+  <tr>
+    <td>The tray Gateway still launches and registers after install.</td>
+    <td>Only <code>UseShellExecute</code> changed; <code>FileName</code>, <code>Arguments</code>
+        (<code>--managed</code>) and <code>WorkingDirectory</code> are unchanged, and the existing
+        health-wait (gateway <code>/healthz</code>, Cockpit, autostart Run key) is untouched.
+        Mirrors the GatewayApp self-update relaunch precedent which launches the same exe this way.</td>
+    <td><code>BuildTrayLaunchInfo_UsesShellExecute_NoRedirection</code> asserts the launch config is
+        intact (exe, args, working dir) plus the fix. <span class="pass">PASS</span><br>
+        Live machine fleet still healthy at end of run: Gateway 7878 <code>/healthz</code> 200,
+        Cockpit 7470 <code>/</code> 200, Director 7887 <code>/healthz</code> 200.</td>
+  </tr>
+  <tr>
+    <td>The tray-launch <code>ProcessStartInfo</code> sets <code>UseShellExecute=true</code>.</td>
+    <td>Set in <code>BuildTrayLaunchInfo</code>.</td>
+    <td>The diff (Section 2) and
+        <code>BuildTrayLaunchInfo_UsesShellExecute_NoRedirection</code> asserting
+        <code>UseShellExecute==true</code> and no redirection. <span class="pass">PASS</span></td>
+  </tr>
+</table>
+
+<h2>4. Test run (committed: test-run.txt)</h2>
+<pre>Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.PipedCaller_ReturnsWithFix_AndWouldHangWithoutIt [3 s]
+Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.BuildTrayLaunchInfo_UsesShellExecute_NoRedirection [&lt; 1 ms]
+Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.DefaultPorts_AreCanonical [2 ms]
+Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.InstalledArguments_IsManaged [&lt; 1 ms]
+
+Full suite: Passed! - Failed: 0, Passed: 147, Skipped: 0, Total: 147 (CcDirector.Setup.Engine.Tests)
+Solution build: Build succeeded. 0 Warning(s), 0 Error(s) (dotnet build cc-director.sln)</pre>
+
+<h2>5. How the end-to-end proof reproduces the hang</h2>
+<p>
+  <code>PipedCaller_ReturnsWithFix_AndWouldHangWithoutIt</code> opens an anonymous pipe whose write
+  end is marked inheritable, then starts a long-lived child (<code>ping -n 30 127.0.0.1</code>) two
+  ways and tries to read the pipe to EOF:
+</p>
+<ul>
+  <li><b>OLD</b> (<code>UseShellExecute=false</code>): <code>Process.Start</code> creates the child
+      with <code>bInheritHandles=TRUE</code>, so the child inherits the write handle - exactly how the
+      real Gateway inherited the setup CLI's stdout. The reader gets NO EOF within the window:
+      the hang, reproduced. The test asserts this.</li>
+  <li><b>NEW</b> (the production <code>BuildTrayLaunchInfo</code>, <code>UseShellExecute=true</code>):
+      <code>ShellExecuteEx</code> launches with <code>bInheritHandles=FALSE</code>, so the handle is
+      NOT passed to the child; the reader reaches EOF promptly even though the child is still alive -
+      the piped caller returns. The test asserts this.</li>
+</ul>
+
+<h2>6. CenCon impact</h2>
+<p>
+  No architecture drift and no security-posture change. The launch targets the same exe by the same
+  resolved path (no string concatenation - DT-rule on process paths unaffected) and removes an
+  inherited-handle leak rather than introducing one. No <code>docs/cencon/</code> manifest or
+  security_profile update required.
+</p>
+
+<h2>7. Statement</h2>
+<p class="pass">I believe this issue is finished. All three acceptance criteria are met and proven by
+committed automated tests; the solution builds clean (0 warnings, 0 errors); and the live machine
+fleet was left untouched and confirmed healthy.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-175/test-run.txt
+++ b/docs/cencon/proof/issue-175/test-run.txt
@@ -1,0 +1,8 @@
+A total of 1 test files matched the specified pattern.
+  Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.PipedCaller_ReturnsWithFix_AndWouldHangWithoutIt [3 s]
+  Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.BuildTrayLaunchInfo_UsesShellExecute_NoRedirection [< 1 ms]
+  Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.DefaultPorts_AreCanonical [2 ms]
+  Passed CcDirector.Setup.Engine.Tests.GatewayTrayInstallerTests.InstalledArguments_IsManaged [< 1 ms]
+Total tests: 4
+     Passed: 4
+ Total time: 3.5433 Seconds

--- a/tools/cc-director-setup-engine.Tests/GatewayAndPinsTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayAndPinsTests.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Runtime.Versioning;
 using CcDirector.Setup.Engine;
 using Xunit;
 
@@ -51,6 +54,110 @@ public class GatewayTrayInstallerTests
     {
         Assert.Equal(7878, GatewayTrayInstaller.GatewayDefaultPort);
         Assert.Equal(7470, GatewayTrayInstaller.CockpitDefaultPort);
+    }
+
+    // --- Issue #175: the tray launch must NOT inherit the caller's stdio ---------------------------
+    // When step 4 launched the long-lived tray Gateway with UseShellExecute=false, the Gateway
+    // inherited the setup CLI's stdout handle and held it open for its whole lifetime, so any caller
+    // that PIPED the CLI ("... | Select-Object", "... | tail") hung forever after the CLI exited.
+
+    [Fact]
+    public void BuildTrayLaunchInfo_UsesShellExecute_NoRedirection()
+    {
+        var exe = OperatingSystem.IsWindows() ? @"C:\some\cc-director-gateway.exe" : "/some/cc-director-gateway";
+        var dir = OperatingSystem.IsWindows() ? @"C:\some" : "/some";
+
+        var psi = GatewayTrayInstaller.BuildTrayLaunchInfo(exe, dir);
+
+        // The fix: UseShellExecute=true so the launched Gateway does NOT inherit the caller's stdio.
+        Assert.True(psi.UseShellExecute);
+        // UseShellExecute=true is incompatible with redirection; assert none is requested so the
+        // Gateway never receives an inherited/redirected std handle.
+        Assert.False(psi.RedirectStandardOutput);
+        Assert.False(psi.RedirectStandardError);
+        Assert.False(psi.RedirectStandardInput);
+        Assert.Equal(GatewayTrayInstaller.InstalledArguments, psi.Arguments);
+        Assert.Equal(exe, psi.FileName);
+        Assert.Equal(dir, psi.WorkingDirectory);
+    }
+
+    /// <summary>
+    /// End-to-end proof of the hang and its fix at the OS-handle level. We open an anonymous pipe
+    /// whose WRITE end is inheritable, then start a long-lived child two ways:
+    ///   - UseShellExecute=false (the OLD behavior): Process.Start uses bInheritHandles=TRUE, so the
+    ///     child inherits the write handle and the pipe never reaches EOF while the child lives -> a
+    ///     piped reader BLOCKS (the #175 hang).
+    ///   - UseShellExecute=true  (BuildTrayLaunchInfo): ShellExecuteEx uses bInheritHandles=FALSE, so
+    ///     the handle is NOT passed to the child and the reader reaches EOF promptly even though the
+    ///     child is still alive -> a piped caller returns.
+    /// We assert OLD hangs and NEW does not, which is exactly the difference the fix delivers.
+    /// </summary>
+    [Fact]
+    [SupportedOSPlatform("windows")]
+    public void PipedCaller_ReturnsWithFix_AndWouldHangWithoutIt()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        // A long-lived "Gateway": ping loopback for ~30s. It never writes to stdout, so the only
+        // thing that can keep our pipe open is an INHERITED write handle.
+        var longLivedExe = Path.Combine(Environment.SystemDirectory, "ping.exe");
+        const string longLivedArgs = "-n 30 127.0.0.1";
+        var workDir = Path.GetTempPath();
+
+        // OLD behavior hangs: inherited write handle keeps the read end open while the child lives.
+        var oldReachedEof = TryDrainWithInheritedWritePipe(
+            new ProcessStartInfo
+            {
+                FileName = longLivedExe,
+                Arguments = longLivedArgs,
+                WorkingDirectory = workDir,
+                UseShellExecute = false,
+            },
+            waitForEof: TimeSpan.FromSeconds(3));
+        Assert.False(oldReachedEof); // reproduces the hang: no EOF within the window
+
+        // NEW behavior (the production config): no inherited handle -> EOF promptly, no hang.
+        var newPsi = GatewayTrayInstaller.BuildTrayLaunchInfo(longLivedExe, workDir);
+        newPsi.Arguments = longLivedArgs;
+        var newReachedEof = TryDrainWithInheritedWritePipe(newPsi, waitForEof: TimeSpan.FromSeconds(10));
+        Assert.True(newReachedEof); // piped caller returns even though the child is still alive
+    }
+
+    /// <summary>
+    /// Starts <paramref name="psi"/> while the write end of an anonymous pipe is marked inheritable,
+    /// then tries to read the read end to EOF. Returns true if EOF is reached within
+    /// <paramref name="waitForEof"/> (caller would NOT hang), false if the read blocks for the whole
+    /// window (caller would hang). The child is always killed.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static bool TryDrainWithInheritedWritePipe(ProcessStartInfo psi, TimeSpan waitForEof)
+    {
+        // The write end is marked inheritable. Process.Start with UseShellExecute=false creates the
+        // child with bInheritHandles=TRUE, so the child (and its tree) INHERIT this write handle -
+        // exactly how the real Gateway inherited the setup CLI's stdout. UseShellExecute=true uses
+        // ShellExecuteEx (bInheritHandles=FALSE), so the handle is NOT passed to the child.
+        using var pipe = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable);
+        _ = pipe.GetClientHandleAsString(); // realize the inheritable client handle before the child starts
+
+        Process? child = null;
+        try
+        {
+            child = Process.Start(psi) ?? throw new InvalidOperationException("Process.Start returned null");
+
+            // Release our own copy of the write end so the ONLY remaining writer can be the child
+            // (if it inherited the handle). If nothing inherited it, the read end sees EOF at once.
+            pipe.DisposeLocalCopyOfClientHandle();
+
+            using var reader = new StreamReader(pipe);
+            var readToEnd = Task.Run(() => reader.ReadToEnd());
+            // EOF reached within the window => no hang. Timed out => the child is holding the pipe.
+            return readToEnd.Wait(waitForEof);
+        }
+        finally
+        {
+            try { if (child is { HasExited: false }) child.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            child?.Dispose();
+        }
     }
 }
 

--- a/tools/cc-director-setup-engine/GatewayTrayInstaller.cs
+++ b/tools/cc-director-setup-engine/GatewayTrayInstaller.cs
@@ -99,13 +99,7 @@ public sealed class GatewayTrayInstaller
         // never disagree.
         try
         {
-            var psi = new ProcessStartInfo
-            {
-                FileName = gatewayExe,
-                Arguments = InstalledArguments,
-                WorkingDirectory = _layout.GatewayDir,
-                UseShellExecute = false,
-            };
+            var psi = BuildTrayLaunchInfo(gatewayExe, _layout.GatewayDir);
             using var p = Process.Start(psi)
                 ?? throw new InvalidOperationException("Process.Start returned null");
             steps.Add($"started Gateway tray app pid={p.Id} ({InstalledArguments})");
@@ -133,6 +127,30 @@ public sealed class GatewayTrayInstaller
 
         EngineLog.Write("[GatewayTrayInstaller] InstallAsync success");
         return new GatewayInstallResult(true, $"Gateway tray app installed and running; Cockpit live at {TailnetResolver.FrontDoorUrl()}.", steps);
+    }
+
+    /// <summary>
+    /// Builds the <see cref="ProcessStartInfo"/> for launching the long-lived tray Gateway.
+    ///
+    /// <c>UseShellExecute=true</c> (with NO <c>RedirectStandard*</c>) so the Gateway does NOT inherit
+    /// the setup CLI's stdout/stderr handles. An inherited stdout pipe keeps the caller's pipe open
+    /// for the Gateway's whole lifetime, so any caller that PIPES the CLI
+    /// (e.g. "... | Select-Object", "... | tail") hangs forever after the CLI exits. This mirrors the
+    /// proven fix on the GatewayApp self-update relaunch path (see
+    /// src/CcDirector.GatewayApp/Program.cs startGateway). See issue #175.
+    /// </summary>
+    public static ProcessStartInfo BuildTrayLaunchInfo(string gatewayExe, string workingDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(gatewayExe);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+
+        return new ProcessStartInfo
+        {
+            FileName = gatewayExe,
+            Arguments = InstalledArguments,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = true,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #175.

## Release Notes
The setup CLI's Gateway install no longer hangs callers that pipe its output. The long-lived tray Gateway is now launched with `UseShellExecute=true` so it does not inherit the CLI's stdout/stderr handles.

## Changes
- `tools/cc-director-setup-engine/GatewayTrayInstaller.cs`: extract the step-4 launch into a testable static seam `BuildTrayLaunchInfo` and set `UseShellExecute=true` (no `RedirectStandard*`), mirroring the proven `GatewayApp` self-update relaunch fix (`Program.cs` `startGateway`). Comment references #175 and that precedent.
- `tools/cc-director-setup-engine.Tests/GatewayAndPinsTests.cs`: a config-assertion test and a deterministic end-to-end test that reproduces the inherited-handle hang with the old config and proves a piped caller returns with the fix.

## How to Test
`dotnet test tools/cc-director-setup-engine.Tests/CcDirector.Setup.Engine.Tests.csproj --filter "FullyQualifiedName~GatewayTrayInstallerTests"`

## Expected Result
- `PipedCaller_ReturnsWithFix_AndWouldHangWithoutIt` PASS: old launch blocks a piped reader for the full window (hang reproduced); the production `BuildTrayLaunchInfo` config reaches EOF promptly while the child is still alive.
- `BuildTrayLaunchInfo_UsesShellExecute_NoRedirection` PASS: `UseShellExecute==true`, no redirection, launch config intact.
- Full setup-engine suite: 147 passed, 0 failed. Solution build: 0 warnings, 0 errors (Debug and Release).

## Before / After
- Before: tray Gateway launched `UseShellExecute=false` -> inherits caller stdio -> piped CLI hangs forever after the CLI exits.
- After: tray Gateway launched `UseShellExecute=true` -> no inherited handle -> piped CLI returns to the prompt; the Gateway still launches/registers (unchanged exe, args, working dir, health-wait).

Proof: docs/cencon/proof/issue-175/report.html

Generated with Claude Code (https://claude.com/claude-code)