### PR TITLE
Fix #232: deploy-cockpit.ps1 ships the scoped-CSS bundle (full wwwroot mirror)

### DIFF
--- a/docs/cencon/proof/issue-232/report.html
+++ b/docs/cencon/proof/issue-232/report.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Developer Agent Proof - Issue #232</title>
+<style>
+  :root { --bg:#1e1e1e; --panel:#252526; --border:#3c3c3c; --fg:#cccccc; --muted:#888888; --ok:#22c55e; --teal:#14b8a6; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); font-family:Segoe UI, system-ui, sans-serif; line-height:1.5; }
+  .wrap { max-width:1040px; margin:0 auto; padding:32px 24px 80px; }
+  h1 { font-size:24px; margin:0 0 4px; }
+  h2 { font-size:18px; margin:32px 0 10px; border-bottom:1px solid var(--border); padding-bottom:6px; }
+  .sub { color:var(--muted); font-size:13px; margin-bottom:20px; }
+  .badge { display:inline-block; padding:2px 10px; border-radius:6px; font-size:12px; font-weight:600; }
+  .b-ok { background:#1b3a2a; color:var(--ok); border:1px solid var(--ok); }
+  .chip { display:inline-block; border:1px solid var(--teal); color:var(--teal); border-radius:6px; padding:0 6px; font-size:11px; font-weight:700; }
+  table { border-collapse:collapse; width:100%; margin:12px 0; font-size:14px; }
+  th, td { border:1px solid var(--border); padding:8px 10px; text-align:left; vertical-align:top; }
+  th { background:var(--panel); }
+  code { background:#2d2d30; padding:1px 5px; border-radius:4px; font-family:Cascadia Mono, Consolas, monospace; font-size:12px; }
+  pre { background:#161616; border:1px solid var(--border); border-radius:6px; padding:12px 14px; overflow:auto; font-family:Cascadia Mono, Consolas, monospace; font-size:12px; color:#d4d4d4; }
+  .fig { color:var(--muted); font-size:12px; margin:0 0 18px; }
+  ul { margin:6px 0; } li { margin:3px 0; }
+  .done { background:var(--panel); border:1px solid var(--ok); border-radius:8px; padding:16px 18px; margin-top:28px; }
+  .ok { color:var(--ok); font-weight:600; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Developer Agent - Proof Report</h1>
+  <div class="sub">
+    Issue #232 - [Build] deploy-cockpit.ps1 misses the scoped-CSS bundle - .razor.css changes deploy stale<br/>
+    Branch <code>loop/232-deploy-cockpit-css</code> &middot; CenCon Development Method &middot;
+    Result: <span class="badge b-ok">ALL ACCEPTANCE CRITERIA MET</span>
+  </div>
+
+  <h2>The bug</h2>
+  <p>
+    <code>scripts/deploy-cockpit.ps1</code> swapped a freshly-published Cockpit into the live per-user
+    install by cherry-picking files: all <code>*.dll</code>/<code>*.pdb</code>, three json configs,
+    <code>wwwroot/app.css</code>, and <code>wwwroot/js/*</code>. It never copied
+    <code>wwwroot/cc-director-cockpit.styles.css</code> - the bundle Blazor compiles every component's
+    <b>scoped</b> <code>*.razor.css</code> into (linked by <code>App.razor</code>) - nor its
+    <code>.br</code>/<code>.gz</code> siblings, nor <code>wwwroot/lib</code> (xterm.css) or
+    <code>wwwroot/pages</code>. So any deploy that changed a <code>*.razor.css</code> shipped with the
+    markup updated but its styling stale (hit for real during the #212 W3 deploy, where the
+    Interrupted-sessions styling lives in <code>Fleet.razor.css</code> - required a manual full-folder
+    swap to recover).
+  </p>
+
+  <h2>What was implemented</h2>
+  <ul>
+    <li><b>Full wwwroot mirror</b> - the issue's preferred option ("cockpit = whole-folder swap").
+      The cherry-pick of <code>app.css</code> + <code>js/*</code> is replaced by a deterministic
+      mirror of the entire published <code>wwwroot</code> into the live target via
+      <code>robocopy /MIR</code>, wrapped in a new function <code>Sync-CockpitWwwroot</code>. Every
+      static asset - the scoped <code>*.styles.css</code> bundle and its <code>.br</code>/<code>.gz</code>,
+      <code>app.css</code>, <code>js/</code>, <code>lib/</code>, <code>pages/</code>,
+      <code>_framework/</code> - is always in sync. No copy list to maintain; new assets are picked up
+      automatically.</li>
+    <li><b>Fail-fast, no fallback</b> (CodingStyle.md) - missing stage throws; robocopy exit codes
+      &ge;8 are translated to a thrown error so a real copy failure is loud, not silent. ASCII-only output.</li>
+    <li><b>The DLL/pdb/json copy logic is unchanged</b> - it already mirrors every app assembly and is
+      correct.</li>
+    <li><b>A <code>-DefineOnly</code> switch</b> lets the proof test dot-source the script to exercise
+      the <i>real</i> <code>Sync-CockpitWwwroot</code> against temp dirs - one source of truth, no copied
+      logic - without ever touching the live fleet.</li>
+    <li><b>Hermetic proof test</b> <code>scripts/test/test-deploy-cockpit-css.ps1</code>.</li>
+  </ul>
+
+  <h2>Acceptance criteria - how each is met</h2>
+  <table>
+    <tr><th>Criterion</th><th>How the code satisfies it</th><th>Proof</th></tr>
+    <tr>
+      <td>AC1 - after a deploy where a <code>*.razor.css</code> changed, the live install's
+        <code>cc-director-cockpit.styles.css</code> (and <code>.br</code>/<code>.gz</code>) matches the
+        publish output.</td>
+      <td>The full <code>robocopy /MIR</code> copies the scoped bundle + siblings every deploy.</td>
+      <td><span class="ok">PASS</span> - test SHA-256-hashes the deployed bundle + <code>.br</code>/<code>.gz</code>
+        against the staged publish; all equal.</td>
+    </tr>
+    <tr>
+      <td>AC2 - a styling change in a <code>.razor.css</code> (e.g. <code>Fleet.razor.css</code>) is
+        visibly reflected in the deployed Cockpit without a manual full-folder swap.</td>
+      <td>The mirror overwrites a stale target bundle with the new one, so the recompiled scoped CSS
+        reaches <code>$target\wwwroot</code> on the normal deploy path.</td>
+      <td><span class="ok">PASS</span> - test seeds a STALE bundle in the live target, runs the mirror,
+        then asserts the live bundle changed and now equals the new <code>.razor.css</code> output.</td>
+    </tr>
+  </table>
+
+  <h2>Why a hermetic test instead of a live deploy</h2>
+  <p>
+    The machine is a busy shared host with a LIVE fleet (Gateway 7878, Cockpit 7470, Director 7887) and
+    several other cc-director agent sessions running. Running the real <code>deploy-cockpit.ps1</code>
+    would shut the live Gateway/Cockpit down. So the proof exercises the exact mirror function the deploy
+    now uses, against throwaway temp dirs that reproduce the real <code>wwwroot</code> shape and the
+    stale-bundle scenario - deterministic, repeatable, and zero impact on the fleet. The test also
+    discriminates: under the OLD cherry-pick logic the scoped bundle stays stale and the test fails;
+    under the fix it passes.
+  </p>
+
+  <h2>Test transcript</h2>
+  <p class="fig">scripts/test/test-deploy-cockpit-css.ps1 - exit 0</p>
+  <pre>  PASS: deployed: cc-director-cockpit.styles.css
+  PASS: hash matches publish: cc-director-cockpit.styles.css
+  PASS: deployed: cc-director-cockpit.styles.css.br
+  PASS: hash matches publish: cc-director-cockpit.styles.css.br
+  PASS: deployed: cc-director-cockpit.styles.css.gz
+  PASS: hash matches publish: cc-director-cockpit.styles.css.gz
+  PASS: deployed: app.css
+  PASS: hash matches publish: app.css
+  PASS: deployed: js\app.js
+  PASS: hash matches publish: js\app.js
+  PASS: deployed: lib\xterm.css
+  PASS: hash matches publish: lib\xterm.css
+  PASS: deployed: _framework\blazor.web.js
+  PASS: hash matches publish: _framework\blazor.web.js
+  PASS: scoped bundle changed in live target (stale -&gt; fresh)
+  PASS: live bundle now equals the new .razor.css output
+  PASS: regression: stale scoped bundle no longer served
+
+RESULT: PASS - all assertions green; scoped-CSS bundle now deploys fresh (issue #232).</pre>
+
+  <h2>Build</h2>
+  <p><code>dotnet build cc-director.sln</code> -&gt; <span class="ok">Build succeeded. 0 Warning(s), 0 Error(s).</span>
+  (No C# changed; the build gate confirms the worktree is clean.)</p>
+
+  <h2>CenCon impact</h2>
+  <p>No architecture or security drift. This is an existing ops script's copy list; the deploy still
+  targets the same per-user <code>%LOCALAPPDATA%\cc-director\cockpit</code> location
+  (docs/install/INSTALLATION.md). No <code>docs/cencon/</code> update needed.</p>
+
+  <div class="done">
+    <b>I believe this is finished.</b> The deploy script now mirrors the entire published
+    <code>wwwroot</code>, so the Blazor scoped-CSS bundle (and every other static asset) ships fresh on
+    every deploy. Both acceptance criteria are proven by a hermetic, discriminating test that exercises
+    the real mirror function; the solution builds clean.
+  </div>
+</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-232/test-output.txt
+++ b/docs/cencon/proof/issue-232/test-output.txt
@@ -1,0 +1,19 @@
+  PASS: deployed: cc-director-cockpit.styles.css
+  PASS: hash matches publish: cc-director-cockpit.styles.css
+  PASS: deployed: cc-director-cockpit.styles.css.br
+  PASS: hash matches publish: cc-director-cockpit.styles.css.br
+  PASS: deployed: cc-director-cockpit.styles.css.gz
+  PASS: hash matches publish: cc-director-cockpit.styles.css.gz
+  PASS: deployed: app.css
+  PASS: hash matches publish: app.css
+  PASS: deployed: js\app.js
+  PASS: hash matches publish: js\app.js
+  PASS: deployed: lib\xterm.css
+  PASS: hash matches publish: lib\xterm.css
+  PASS: deployed: _framework\blazor.web.js
+  PASS: hash matches publish: _framework\blazor.web.js
+  PASS: scoped bundle changed in live target (stale -> fresh)
+  PASS: live bundle now equals the new .razor.css output
+  PASS: regression: stale scoped bundle no longer served
+
+RESULT: PASS - all assertions green; scoped-CSS bundle now deploys fresh (issue #232).

--- a/scripts/deploy-cockpit.ps1
+++ b/scripts/deploy-cockpit.ps1
@@ -9,12 +9,46 @@
 # Everything is per-user: NO elevation, NO Windows service (docs/plans/gateway-tray-app.md).
 # The PRODUCTION no-admin update path is the tray app updating its own + the Cockpit's binaries -
 # not this script.
+#
+# -DefineOnly: dot-source this script to load Sync-CockpitWwwroot (and the path vars) WITHOUT
+# running the deploy. The issue #232 proof test uses this so it can exercise the real mirror
+# function against temp dirs - one source of truth, no copied logic - and never touches the live
+# fleet.
+param([switch] $DefineOnly)
 
 $ErrorActionPreference = 'Stop'
 $stage      = 'D:\ReposFred\cc-director\local_builds\cockpit-publish'
 $root       = "$env:LOCALAPPDATA\cc-director"
 $target     = "$root\cockpit"
 $gatewayExe = "$root\gateway\cc-director-gateway.exe"
+
+# Mirror the whole published wwwroot into the live install (issue #232).
+#
+# The old script cherry-picked wwwroot\app.css + wwwroot\js\* and left everything else stale.
+# That silently dropped wwwroot\cc-director-cockpit.styles.css - the bundle Blazor compiles every
+# component's SCOPED *.razor.css into (App.razor links it) - plus its .br/.gz siblings, wwwroot\lib
+# (xterm.css) and wwwroot\pages. Result: any deploy that changed a .razor.css shipped with the
+# markup updated but its styling stale (hit for real during the #212 W3 deploy). Mirroring the
+# entire wwwroot is the standing "cockpit = whole-folder swap" guidance and is future-proof: new
+# static assets are picked up automatically, no copy list to maintain.
+#
+# robocopy /MIR makes the target wwwroot byte-identical to the staged wwwroot (copies new/changed,
+# prunes removed). It is deterministic - no fallback. Robocopy exit codes 0-7 are SUCCESS (8+ are
+# failures); we translate that explicitly so $LASTEXITCODE does not trip $ErrorActionPreference.
+function Sync-CockpitWwwroot {
+  param(
+    [Parameter(Mandatory)] [string] $StageWwwroot,
+    [Parameter(Mandatory)] [string] $TargetWwwroot
+  )
+  if (-not (Test-Path $StageWwwroot)) { throw "Staged wwwroot not found: $StageWwwroot" }
+  New-Item -ItemType Directory -Force $TargetWwwroot | Out-Null
+  robocopy $StageWwwroot $TargetWwwroot /MIR /NJH /NJS /NP /NFL /NDL | Out-Null
+  $rc = $LASTEXITCODE
+  if ($rc -ge 8) { throw "robocopy mirror of wwwroot FAILED with exit code $rc ($StageWwwroot -> $TargetWwwroot)" }
+  return $rc
+}
+
+if ($DefineOnly) { return }
 
 if (-not (Test-Path "$stage\cc-director-cockpit.dll")) { Write-Host "ERROR: cockpit build not staged at $stage." ; exit 1 }
 if (-not (Test-Path $gatewayExe)) { Write-Host "ERROR: Gateway tray app not installed at $gatewayExe." ; exit 1 }
@@ -40,8 +74,9 @@ foreach ($dll in Get-ChildItem "$stage\*.dll","$stage\*.pdb") {
 foreach ($f in @('cc-director-cockpit.deps.json','cc-director-cockpit.runtimeconfig.json','cc-director-cockpit.staticwebassets.endpoints.json')) {
   if (Test-Path "$stage\$f") { Copy-Item "$stage\$f" "$target\$f" -Force }
 }
-Copy-Item "$stage\wwwroot\app.css" "$target\wwwroot\app.css" -Force
-Copy-Item "$stage\wwwroot\js\*"    "$target\wwwroot\js\" -Force -Recurse
+# Mirror the ENTIRE published wwwroot (scoped *.styles.css bundle + .br/.gz, app.css, js, lib,
+# pages, _framework) so a .razor.css change deploys fresh instead of stale (issue #232).
+Sync-CockpitWwwroot -StageWwwroot "$stage\wwwroot" -TargetWwwroot "$target\wwwroot"
 
 Write-Host "Relaunching the Gateway tray app..."
 Start-Process -FilePath $gatewayExe -ArgumentList '--managed' -WorkingDirectory "$root\gateway"

--- a/scripts/test/test-deploy-cockpit-css.ps1
+++ b/scripts/test/test-deploy-cockpit-css.ps1
@@ -1,0 +1,103 @@
+# Proof test for issue #232: deploy-cockpit.ps1 must ship the Blazor scoped-CSS bundle
+# (wwwroot\cc-director-cockpit.styles.css + .br/.gz) so a .razor.css change deploys fresh,
+# not stale.
+#
+# Hermetic: builds a fake "publish" stage and a fake "live target" under the temp dir, then
+# exercises the REAL Sync-CockpitWwwroot function from scripts\deploy-cockpit.ps1 (loaded via
+# -DefineOnly, so the live fleet is never touched). Asserts:
+#   1. The scoped bundle + .br/.gz land in the target and hash-match the stage (AC1).
+#   2. A CHANGED scoped bundle (the .razor.css edit) overwrites a STALE one in the live target,
+#      so the change is reflected without a manual full-folder swap (AC2).
+#   3. The old miss is gone: a previous run only copied app.css; the bundle now arrives too.
+#
+# ASCII only. Run: powershell -ExecutionPolicy Bypass -File scripts\test\test-deploy-cockpit-css.ps1
+# Exit 0 = PASS, non-zero = FAIL.
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot   = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$deployScript = Join-Path $repoRoot 'scripts\deploy-cockpit.ps1'
+if (-not (Test-Path $deployScript)) { Write-Host "FAIL: deploy script not found at $deployScript"; exit 1 }
+
+# Load Sync-CockpitWwwroot from the real deploy script WITHOUT running the deploy.
+. $deployScript -DefineOnly
+if (-not (Get-Command Sync-CockpitWwwroot -ErrorAction SilentlyContinue)) {
+  Write-Host "FAIL: Sync-CockpitWwwroot was not defined by the deploy script"; exit 1
+}
+
+$failures = New-Object System.Collections.Generic.List[string]
+function Assert-True([bool] $cond, [string] $msg) {
+  if ($cond) { Write-Host "  PASS: $msg" } else { Write-Host "  FAIL: $msg"; $script:failures.Add($msg) }
+}
+function Get-Hash([string] $path) { (Get-FileHash -Algorithm SHA256 -LiteralPath $path).Hash }
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("cc-232-" + [Guid]::NewGuid().ToString('N'))
+$stageWww  = Join-Path $work 'stage\wwwroot'
+$targetWww = Join-Path $work 'target\wwwroot'
+
+try {
+  # --- Arrange: a published wwwroot that mirrors the real shape ---
+  New-Item -ItemType Directory -Force (Join-Path $stageWww 'js')   | Out-Null
+  New-Item -ItemType Directory -Force (Join-Path $stageWww 'lib')  | Out-Null
+  New-Item -ItemType Directory -Force (Join-Path $stageWww '_framework') | Out-Null
+  Set-Content -LiteralPath (Join-Path $stageWww 'app.css') -Value 'body{color:#111}' -Encoding ascii
+  Set-Content -LiteralPath (Join-Path $stageWww 'js\app.js') -Value 'console.log("v2")' -Encoding ascii
+  Set-Content -LiteralPath (Join-Path $stageWww 'lib\xterm.css') -Value '.xterm{}' -Encoding ascii
+  Set-Content -LiteralPath (Join-Path $stageWww '_framework\blazor.web.js') -Value '// blazor v2' -Encoding ascii
+  # The scoped bundle reflecting a NEW Fleet.razor.css (the AC2 scenario), plus siblings.
+  $newBundle = '.b-fleet[b-xyz]{background:#0a84ff}'   # the "after" styling
+  Set-Content -LiteralPath (Join-Path $stageWww 'cc-director-cockpit.styles.css') -Value $newBundle -Encoding ascii
+  Set-Content -LiteralPath (Join-Path $stageWww 'cc-director-cockpit.styles.css.br') -Value 'BR-NEW' -Encoding ascii
+  Set-Content -LiteralPath (Join-Path $stageWww 'cc-director-cockpit.styles.css.gz') -Value 'GZ-NEW' -Encoding ascii
+
+  # --- Arrange: a live target with the OLD bundle (simulating the previous deploy where only
+  #     app.css/js were copied, so the scoped bundle was stale) ---
+  New-Item -ItemType Directory -Force $targetWww | Out-Null
+  $oldBundle = '.b-fleet[b-old]{background:#333}'      # the "before" stale styling
+  Set-Content -LiteralPath (Join-Path $targetWww 'cc-director-cockpit.styles.css') -Value $oldBundle -Encoding ascii
+  $beforeHash = Get-Hash (Join-Path $targetWww 'cc-director-cockpit.styles.css')
+
+  # --- Act: run the real mirror function (what the deploy now does) ---
+  Sync-CockpitWwwroot -StageWwwroot $stageWww -TargetWwwroot $targetWww | Out-Null
+
+  # --- Assert AC1: every static asset, including the scoped bundle, hash-matches publish ---
+  $assets = @(
+    'cc-director-cockpit.styles.css',
+    'cc-director-cockpit.styles.css.br',
+    'cc-director-cockpit.styles.css.gz',
+    'app.css',
+    'js\app.js',
+    'lib\xterm.css',
+    '_framework\blazor.web.js'
+  )
+  foreach ($rel in $assets) {
+    $s = Join-Path $stageWww  $rel
+    $t = Join-Path $targetWww $rel
+    Assert-True (Test-Path $t) "deployed: $rel"
+    if (Test-Path $t) {
+      Assert-True ((Get-Hash $s) -eq (Get-Hash $t)) "hash matches publish: $rel"
+    }
+  }
+
+  # --- Assert AC2: the stale bundle was overwritten by the new one (change reflected live) ---
+  $afterHash = Get-Hash (Join-Path $targetWww 'cc-director-cockpit.styles.css')
+  Assert-True ($afterHash -ne $beforeHash) "scoped bundle changed in live target (stale -> fresh)"
+  $live = Get-Content -Raw -LiteralPath (Join-Path $targetWww 'cc-director-cockpit.styles.css')
+  Assert-True ($live.Trim() -eq $newBundle) "live bundle now equals the new .razor.css output"
+
+  # --- Regression guard: the exact bug. The bundle must NOT still equal the old stale content. ---
+  Assert-True ($live.Trim() -ne $oldBundle) "regression: stale scoped bundle no longer served"
+}
+finally {
+  if (Test-Path $work) { Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue }
+}
+
+Write-Host ''
+if ($failures.Count -eq 0) {
+  Write-Host "RESULT: PASS - all assertions green; scoped-CSS bundle now deploys fresh (issue #232)."
+  exit 0
+} else {
+  Write-Host ("RESULT: FAIL - {0} assertion(s) failed:" -f $failures.Count)
+  foreach ($f in $failures) { Write-Host "  - $f" }
+  exit 1
+}


### PR DESCRIPTION
Closes #232.

## Release Notes
`deploy-cockpit.ps1` now mirrors the entire published `wwwroot` into the live install, so a `.razor.css` change deploys fresh instead of stale.

## Changes
- `scripts/deploy-cockpit.ps1`: replaced the `wwwroot\app.css` + `wwwroot\js\*` cherry-pick with a deterministic full mirror of the published `wwwroot` (`robocopy /MIR`) in a new `Sync-CockpitWwwroot` function - the issue's preferred "cockpit = whole-folder swap" option. Picks up the scoped `cc-director-cockpit.styles.css` bundle + `.br`/`.gz`, `lib/` (xterm.css), `pages/`, `_framework/`, etc. Fail-fast on robocopy exit >=8; ASCII-only; no fallback. Added a `-DefineOnly` switch so the proof test can load the real function without running the live deploy.
- `scripts/test/test-deploy-cockpit-css.ps1`: hermetic proof test.
- `docs/cencon/proof/issue-232/`: HTML report + test transcript.

## How to Test
`powershell -ExecutionPolicy Bypass -File scripts\test\test-deploy-cockpit-css.ps1`

## Expected Result
Exit 0, 17/17 assertions PASS. The test seeds a STALE scoped bundle in a fake live target, runs the real mirror function, and asserts: the scoped bundle + `.br`/`.gz` hash-match publish (AC1), and the stale bundle was overwritten by the new `.razor.css` output (AC2). It discriminates - under the old cherry-pick logic the bundle stays stale and the test fails.

## Before / After
- Before: deploy left `cc-director-cockpit.styles.css` stale; a `.razor.css` change needed a manual full-folder swap to show up.
- After: every `wwwroot` asset, including the scoped bundle, is mirrored on every deploy.

CenCon: no architecture/security drift (ops script copy list; same per-user target).

Live fleet (Gateway 7878, Cockpit 7470, Director 7887) confirmed still up; no live deploy was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)