### PR TITLE
Fix #176: stop self-update test harness polluting production installed.json

### DIFF
--- a/docs/cencon/proof/issue-176/prod-setup-hashes.txt
+++ b/docs/cencon/proof/issue-176/prod-setup-hashes.txt
@@ -1,0 +1,27 @@
+Issue #176 - Production setup state byte-identical across the work (AC1 evidence)
+================================================================================
+
+Production setup dir: %LOCALAPPDATA%\cc-director\config\setup
+
+SHA-256 captured at the START of the dev session (before any isolation experiment):
+  installed.json   = BFDBD7E2C17D975FED03450A5AA99C7EBEE5EC1E71F0C8EC607DBAAD358E08E7
+  update-pins.json = E3566B3A06430868D71E9287DFD6C6C520A3DA027AABEA01951D407EE131DC2F
+
+SHA-256 captured at the END (after building, running the full 153-test engine suite,
+and exercising the isolated InstalledManifest/PinStore writes under CC_DIRECTOR_ROOT):
+  installed.json   = BFDBD7E2C17D975FED03450A5AA99C7EBEE5EC1E71F0C8EC607DBAAD358E08E7
+  update-pins.json = E3566B3A06430868D71E9287DFD6C6C520A3DA027AABEA01951D407EE131DC2F
+
+Result: BYTE-IDENTICAL. The production installed.json still records the REAL versions
+("gateway":"0.6.22", ...), never the fake 9.9.x the self-update harness stages.
+
+Live fleet untouched during the work:
+  Gateway  http://127.0.0.1:7878/healthz -> 200
+  Cockpit  http://127.0.0.1:7470/        -> 200
+  Director http://127.0.0.1:7887/healthz -> 200
+
+Note: the live self-update script (test-gateway-selfupdate.ps1) was NOT executed end-to-end
+on this busy shared machine (it builds and spawns gateway processes and binds ports). Its
+isolation MECHANISM is proven hermetically by SelfUpdateIsolationTests, which records the same
+fake 9.9.x versions GatewaySelfUpdate would, under an isolated CC_DIRECTOR_ROOT, and asserts the
+production setup files are byte-identical before/after - the same hashes shown above.

--- a/docs/cencon/proof/issue-176/qa-report.html
+++ b/docs/cencon/proof/issue-176/qa-report.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #176 - QA Proof Report</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 62rem; color: #1b1b1b; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #1a7a32; padding-bottom: .3rem; }
+  h2 { margin-top: 2rem; color: #1a7a32; }
+  code, pre { font-family: Consolas, monospace; background: #f4f6fa; }
+  pre { padding: 1rem; border-radius: 6px; overflow-x: auto; border: 1px solid #dfe3ea; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cfd6e2; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #eafbef; }
+  .pass { color: #1a7a32; font-weight: bold; }
+  .meta { color: #555; font-size: .9rem; }
+</style>
+</head>
+<body>
+<h1>Issue #176 - QA Proof Report (independent verification)</h1>
+<p class="meta">QA Agent (CenCon) - independent of the Developer Agent. Repo: thefrederiksen/cc-director.
+PR #306, branch <code>loop/176-selfupdate-installedjson</code> @ 07a9124. Verified on a busy shared
+machine; the live fleet (Gateway 7878, Cockpit 7470, Director 7887) was confirmed responding 200
+before, during, and after, and the production setup state was kept byte-identical throughout.</p>
+
+<h2>Method</h2>
+<p>The PR branch was checked out fresh and built and tested by QA independently - the Developer's
+binaries, test output, and screenshots were NOT reused. The full setup-engine test project was run
+by QA; the script's production-root refusal was exercised by QA; the production setup files were
+hashed by QA at the start, after the build + full test run, and after the refusal run.</p>
+
+<h2>Acceptance criteria - independently verified</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-observed)</th><th>Result</th></tr>
+<tr>
+  <td>1</td>
+  <td>Running the self-update test leaves production <code>installed.json</code> /
+      <code>update-pins.json</code> byte-identical (hash before/after).</td>
+  <td>Production setup files unchanged; the harness writes the fake versions only to an isolated root.</td>
+  <td>Production SHA-256 identical across the entire QA session (baseline -&gt; after build+153 tests -&gt;
+      after refusal run). The <code>RecordingFakeVersions_UnderIsolatedRoot_LeavesProductionSetupStateUntouched</code>
+      test (which performs the REAL <code>InstalledManifest.Set(gateway,9.9.9).Save()</code> +
+      <code>PinStore.Pin(gateway,9.9.8)</code> under <code>CC_DIRECTOR_ROOT</code>) passed in QA's own run, and
+      QA confirmed production unchanged. The script also refuses the production root: invoking it with
+      <code>-Root %LOCALAPPDATA%\cc-director</code> exited 2 with a refusal message before any build or process spawn.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>A poisoned installed version (higher than newest release) -&gt; planner logs loudly and does NOT
+      report UpToDate; prefers the exe FileVersion.</td>
+  <td>UpdatePlanner ignores the anomalous recorded version, logs a WARNING, and uses the exe stamp.</td>
+  <td>QA ran the guard tests independently:
+      <code>PoisonedInstalledVersion_DoesNotReportUpToDate_PrefersExeFileVersion</code> (exact #176 case: recorded
+      9.9.9, exe 0.6.5, release 0.6.6 -&gt; Update from 0.6.5, NOT UpToDate),
+      <code>PoisonedInstalledVersion_NoReadableExeStamp_ReappliesInsteadOfUpToDate</code> (no exe stamp -&gt; Update,
+      never UpToDate on the discarded fake), and
+      <code>PoisonedInstalledVersion_ExeAlreadyAtRelease_ReportsUpToDateFromExeStamp</code> all passed. The loud
+      <code>EngineLog.Write</code> WARNING is present in <code>UpdatePlanner.Plan</code>. Logic reviewed: guard fires only on
+      <code>present &amp;&amp; IsNewer(recorded, release) &amp;&amp; recorded != fileVersion</code>, and <code>VersionUtil.IsNewer</code>
+      returns false on any unparseable side, so legitimate states are never falsely flagged.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>A normal install/update still completes and reports success only when the exe was actually swapped.</td>
+  <td>Legitimate at-or-below versions still resolve to UpToDate/Update correctly; guard does not misfire.</td>
+  <td><code>NormalInstalledVersion_NotTreatedAsPoisoned</code> (recorded 0.6.6 == release 0.6.6 -&gt; UpToDate) and the
+      pre-existing <code>IndependentVersioning_OnlyBehindComponentUpdates</code> /
+      <code>PinnedVersion_IsSkippedNotUpdated</code> all passed in QA's run. The guard only touches the anomalous
+      installed &gt; release path; the happy/rollback paths of the script are unchanged.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>QA build &amp; test evidence (independent run)</h2>
+<pre>dotnet build cc-director.sln -c Debug
+  Build succeeded.  0 Warning(s)  0 Error(s)
+
+dotnet test tools/cc-director-setup-engine.Tests/CcDirector.Setup.Engine.Tests.csproj
+  Passed!  - Failed: 0, Passed: 153, Skipped: 0, Total: 153</pre>
+
+<h2>Production setup state - byte-identical throughout (QA hashes)</h2>
+<pre>installed.json   = BFDBD7E2C17D975FED03450A5AA99C7EBEE5EC1E71F0C8EC607DBAAD358E08E7   (baseline / post-tests / post-refusal - all identical)
+update-pins.json = E3566B3A06430868D71E9287DFD6C6C520A3DA027AABEA01951D407EE131DC2F   (baseline / post-tests / post-refusal - all identical)</pre>
+<p>These match the hashes the Developer recorded, confirming production was never touched by QA's
+build, the 153-test run, or the production-root refusal run.</p>
+
+<h2>Production-root refusal (QA-observed)</h2>
+<pre>powershell -File scripts\test-gateway-selfupdate.ps1 -Root %LOCALAPPDATA%\cc-director
+  EXITCODE = 2
+  FAILED: -Root must not be the production install root (C:\Users\soren\AppData\Local\cc-director). Refusing to pollute production setup state.</pre>
+<p>The refusal fires before any build or process spawn - no port was bound, no gateway was launched,
+the live fleet stayed at 200/200/200.</p>
+
+<h2>Regression / CenCon checks</h2>
+<ul>
+  <li>Full setup-engine suite green (153/153); no adjacent test regressed.</li>
+  <li>Change confined to the <code>CcDirector.Setup.Engine</code> container's update-planning logic + its test
+      harness. No container boundaries, data flows, or DT security rules affected; no <code>docs/cencon/</code>
+      update required.</li>
+  <li>Live fleet (7878 / 7470 / 7887) confirmed 200 before, during, and after QA.</li>
+</ul>
+
+<p class="pass">VERIFIED - all acceptance criteria met. Merging to main on a clean build.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-176/report.html
+++ b/docs/cencon/proof/issue-176/report.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #176 - Developer Proof Report</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 60rem; color: #1b1b1b; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #2d6cdf; padding-bottom: .3rem; }
+  h2 { margin-top: 2rem; color: #2d6cdf; }
+  code, pre { font-family: Consolas, monospace; background: #f4f6fa; }
+  pre { padding: 1rem; border-radius: 6px; overflow-x: auto; border: 1px solid #dfe3ea; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cfd6e2; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #eef3fc; }
+  .pass { color: #1a7a32; font-weight: bold; }
+  .meta { color: #555; font-size: .9rem; }
+</style>
+</head>
+<body>
+<h1>Issue #176 - Self-update test harness pollutes production installed.json</h1>
+<p class="meta">Developer Agent (CenCon) - implementation proof. Repo: thefrederiksen/cc-director.
+Branch: <code>loop/176-selfupdate-installedjson</code>.</p>
+
+<h2>Problem</h2>
+<p>A live v0.6.6 gateway install reported success but silently did <strong>not</strong> swap the
+gateway exe. Root cause: the gateway self-update <em>test</em> harness wrote FAKE versions
+(<code>gateway 9.9.9</code> into <code>installed.json</code>, <code>9.9.8</code> into
+<code>update-pins.json</code>) into the <strong>production</strong>
+<code>%LOCALAPPDATA%\cc-director\config\setup</code> state. <code>UpdatePlanner</code> then judged
+installed <code>9.9.9 &gt;= release 0.6.6</code> -&gt; UpToDate -&gt; the swap never ran while the
+installer reported success.</p>
+
+<h2>Two independent defenses (as specified)</h2>
+
+<h3>Defense 1 - isolate the test harness (no production writes)</h3>
+<p><code>scripts/test-gateway-selfupdate.ps1</code> now takes a <code>-Root</code> override and exports
+<code>CC_DIRECTOR_ROOT</code> to a throwaway temp root before launching the self-update helper.
+<code>InstallLayout.Default()</code> already honors <code>CC_DIRECTOR_ROOT</code>, so the helper's
+<code>InstalledManifest.Save</code> / <code>PinStore.Save</code> writes land under the isolated root,
+never production. The script also (a) refuses to run if <code>-Root</code> resolves to the production
+root, and (b) hashes the production <code>installed.json</code> / <code>update-pins.json</code>
+before and after the run and FAILS the run if they changed.</p>
+
+<h3>Defense 2 - sanity guard in UpdatePlanner</h3>
+<p><code>InstalledStateReader</code> now records the exe's real on-disk <code>FileVersion</code>
+separately from the recorded (installed.json) version. <code>UpdatePlanner.Plan</code> detects when the
+recorded installed version is strictly NEWER than the newest released version (the test-pollution
+signature), logs a loud <code>WARNING</code> via <code>EngineLog</code>, and prefers the exe's real
+<code>FileVersion</code> for the decision instead of reporting UpToDate. If the exe carries no
+readable stamp to fall back on, it re-applies the released build rather than trusting the discarded
+fake version.</p>
+
+<h2>Acceptance criteria - status</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>How met</th><th>Proof</th></tr>
+<tr>
+  <td>1</td>
+  <td>Running the self-update test leaves production <code>installed.json</code> /
+      <code>update-pins.json</code> byte-identical (hash before/after).</td>
+  <td>Script sets <code>CC_DIRECTOR_ROOT</code> to a throwaway root; helper writes land there.
+      Mechanism proven hermetically.</td>
+  <td class="pass">PASS - <code>prod-setup-hashes.txt</code> (identical SHA-256 before/after) +
+      <code>SelfUpdateIsolationTests</code></td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>A poisoned installed version (higher than newest release) -&gt; planner logs loudly and does
+      NOT report UpToDate; prefers the exe FileVersion.</td>
+  <td>Sanity guard in <code>UpdatePlanner.Plan</code> + exe FileVersion carried on
+      <code>InstalledComponent</code>.</td>
+  <td class="pass">PASS - 4 new <code>UpdatePlannerTests</code> (see test-output.txt)</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>A normal install/update still completes and reports success only when the exe was actually
+      swapped.</td>
+  <td>The happy/rollback paths of the script are unchanged; the guard only fires on the anomalous
+      installed &gt; release case, so a legitimate behind-version still flags Update and a current
+      version stays UpToDate.</td>
+  <td class="pass">PASS - <code>NormalInstalledVersion_NotTreatedAsPoisoned</code> +
+      existing <code>IndependentVersioning_OnlyBehindComponentUpdates</code> /
+      <code>PinnedVersion_IsSkippedNotUpdated</code> (153/153 engine tests green)</td>
+</tr>
+</table>
+
+<h2>Files changed</h2>
+<ul>
+  <li><code>scripts/test-gateway-selfupdate.ps1</code> - <code>-Root</code> override, CC_DIRECTOR_ROOT
+      isolation, production-root refusal, before/after hash check.</li>
+  <li><code>tools/cc-director-setup-engine/InstalledComponent.cs</code> - added on-disk
+      <code>FileVersion</code>.</li>
+  <li><code>tools/cc-director-setup-engine/InstalledStateReader.cs</code> - populate
+      <code>FileVersion</code> from the exe stamp.</li>
+  <li><code>tools/cc-director-setup-engine/UpdatePlanner.cs</code> - poisoned-version sanity guard.</li>
+  <li><code>tools/cc-director-setup-engine.Tests/UpdatePlannerTests.cs</code> - 4 guard tests.</li>
+  <li><code>tools/cc-director-setup-engine.Tests/SelfUpdateIsolationTests.cs</code> - 2 isolation tests.</li>
+</ul>
+
+<h2>Build &amp; test evidence</h2>
+<pre>dotnet build cc-director.sln
+  Build succeeded.
+  0 Warning(s)
+  0 Error(s)
+
+dotnet test (setup-engine):
+  Passed! - Failed: 0, Passed: 153, Skipped: 0, Total: 153</pre>
+<p>Production setup files SHA-256, start vs end of session - identical:</p>
+<pre>installed.json   = BFDBD7E2C17D975FED03450A5AA99C7EBEE5EC1E71F0C8EC607DBAAD358E08E7  (both)
+update-pins.json = E3566B3A06430868D71E9287DFD6C6C520A3DA027AABEA01951D407EE131DC2F  (both)
+installed.json content: { "gateway":"0.6.22", "cockpit":"0.6.22", "director":"0.6.22", "python-tools":"0.6.22" }  (real versions, no 9.9.x)</pre>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security-posture drift. The change is confined to the
+<code>CcDirector.Setup.Engine</code> container's update-planning logic and its test harness; no
+container boundaries, data flows, or DT-rules are affected. No <code>docs/cencon/</code> update
+required.</p>
+
+<h2>Note on the live end-to-end run</h2>
+<p>The full <code>test-gateway-selfupdate.ps1</code> end-to-end run (which builds the gateway and
+spawns processes binding ports) was NOT executed on this busy shared machine to avoid disturbing the
+live fleet (Gateway 7878, Cockpit 7470, Director 7887 - all confirmed responding 200 at the end). The
+isolation mechanism the script depends on is proven hermetically and repeatably by
+<code>SelfUpdateIsolationTests</code> under net10.0, asserting the production files are byte-identical
+to the hashes above.</p>
+
+<p class="pass">I believe this is finished.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-176/test-output.txt
+++ b/docs/cencon/proof/issue-176/test-output.txt
@@ -1,0 +1,26 @@
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  CcDirector.Setup.Engine -> D:\ReposFred\cc-director-wt-176\tools\cc-director-setup-engine\bin\Debug\net10.0\CcDirector.Setup.Engine.dll
+  CcDirector.Setup.Engine.Tests -> D:\ReposFred\cc-director-wt-176\tools\cc-director-setup-engine.Tests\bin\Debug\net10.0\CcDirector.Setup.Engine.Tests.dll
+Test run for D:\ReposFred\cc-director-wt-176\tools\cc-director-setup-engine.Tests\bin\Debug\net10.0\CcDirector.Setup.Engine.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 10.0.9)
+[xUnit.net 00:00:00.05]   Discovering: CcDirector.Setup.Engine.Tests
+[xUnit.net 00:00:00.09]   Discovered:  CcDirector.Setup.Engine.Tests
+[xUnit.net 00:00:00.09]   Starting:    CcDirector.Setup.Engine.Tests
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.NotInstalled_BecomesInstall [17 ms]
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.PoisonedInstalledVersion_NoReadableExeStamp_ReappliesInsteadOfUpToDate [1 ms]
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.NoAssetInManifest_BecomesMissingAsset [2 ms]
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.IndependentVersioning_OnlyBehindComponentUpdates [1 ms]
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.PoisonedInstalledVersion_ExeAlreadyAtRelease_ReportsUpToDateFromExeStamp [< 1 ms]
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.NormalInstalledVersion_NotTreatedAsPoisoned [< 1 ms]
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.PinnedVersion_IsSkippedNotUpdated [1 ms]
+  Passed CcDirector.Setup.Engine.Tests.UpdatePlannerTests.PoisonedInstalledVersion_DoesNotReportUpToDate_PrefersExeFileVersion [< 1 ms]
+  Passed CcDirector.Setup.Engine.Tests.SelfUpdateIsolationTests.RecordingFakeVersions_UnderIsolatedRoot_LeavesProductionSetupStateUntouched [35 ms]
+[xUnit.net 00:00:00.18]   Finished:    CcDirector.Setup.Engine.Tests
+  Passed CcDirector.Setup.Engine.Tests.SelfUpdateIsolationTests.Default_HonorsCcDirectorRootOverride [< 1 ms]
+
+Test Run Successful.
+Total tests: 10
+     Passed: 10
+ Total time: 0.4924 Seconds

--- a/scripts/test-gateway-selfupdate.ps1
+++ b/scripts/test-gateway-selfupdate.ps1
@@ -21,13 +21,21 @@
 .PARAMETER Port
   Alternate port the throwaway instance binds (default 7899 - NOT the live 7878/7470).
 
+.PARAMETER Root
+  ISOLATED install root for this test run (issue #176). The self-update helper records the new
+  version into <Root>\config\setup\installed.json and any rollback pin into update-pins.json. By
+  pointing CC_DIRECTOR_ROOT at a throwaway temp dir, this test NEVER writes the FAKE 9.9.x versions
+  into the PRODUCTION %LOCALAPPDATA%\cc-director setup state. Defaults to a fresh temp dir under the
+  test work dir. Do NOT point this at %LOCALAPPDATA%\cc-director.
+
 .EXAMPLE
   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\test-gateway-selfupdate.ps1
 #>
 [CmdletBinding()]
 param(
     [int]$Port = 7899,
-    [int]$DeadPort = 7897
+    [int]$DeadPort = 7897,
+    [string]$Root
 )
 
 $ErrorActionPreference = 'Continue'
@@ -36,6 +44,31 @@ $work = Join-Path $env:TEMP ("cc-gwsu-" + [Guid]::NewGuid().ToString('N'))
 $installed = Join-Path $work 'installed\cc-director-gateway.exe'
 $staged    = Join-Path $work 'staged\cc-director-gateway.exe'
 $runArgs   = "--port $Port --no-autostart"
+
+# --- Isolation (issue #176): the self-update helper writes installed.json / update-pins.json into
+# CC_DIRECTOR_ROOT\config\setup. Point that at a THROWAWAY root so the FAKE 9.9.x versions this test
+# stages never land in the production %LOCALAPPDATA%\cc-director setup state (a silent half-install).
+if ([string]::IsNullOrWhiteSpace($Root)) { $Root = Join-Path $work 'root' }
+$prodRoot = Join-Path $env:LOCALAPPDATA 'cc-director'
+if ([IO.Path]::GetFullPath($Root).TrimEnd('\') -ieq [IO.Path]::GetFullPath($prodRoot).TrimEnd('\')) {
+    Write-Output "FAILED: -Root must not be the production install root ($prodRoot). Refusing to pollute production setup state."
+    exit 2
+}
+New-Item -ItemType Directory -Force $Root | Out-Null
+$env:CC_DIRECTOR_ROOT = $Root
+Write-Output "[OK] isolated install root: $Root (production $prodRoot is untouched)"
+
+# Snapshot the production setup files so we can PROVE they are byte-identical before vs after the run.
+$prodSetup = Join-Path $prodRoot 'config\setup'
+$prodInstalled = Join-Path $prodSetup 'installed.json'
+$prodPins      = Join-Path $prodSetup 'update-pins.json'
+function Get-FileHashOrNull([string]$p) {
+    if (Test-Path $p) { return (Get-FileHash -Algorithm SHA256 -LiteralPath $p).Hash }
+    return '(absent)'
+}
+$prodInstalledHashBefore = Get-FileHashOrNull $prodInstalled
+$prodPinsHashBefore      = Get-FileHashOrNull $prodPins
+Write-Output "[hash-before] installed.json=$prodInstalledHashBefore  update-pins.json=$prodPinsHashBefore"
 
 # The throwaway must never touch the live Tailscale serve mappings; children inherit this.
 $env:CC_GATEWAY_NO_TAILSCALE = '1'
@@ -104,11 +137,23 @@ try {
     $h2 = Healthy $Port   # after rollback the previous build relaunches with the REAL port args
     Write-Output ("  exit={0}  healthy-after-rollback={1}  (expect exit 1, healthy true)" -f $rc2, $h2)
 
+    # --- Isolation proof (issue #176): the production setup files must be byte-identical to before. ---
+    $prodInstalledHashAfter = Get-FileHashOrNull $prodInstalled
+    $prodPinsHashAfter      = Get-FileHashOrNull $prodPins
     Write-Output ""
-    if ($rc1 -eq 0 -and $h1 -and $rc2 -ne 0 -and $h2) {
-        Write-Output "RESULT: PASS - self-update applies a healthy build and auto-rolls-back an unhealthy one."
+    Write-Output "[hash-after ] installed.json=$prodInstalledHashAfter  update-pins.json=$prodPinsHashAfter"
+    $prodUntouched = ($prodInstalledHashAfter -eq $prodInstalledHashBefore) -and ($prodPinsHashAfter -eq $prodPinsHashBefore)
+    if ($prodUntouched) {
+        Write-Output "[OK] production setup state byte-identical (installed.json + update-pins.json unchanged)."
     } else {
-        Write-Output "RESULT: FAIL - see the values above and %LOCALAPPDATA%\cc-director\logs."
+        Write-Output "[X] PRODUCTION SETUP STATE CHANGED - this test polluted $prodSetup (issue #176 regression)."
+    }
+
+    Write-Output ""
+    if ($rc1 -eq 0 -and $h1 -and $rc2 -ne 0 -and $h2 -and $prodUntouched) {
+        Write-Output "RESULT: PASS - self-update applies a healthy build, auto-rolls-back an unhealthy one, and leaves production setup state untouched."
+    } else {
+        Write-Output "RESULT: FAIL - see the values above and $($env:CC_DIRECTOR_ROOT)\logs."
     }
 }
 finally {

--- a/tools/cc-director-setup-engine.Tests/SelfUpdateIsolationTests.cs
+++ b/tools/cc-director-setup-engine.Tests/SelfUpdateIsolationTests.cs
@@ -1,0 +1,84 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Issue #176 defense #1: the self-update test harness must write its FAKE versions into an ISOLATED
+/// install root (via CC_DIRECTOR_ROOT), never the production %LOCALAPPDATA%\cc-director setup state.
+///
+/// These tests prove the engine-side mechanism the script relies on: InstallLayout.Default() honors
+/// CC_DIRECTOR_ROOT, so the version-recording (InstalledManifest) and rollback-pin (PinStore) writes
+/// that GatewaySelfUpdate performs land under the isolated root - leaving the production
+/// installed.json / update-pins.json byte-identical.
+/// </summary>
+public class SelfUpdateIsolationTests
+{
+    [Fact]
+    public void Default_HonorsCcDirectorRootOverride()
+    {
+        var iso = Path.Combine(Path.GetTempPath(), "cc-iso-" + Guid.NewGuid().ToString("N"));
+        var previous = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        try
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", iso);
+            var layout = InstallLayout.Default();
+            Assert.Equal(iso, layout.LocalRoot);
+            Assert.StartsWith(iso, layout.InstalledManifestPath, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", previous);
+        }
+    }
+
+    [Fact]
+    public void RecordingFakeVersions_UnderIsolatedRoot_LeavesProductionSetupStateUntouched()
+    {
+        // Snapshot the production setup files (whatever their current state) so we can prove they do
+        // not change while we record fake 9.9.x versions exactly like GatewaySelfUpdate would.
+        var prod = InstallLayout.Default(); // production layout (no override active in this assertion)
+        var prodInstalledBefore = SnapshotBytes(prod.InstalledManifestPath);
+        var prodPinsBefore = SnapshotBytes(Path.Combine(prod.SetupStateDir, "update-pins.json"));
+
+        var iso = Path.Combine(Path.GetTempPath(), "cc-iso-" + Guid.NewGuid().ToString("N"));
+        var previous = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        try
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", iso);
+            var layout = InstallLayout.Default();
+            Assert.Equal(iso, layout.LocalRoot);
+
+            // Mirror GatewaySelfUpdate.RecordInstalled + Pin: write the FAKE versions the harness stages.
+            var manifest = InstalledManifest.Load(layout);
+            manifest.Set(ComponentRegistry.Gateway.Id, "9.9.9");
+            manifest.Save(layout);
+
+            var pins = PinStore.Load(layout);
+            pins.Pin(ComponentRegistry.Gateway.Id, "9.9.8");
+            PinStore.Save(layout, pins);
+
+            // The fake versions landed under the ISOLATED root...
+            Assert.True(File.Exists(layout.InstalledManifestPath), "isolated installed.json should exist");
+            Assert.Contains("9.9.9", File.ReadAllText(layout.InstalledManifestPath));
+            Assert.True(File.Exists(Path.Combine(layout.SetupStateDir, "update-pins.json")), "isolated update-pins.json should exist");
+
+            // ...and the isolated root is NOT the production root.
+            Assert.NotEqual(prod.LocalRoot, layout.LocalRoot);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", previous);
+            try { if (Directory.Exists(iso)) Directory.Delete(iso, recursive: true); } catch { /* best-effort temp cleanup */ }
+        }
+
+        // The production setup files are byte-identical to before the isolated write.
+        var prodInstalledAfter = SnapshotBytes(prod.InstalledManifestPath);
+        var prodPinsAfter = SnapshotBytes(Path.Combine(prod.SetupStateDir, "update-pins.json"));
+        Assert.Equal(prodInstalledBefore, prodInstalledAfter);
+        Assert.Equal(prodPinsBefore, prodPinsAfter);
+    }
+
+    private static byte[] SnapshotBytes(string path) =>
+        File.Exists(path) ? File.ReadAllBytes(path) : Array.Empty<byte>();
+}

--- a/tools/cc-director-setup-engine.Tests/UpdatePlannerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/UpdatePlannerTests.cs
@@ -26,6 +26,15 @@ public class UpdatePlannerTests
         return map;
     }
 
+    private static Dictionary<string, InstalledComponent> InstalledWithFileVersion(
+        string id, string? recordedVersion, string? fileVersion)
+    {
+        return new Dictionary<string, InstalledComponent>(StringComparer.OrdinalIgnoreCase)
+        {
+            [id] = new InstalledComponent(id, Present: true, Version: recordedVersion, Path: $@"C:\x\{id}", FileVersion: fileVersion),
+        };
+    }
+
     [Fact]
     public void NotInstalled_BecomesInstall()
     {
@@ -95,5 +104,74 @@ public class UpdatePlannerTests
         Assert.Equal(PlanItemKind.Pinned, plan.Items.Single(i => i.ComponentId == "cc-pdf").Kind);
         Assert.Empty(plan.ToUpdate);
         Assert.False(plan.HasWork);
+    }
+
+    // --- Issue #176: sanity guard against a poisoned (test-polluted) installed version ---
+
+    [Fact]
+    public void PoisonedInstalledVersion_DoesNotReportUpToDate_PrefersExeFileVersion()
+    {
+        // The exact #176 scenario: installed.json records a FAKE 9.9.9 for the gateway (self-update
+        // test pollution) while the released gateway is 0.6.6 and the exe on disk is really 0.6.5.
+        // The planner must NOT trust 9.9.9 (which would say UpToDate and skip the swap); it must use
+        // the exe's real FileVersion 0.6.5 and therefore flag an Update to 0.6.6.
+        var components = new[] { ComponentRegistry.Gateway };
+        var manifest = Manifest(("cc-director-gateway-win-x64.exe", "0.6.6"));
+        var installed = InstalledWithFileVersion("gateway", recordedVersion: "9.9.9", fileVersion: "0.6.5");
+
+        var plan = UpdatePlanner.Plan(components, installed, manifest);
+
+        var item = plan.Items.Single(i => i.ComponentId == "gateway");
+        Assert.NotEqual(PlanItemKind.UpToDate, item.Kind);
+        Assert.Equal(PlanItemKind.Update, item.Kind);
+        Assert.Equal("0.6.5", item.FromVersion);   // the real exe stamp, not the poisoned 9.9.9
+        Assert.Equal("0.6.6", item.ToVersion);
+    }
+
+    [Fact]
+    public void PoisonedInstalledVersion_ExeAlreadyAtRelease_ReportsUpToDateFromExeStamp()
+    {
+        // Poisoned record 9.9.9 but the exe is genuinely already at the released 0.6.6: the guard
+        // discards 9.9.9, uses the real stamp 0.6.6, and correctly reports UpToDate on THAT basis.
+        var components = new[] { ComponentRegistry.Gateway };
+        var manifest = Manifest(("cc-director-gateway-win-x64.exe", "0.6.6"));
+        var installed = InstalledWithFileVersion("gateway", recordedVersion: "9.9.9", fileVersion: "0.6.6");
+
+        var plan = UpdatePlanner.Plan(components, installed, manifest);
+
+        var item = plan.Items.Single(i => i.ComponentId == "gateway");
+        Assert.Equal(PlanItemKind.UpToDate, item.Kind);
+        Assert.Equal("0.6.6", item.FromVersion);
+    }
+
+    [Fact]
+    public void PoisonedInstalledVersion_NoReadableExeStamp_ReappliesInsteadOfUpToDate()
+    {
+        // Poisoned record 9.9.9 and the exe carries no readable stamp: we must never report UpToDate
+        // on the basis of the discarded fake version - re-apply the released build to correct it.
+        var components = new[] { ComponentRegistry.Gateway };
+        var manifest = Manifest(("cc-director-gateway-win-x64.exe", "0.6.6"));
+        var installed = InstalledWithFileVersion("gateway", recordedVersion: "9.9.9", fileVersion: null);
+
+        var plan = UpdatePlanner.Plan(components, installed, manifest);
+
+        var item = plan.Items.Single(i => i.ComponentId == "gateway");
+        Assert.Equal(PlanItemKind.Update, item.Kind);
+    }
+
+    [Fact]
+    public void NormalInstalledVersion_NotTreatedAsPoisoned()
+    {
+        // A legitimate installed version at-or-below the release is never disturbed by the guard:
+        // recorded 0.6.6 == released 0.6.6 stays UpToDate even when no separate file stamp is read.
+        var components = new[] { ComponentRegistry.Gateway };
+        var manifest = Manifest(("cc-director-gateway-win-x64.exe", "0.6.6"));
+        var installed = InstalledWithFileVersion("gateway", recordedVersion: "0.6.6", fileVersion: "0.6.6");
+
+        var plan = UpdatePlanner.Plan(components, installed, manifest);
+
+        var item = plan.Items.Single(i => i.ComponentId == "gateway");
+        Assert.Equal(PlanItemKind.UpToDate, item.Kind);
+        Assert.Equal("0.6.6", item.FromVersion);
     }
 }

--- a/tools/cc-director-setup-engine/InstalledComponent.cs
+++ b/tools/cc-director-setup-engine/InstalledComponent.cs
@@ -3,6 +3,12 @@ namespace CcDirector.Setup.Engine;
 /// <summary>The on-disk state of a component: present or not, and at what version.</summary>
 /// <param name="ComponentId">The component this describes.</param>
 /// <param name="Present">True if the component's file exists on disk.</param>
-/// <param name="Version">The installed version, or null if absent / unreadable.</param>
+/// <param name="Version">The installed version, or null if absent / unreadable. This is the
+/// recorded version (from installed.json) when one exists, otherwise the on-disk file stamp.</param>
 /// <param name="Path">The resolved on-disk path that was inspected.</param>
-public sealed record InstalledComponent(string ComponentId, bool Present, string? Version, string Path);
+/// <param name="FileVersion">The actual on-disk file-version stamp of the component's exe (null if
+/// absent / unreadable / not stamped). Kept distinct from <paramref name="Version"/> so the update
+/// planner can cross-check a recorded version against the file the exe really is - and prefer this
+/// real stamp when the recorded version is anomalous (issue #176 test-pollution guard).</param>
+public sealed record InstalledComponent(
+    string ComponentId, bool Present, string? Version, string Path, string? FileVersion = null);

--- a/tools/cc-director-setup-engine/InstalledStateReader.cs
+++ b/tools/cc-director-setup-engine/InstalledStateReader.cs
@@ -33,11 +33,15 @@ public sealed class InstalledStateReader
         if (!_fileExists(path))
             return new InstalledComponent(component.Id, Present: false, Version: null, Path: path);
 
+        // The on-disk file-version stamp is the ground truth for what the exe actually IS. Read it
+        // separately so the planner can cross-check the recorded version against it (issue #176).
+        var fileVersion = _readVersion(path);
+
         // Prefer the version we recorded when we placed it (reliable for every component, incl. tools
         // that carry no file-version stamp); fall back to the on-disk file version for installs that
         // predate the manifest.
-        var version = _installed.Get(component.Id) ?? _readVersion(path);
-        return new InstalledComponent(component.Id, Present: true, Version: version, Path: path);
+        var version = _installed.Get(component.Id) ?? fileVersion;
+        return new InstalledComponent(component.Id, Present: true, Version: version, Path: path, FileVersion: fileVersion);
     }
 
     /// <summary>Inspect a set of components, keyed by component id.</summary>

--- a/tools/cc-director-setup-engine/UpdatePlanner.cs
+++ b/tools/cc-director-setup-engine/UpdatePlanner.cs
@@ -39,6 +39,27 @@ public static class UpdatePlanner
             var fromVersion = state?.Version;
             var present = state?.Present ?? false;
 
+            // Sanity guard (issue #176): a recorded installed version that is strictly NEWER than the
+            // newest released asset is anomalous - it never happens legitimately and is the signature
+            // of test-harness pollution writing a fake version (e.g. 9.9.9) into installed.json. If we
+            // trusted it we would report UpToDate forever and silently skip a real swap. So we log
+            // loudly and prefer the exe's actual on-disk FileVersion for the decision instead. When the
+            // exe carries no readable stamp to fall back on, we refuse to report UpToDate on the basis
+            // of the discarded fake version and re-apply the released build instead.
+            var poisonedInstalledVersion = present
+                && VersionUtil.IsNewer(fromVersion, asset.Version)
+                && !string.Equals(fromVersion, state?.FileVersion, StringComparison.OrdinalIgnoreCase);
+            if (poisonedInstalledVersion)
+            {
+                var fileVersion = state?.FileVersion;
+                EngineLog.Write(
+                    $"[UpdatePlanner] WARNING: recorded installed version '{fromVersion}' for '{c.Id}' is " +
+                    $"NEWER than the newest released version '{asset.Version}'. This is anomalous (likely " +
+                    $"self-update test pollution in installed.json). Ignoring the recorded version and " +
+                    $"using the exe's actual FileVersion '{fileVersion ?? "(unreadable)"}' instead.");
+                fromVersion = fileVersion;
+            }
+
             if (pins.IsPinned(c.Id, asset.Version))
             {
                 items.Add(new PlanItem(c.Id, PlanItemKind.Pinned, asset.Name, fromVersion, asset.Version, asset.Sha256));
@@ -49,6 +70,10 @@ public static class UpdatePlanner
             if (!present)
                 kind = PlanItemKind.Install;
             else if (VersionUtil.IsNewer(asset.Version, fromVersion))
+                kind = PlanItemKind.Update;
+            else if (poisonedInstalledVersion && string.IsNullOrWhiteSpace(fromVersion))
+                // Poisoned record AND no readable exe stamp to trust: never report UpToDate on a
+                // version we just discarded - re-apply the released build to correct the state.
                 kind = PlanItemKind.Update;
             else
                 kind = PlanItemKind.UpToDate;


### PR DESCRIPTION
Closes #176.

## Release Notes
The gateway self-update **test** harness no longer writes fake versions into the production install state, and `UpdatePlanner` no longer trusts an impossibly-high recorded version - eliminating the silent half-install where an install reports success but never swaps the exe.

## Changes
Two independent defenses (as the issue specified):

1. **Test isolation** - `scripts/test-gateway-selfupdate.ps1` takes a `-Root` override and exports `CC_DIRECTOR_ROOT` to a throwaway temp root before launching the self-update helper. `InstallLayout.Default()` already honors `CC_DIRECTOR_ROOT`, so the helper's `InstalledManifest`/`PinStore` writes land in the isolated layout, never production `%LOCALAPPDATA%\cc-director`. The script refuses the production root and hashes `installed.json`/`update-pins.json` before/after, failing if they change.
2. **UpdatePlanner sanity guard** - `InstalledComponent` now carries the exe's real on-disk `FileVersion` separately from the recorded version. When the recorded installed version is strictly newer than the newest release (the pollution signature), `UpdatePlanner` logs a loud WARNING and prefers the exe `FileVersion` rather than reporting UpToDate; with no readable stamp it re-applies the released build.

## How to Test
- `dotnet test tools/cc-director-setup-engine.Tests/CcDirector.Setup.Engine.Tests.csproj` (153/153 green).
- The new `UpdatePlannerTests` cover the poisoned-version guard; `SelfUpdateIsolationTests` proves the `CC_DIRECTOR_ROOT` isolation leaves production setup files byte-identical.

## Expected Result
- Production `installed.json`/`update-pins.json` byte-identical across a test run (AC1).
- A poisoned (installed > release) version logs loudly and does NOT report UpToDate (AC2).
- A normal install/update still completes only when the exe was actually swapped (AC3).

## Before / After
- Before: self-update test wrote `gateway 9.9.9` into production `installed.json`; planner said UpToDate; swap skipped; install falsely reported success.
- After: test writes only to an isolated root; planner detects and rejects the anomalous version, preferring the real exe stamp.

Proof: `docs/cencon/proof/issue-176/report.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)