### PR TITLE
fix(#291): prune SessionOwnerCache on observed session exit (404, not 503)

### DIFF
--- a/docs/cencon/proof/issue-291/qa-report.html
+++ b/docs/cencon/proof/issue-291/qa-report.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #291 - QA Proof - Prune SessionOwnerCache on observed exit</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; margin: 2rem auto; max-width: 980px; color: #1b1f23; line-height: 1.5; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #1d76db; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; color: #1d76db; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #0d1117; color: #c9d1d9; padding: 1rem; border-radius: 6px; overflow-x: auto; font-size: .85rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .7rem; text-align: left; vertical-align: top; font-size: .9rem; }
+  th { background: #f6f8fa; }
+  .pass { color: #1a7f37; font-weight: 600; }
+  .verdict { background: #dafbe1; border: 1px solid #1a7f37; border-radius: 6px; padding: 1rem; margin-top: 2rem; }
+  .meta { color: #57606a; font-size: .85rem; }
+</style>
+</head>
+<body>
+<h1>Issue #291 - QA Proof - Per-session WS proxy returns 404 (not 503) for an EXITED session on a reachable Director</h1>
+<p class="meta">QA Agent (independent verification) &middot; PR #312 &middot; branch <code>issue-291-prune-owner-cache-on-exit</code> &middot; decided approach: option 1 (prune the owner cache on observed exit)</p>
+
+<h2>How QA verified (independent of the Developer's report)</h2>
+<p>
+This is a Gateway-side resolution-logic change with no UI surface, so the correct proof artifact is a
+self-hosted <code>GatewayHost</code> driven over real HTTP &mdash; not a screenshot. QA built the change
+into the test binary itself (full solution build, 0/0) and ran the Gateway test suite, which stands up a
+real <code>GatewayHost</code> + a fake reachable Director, drives the <code>GET /sessions</code> aggregator,
+then hits the actual per-session WS proxy endpoints (<code>/sessions/{sid}/stream</code>) over HTTP and reads
+the status code. QA also code-read the resolution path (<code>SessionWsProxyEndpoints.ProxyAsync</code> -&gt;
+<code>SessionOwnerCache.OwnerOf</code>) and the prune wiring (<code>GatewayEndpoints</code> aggregator -&gt;
+<code>RetainForDirector</code>, sharing the same <code>SessionOwners</code> instance in <code>GatewayHost</code>).
+</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-observed)</th><th>Result</th></tr>
+<tr>
+  <td>1</td>
+  <td>Aggregator (<code>GET /sessions</code>) removes a session from <code>SessionOwnerCache</code> when it is Exited / disappeared on a reachable Director.</td>
+  <td>Cache entry for the gone session is dropped after one aggregation.</td>
+  <td><code>RetainForDirector</code> computes the live (non-Exited) id set per reachable Director and removes any cached entry owned by that Director not in the set. After driving <code>GET /sessions</code>, <code>SessionOwners.OwnerOf("gone")</code> is null.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>WS request for an EXITED session whose owning Director is ONLINE returns 404 (not 503).</td>
+  <td>HTTP 404 on <code>/sessions/gone/stream</code>.</td>
+  <td>Integration test drives the real endpoint over HTTP after aggregation: <code>HttpStatusCode.NotFound</code> (404).</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>Offline-owner session (cached owner, Director unreachable) still returns 503 - #288 must not regress.</td>
+  <td>HTTP 503 on <code>/sessions/offline-owned/stream</code>; cache entry preserved.</td>
+  <td>Reconcile triggered by a DIFFERENT reachable Director never touches the offline owner's entry; real endpoint returns <code>HttpStatusCode.ServiceUnavailable</code> (503).</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>4</td>
+  <td>Unit tests cover both (exited-then-pruned -&gt; 404; offline owner -&gt; 503). Existing <code>SessionWsProxyEndpointsTests</code> still pass.</td>
+  <td>New tests present; SessionWsProxyEndpointsTests green.</td>
+  <td>6 <code>SessionOwnerCacheTests</code> + 2 <code>SessionsAggregationTests</code> (#291) pass. <code>SessionWsProxyEndpointsTests</code> 7/7 pass. Full Gateway project 415/415.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>5</td>
+  <td>Build clean (0/0).</td>
+  <td>0 warnings, 0 errors.</td>
+  <td>Full <code>cc-director.sln</code> build: Build succeeded, 0 Warning(s), 0 Error(s).</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>QA commands &amp; observed output</h2>
+<pre>
+$ dotnet build cc-director.sln -c Debug
+  Build succeeded.  0 Warning(s)  0 Error(s)
+
+$ dotnet test ...Gateway.Tests --filter "SessionsAggregationTests|SessionOwnerCacheTests|SessionWsProxyEndpointsTests"
+  Passed!  - Failed: 0, Passed: 28, Total: 28
+
+  Passed  Aggregator_prunes_owner_cache_for_session_no_longer_live_on_reachable_director_then_ws_proxy_is_404
+  Passed  Aggregator_prune_does_not_touch_a_session_owned_by_a_different_offline_director
+
+$ dotnet test ...Gateway.Tests --filter "SessionWsProxyEndpointsTests"
+  Passed!  - Failed: 0, Passed: 7, Total: 7      (no #288 regression)
+
+$ dotnet test ...Gateway.Tests   (full project)
+  Passed!  - Failed: 0, Passed: 415, Total: 415
+</pre>
+
+<h2>Regression sweep</h2>
+<p>
+Full Gateway test project green (415/415); full solution build clean. The prune is scoped to the
+caller's own reachable Director (<code>RetainForDirector</code> only removes entries whose value equals
+<code>directorId</code>), so no adjacent owner-cache behaviour is affected. CenCon: no security DT rule
+touched; in-memory resolution-logic change only.
+</p>
+
+<div class="verdict">
+<strong>VERIFIED - all acceptance criteria met.</strong> Exited session on a reachable Director -&gt; 404
+(cache pruned); offline owner -&gt; still 503 (#288 preserved); existing SessionWsProxyEndpointsTests pass;
+build clean (0/0). Authorized squash-merge to main inside the implementation-loop.
+</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-291/report.html
+++ b/docs/cencon/proof/issue-291/report.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #291 - Developer Proof - Prune SessionOwnerCache on observed exit</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; margin: 2rem auto; max-width: 980px; color: #1b1f23; line-height: 1.5; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #1d76db; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; color: #1d76db; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #0d1117; color: #c9d1d9; padding: 1rem; border-radius: 6px; overflow-x: auto; font-size: .85rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .7rem; text-align: left; vertical-align: top; font-size: .9rem; }
+  th { background: #f6f8fa; }
+  .pass { color: #1a7f37; font-weight: 600; }
+  .verdict { background: #dafbe1; border: 1px solid #1a7f37; border-radius: 6px; padding: 1rem; margin-top: 2rem; }
+  .meta { color: #57606a; font-size: .85rem; }
+</style>
+</head>
+<body>
+<h1>Issue #291 - Per-session WS proxy: EXITED session returns 503 where 404 is correct</h1>
+<p class="meta">Developer Agent proof &middot; PR #312 &middot; branch <code>issue-291-prune-owner-cache-on-exit</code> &middot; decided approach: option 1 (prune the owner cache on observed exit)</p>
+
+<h2>What was implemented</h2>
+<p>
+After #289 the per-session WebSocket proxy (<code>/sessions/{sid}/stream</code> and <code>/dictate</code>)
+answered <strong>503 "owning director offline"</strong> for any session present in
+<code>SessionOwnerCache</code> &mdash; including a session that had simply <strong>EXITED</strong> while its
+owning Director was still online, because the cache entry persisted. That is a stale 503 where 404 is
+correct.
+</p>
+<p>The fix prunes the owner cache when the fleet aggregator observes a session is no longer live on a reachable Director:</p>
+<ul>
+  <li><code>SessionOwnerCache.Forget(sessionId)</code> &mdash; drop one cached owner.</li>
+  <li><code>SessionOwnerCache.RetainForDirector(directorId, liveSessionIds)</code> &mdash; drop every cached
+      entry that points at <em>directorId</em> but whose session id is no longer in that Director's live set.
+      Only ever called for a Director that just answered (reachable), so entries owned by a <em>different</em>
+      (offline) Director are never touched.</li>
+  <li><code>GET /sessions</code> aggregator &mdash; after a Director responds successfully, computes its live
+      (non-Exited) session ids from the raw returned list and calls <code>RetainForDirector</code>. An exited
+      or disappeared session is reconciled out, so the WS proxy reverts to 404.</li>
+</ul>
+
+<h2>Acceptance criteria &rarr; proof</h2>
+<table>
+  <tr><th>Acceptance criterion</th><th>Expected</th><th>Actual (test)</th><th>Result</th></tr>
+  <tr>
+    <td>Aggregator observes a session as Exited / disappeared on a <strong>reachable</strong> Director &rarr; removed from <code>SessionOwnerCache</code>.</td>
+    <td>Cache entry pruned after one aggregation.</td>
+    <td><code>SessionsAggregationTests.Aggregator_prunes_owner_cache_for_session_no_longer_live_on_reachable_director_then_ws_proxy_is_404</code> asserts <code>OwnerOf("gone")</code> is null after <code>GET /sessions</code>. Unit: <code>SessionOwnerCacheTests.RetainForDirector_drops_sessions_no_longer_live_on_that_director</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>WS request for an <strong>exited</strong> session whose owner is <strong>online</strong> &rarr; <strong>404</strong> (not 503).</td>
+    <td>HTTP 404.</td>
+    <td>Same test: <code>GET sessions/gone/stream</code> &rarr; <code>404 NotFound</code> after the prune.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><strong>Offline-owner</strong> session (cached owner, Director unreachable) still &rarr; <strong>503</strong> (#288 must not regress).</td>
+    <td>HTTP 503.</td>
+    <td><code>SessionsAggregationTests.Aggregator_prune_does_not_touch_a_session_owned_by_a_different_offline_director</code> (&rarr; 503 after a reconcile of a different reachable Director) and the existing <code>SessionWsProxyEndpointsTests.Known_session_with_offline_owner_returns_503_not_404</code>. Unit: <code>SessionOwnerCacheTests.RetainForDirector_never_touches_entries_owned_by_a_different_director</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Unit tests cover (a) exited-then-pruned &rarr; 404; (b) offline owner &rarr; still 503. Existing <code>SessionWsProxyEndpointsTests</code> still pass.</td>
+    <td>Both covered; existing suite green.</td>
+    <td>6 new <code>SessionOwnerCacheTests</code> + 2 new <code>SessionsAggregationTests</code>; all 7 existing <code>SessionWsProxyEndpointsTests</code> pass.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Build clean (0/0).</td>
+    <td>0 warnings, 0 errors.</td>
+    <td><code>dotnet build cc-director.sln</code> &rarr; Build succeeded, 0 Warning(s), 0 Error(s).</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Test run output</h2>
+<pre>
+Passed  SessionOwnerCacheTests.Forget_removes_only_the_named_session
+Passed  SessionOwnerCacheTests.Forget_is_a_noop_for_unknown_or_empty_id
+Passed  SessionOwnerCacheTests.RetainForDirector_drops_sessions_no_longer_live_on_that_director
+Passed  SessionOwnerCacheTests.RetainForDirector_drops_all_when_director_reports_no_live_sessions
+Passed  SessionOwnerCacheTests.RetainForDirector_never_touches_entries_owned_by_a_different_director
+Passed  SessionOwnerCacheTests.RetainForDirector_is_a_noop_for_empty_director_id
+Passed  SessionsAggregationTests.Aggregator_prunes_owner_cache_for_session_no_longer_live_on_reachable_director_then_ws_proxy_is_404
+Passed  SessionsAggregationTests.Aggregator_prune_does_not_touch_a_session_owned_by_a_different_offline_director
+Passed  SessionWsProxyEndpointsTests.Known_session_with_offline_owner_returns_503_not_404(leg: "stream")
+Passed  SessionWsProxyEndpointsTests.Known_session_with_offline_owner_returns_503_not_404(leg: "dictate")
+Passed  SessionWsProxyEndpointsTests.Unknown_session_returns_404_not_the_cockpit_interstitial(stream/dictate)
+Passed  SessionWsProxyEndpointsTests.Unknown_uncached_session_still_returns_404
+Passed  SessionWsProxyEndpointsTests.Per_session_ws_routes_are_explicit_endpoints_not_the_fallback_proxy(stream/dictate)
+...
+Passed!  - Failed: 0, Passed: 28, Skipped: 0, Total: 28  (CcDirector.Gateway.Tests.dll)
+</pre>
+
+<h2>CenCon impact</h2>
+<p>
+<strong>No drift.</strong> This is internal cache hygiene in <code>CcDirector.Gateway</code> (Discovery /
+Api). No architecture container changes; no security rule (DT-xx) is affected. No <code>docs/cencon/</code>
+manifest or security-profile update required.
+</p>
+
+<div class="verdict">
+  <strong>I believe this is finished.</strong> The exited-session-on-online-owner path now returns 404,
+  the offline-owner path still returns 503 (#288 preserved), every acceptance criterion has a passing
+  test, and the full solution builds 0/0.
+</div>
+</body>
+</html>

--- a/src/CcDirector.Gateway.Tests/SessionOwnerCacheTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionOwnerCacheTests.cs
@@ -1,0 +1,92 @@
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #291: the owner cache must be pruned when a session exits on a REACHABLE Director, so the
+/// per-session WS proxy reverts to 404 (session gone) instead of #288's 503 (owner offline). These
+/// unit tests pin <see cref="SessionOwnerCache.Forget"/> and
+/// <see cref="SessionOwnerCache.RetainForDirector"/>, and that an offline owner's entry survives a
+/// reconcile of a DIFFERENT Director (the #288 503 path must not regress).
+/// </summary>
+public sealed class SessionOwnerCacheTests
+{
+    [Fact]
+    public void Forget_removes_only_the_named_session()
+    {
+        var cache = new SessionOwnerCache();
+        cache.Remember("s1", "dir-a");
+        cache.Remember("s2", "dir-a");
+
+        cache.Forget("s1");
+
+        Assert.Null(cache.OwnerOf("s1"));
+        Assert.Equal("dir-a", cache.OwnerOf("s2"));
+    }
+
+    [Fact]
+    public void Forget_is_a_noop_for_unknown_or_empty_id()
+    {
+        var cache = new SessionOwnerCache();
+        cache.Remember("s1", "dir-a");
+
+        cache.Forget("nope");
+        cache.Forget("");
+
+        Assert.Equal("dir-a", cache.OwnerOf("s1"));
+    }
+
+    [Fact]
+    public void RetainForDirector_drops_sessions_no_longer_live_on_that_director()
+    {
+        var cache = new SessionOwnerCache();
+        cache.Remember("live", "dir-a");
+        cache.Remember("exited", "dir-a");
+
+        // dir-a just answered and only reports "live" -> "exited" is gone.
+        cache.RetainForDirector("dir-a", new[] { "live" });
+
+        Assert.Equal("dir-a", cache.OwnerOf("live"));
+        Assert.Null(cache.OwnerOf("exited"));
+    }
+
+    [Fact]
+    public void RetainForDirector_drops_all_when_director_reports_no_live_sessions()
+    {
+        var cache = new SessionOwnerCache();
+        cache.Remember("s1", "dir-a");
+        cache.Remember("s2", "dir-a");
+
+        cache.RetainForDirector("dir-a", Array.Empty<string>());
+
+        Assert.Null(cache.OwnerOf("s1"));
+        Assert.Null(cache.OwnerOf("s2"));
+    }
+
+    [Fact]
+    public void RetainForDirector_never_touches_entries_owned_by_a_different_director()
+    {
+        // The #288 503 case: dir-b is OFFLINE (we never reconcile it). Reconciling the reachable
+        // dir-a must leave dir-b's cached session intact so the WS proxy still answers 503 for it.
+        var cache = new SessionOwnerCache();
+        cache.Remember("offline-owned", "dir-b");
+        cache.Remember("a1", "dir-a");
+
+        cache.RetainForDirector("dir-a", Array.Empty<string>());
+
+        Assert.Null(cache.OwnerOf("a1"));
+        Assert.Equal("dir-b", cache.OwnerOf("offline-owned"));
+    }
+
+    [Fact]
+    public void RetainForDirector_is_a_noop_for_empty_director_id()
+    {
+        var cache = new SessionOwnerCache();
+        cache.Remember("s1", "dir-a");
+
+        cache.RetainForDirector("", Array.Empty<string>());
+
+        Assert.Equal("dir-a", cache.OwnerOf("s1"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
@@ -227,6 +227,47 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
         Assert.Equal("b", s.SessionId);
     }
 
+    // ---------- owner-cache pruning on observed exit (issue #291) ----------
+
+    [Fact]
+    public async Task Aggregator_prunes_owner_cache_for_session_no_longer_live_on_reachable_director_then_ws_proxy_is_404()
+    {
+        // A reachable Director that reports only "live". The cache still holds an OLD session "gone"
+        // attributed to this Director (it was seen on a prior poll, then exited). After the aggregator
+        // observes the Director's current live set, "gone" must be pruned, so the per-session WS proxy
+        // answers 404 (session gone) instead of #288's 503 (owner offline).
+        var fake = await StartFake("M", "u", new[] { Sample("live", "ClaudeCode", "r", "Idle", "green") });
+        await Register(fake);
+        _gateway.SessionOwners.Remember("gone", fake.DirectorId);
+        Assert.Equal(fake.DirectorId, _gateway.SessionOwners.OwnerOf("gone"));
+
+        // Drive one aggregation: the reachable Director reports "live" only -> "gone" is reconciled out.
+        await GetSessions();
+
+        Assert.Null(_gateway.SessionOwners.OwnerOf("gone"));
+
+        // The WS proxy now sees no cached owner and no live owner -> 404, not 503.
+        var resp = await _http.GetAsync("sessions/gone/stream");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Aggregator_prune_does_not_touch_a_session_owned_by_a_different_offline_director()
+    {
+        // #288 must not regress: a session cached against an OFFLINE Director (id never registered, so
+        // unreachable) must survive a reconcile triggered by a DIFFERENT reachable Director, and the
+        // WS proxy must still answer 503 for it.
+        var reachable = await StartFake("M", "u", new[] { Sample("live", "ClaudeCode", "r", "Idle", "green") });
+        await Register(reachable);
+        _gateway.SessionOwners.Remember("offline-owned", "dead-director-id");
+
+        await GetSessions();
+
+        Assert.Equal("dead-director-id", _gateway.SessionOwners.OwnerOf("offline-owned"));
+        var resp = await _http.GetAsync("sessions/offline-owned/stream");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+    }
+
     // ---------- view-url shape ----------
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -356,6 +356,21 @@ internal static class GatewayEndpoints
                 }
                 if (sessions is null) continue;
 
+                // Issue #291: this Director just answered (reachable), so its returned list is the
+                // authoritative live set for it. Prune any session the cache still attributes to this
+                // Director that is no longer live here - it exited or disappeared - so the per-session
+                // WS proxy reverts to 404 instead of #288's 503 "owner offline". Computed from the raw
+                // returned list (before the per-session view filters below) and excluding Exited rows
+                // (a Director may include them when includeExited=true). Owners on OTHER Directors are
+                // untouched, so an offline owner's sessions stay cached -> still 503 (#288 unchanged).
+                var liveIds = new HashSet<string>(
+                    sessions
+                        .Where(x => !string.IsNullOrEmpty(x.SessionId)
+                                 && !string.Equals(x.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase))
+                        .Select(x => x.SessionId),
+                    StringComparer.Ordinal);
+                owners?.RetainForDirector(d.DirectorId, liveIds);
+
                 var baseUrl = DeriveDirectorBaseUrl(ctx, d);
                 var gatewayBaseUrl = DeriveGatewayBaseUrl(ctx);
                 foreach (var s in sessions)

--- a/src/CcDirector.Gateway/Discovery/SessionOwnerCache.cs
+++ b/src/CcDirector.Gateway/Discovery/SessionOwnerCache.cs
@@ -33,4 +33,38 @@ public sealed class SessionOwnerCache
     /// <summary>The Director id last seen owning <paramref name="sessionId"/>, or null if never observed.</summary>
     public string? OwnerOf(string sessionId)
         => !string.IsNullOrEmpty(sessionId) && _ownerBySession.TryGetValue(sessionId, out var id) ? id : null;
+
+    /// <summary>
+    /// Drop the cached owner for <paramref name="sessionId"/> (e.g. the session has exited).
+    /// No-op when the id is empty or not cached.
+    /// </summary>
+    public void Forget(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        _ownerBySession.TryRemove(sessionId, out _);
+    }
+
+    /// <summary>
+    /// Reconcile the cache against a REACHABLE Director's live session set (issue #291): drop every
+    /// cached entry that points at <paramref name="directorId"/> but whose session id is no longer in
+    /// <paramref name="liveSessionIds"/>. A session is considered gone when the Director (which we just
+    /// reached) no longer reports it as live - it exited or disappeared - so the per-session WS proxy
+    /// reverts to 404 instead of the 503 "owner offline" verdict from #288.
+    ///
+    /// Caller contract: only invoke this for a Director that just answered (reachable). Entries owned
+    /// by a DIFFERENT Director are never touched, so an offline owner's sessions stay cached -> still
+    /// 503 (#288 must not regress).
+    /// </summary>
+    public void RetainForDirector(string directorId, IReadOnlyCollection<string> liveSessionIds)
+    {
+        if (string.IsNullOrEmpty(directorId)) return;
+
+        var live = liveSessionIds as HashSet<string> ?? new HashSet<string>(liveSessionIds, StringComparer.Ordinal);
+        foreach (var kvp in _ownerBySession)
+        {
+            if (!string.Equals(kvp.Value, directorId, StringComparison.Ordinal)) continue;
+            if (live.Contains(kvp.Key)) continue;
+            _ownerBySession.TryRemove(new KeyValuePair<string, string>(kvp.Key, kvp.Value));
+        }
+    }
 }


### PR DESCRIPTION
Closes #291.

## Release Notes
The per-session WebSocket proxy now returns **404** for a session that has **exited** while its owning Director is still online, instead of the misleading **503 "owning director offline"** introduced by #289. An offline-owner session (Director unreachable) still returns 503 — #288 behavior is preserved.

## Changes
- `SessionOwnerCache`: add `Forget(sessionId)` and `RetainForDirector(directorId, liveSessionIds)`. The latter prunes every cached entry pointing at a **reachable** Director whose session id is no longer in that Director's live set (it exited or disappeared). Entries owned by a different (offline) Director are never touched.
- `GET /sessions` aggregator: after a Director answers (reachable), reconcile the owner cache against its live (non-Exited) session ids. This is the decided approach — option 1, prune on observed exit.

## How to Test
`dotnet test src/CcDirector.Gateway.Tests` — see `SessionOwnerCacheTests`, and in `SessionsAggregationTests`:
- `Aggregator_prunes_owner_cache_for_session_no_longer_live_on_reachable_director_then_ws_proxy_is_404`
- `Aggregator_prune_does_not_touch_a_session_owned_by_a_different_offline_director`

## Expected Result
Exited session + online owner -> 404. Offline owner -> 503 (unchanged). Build clean (0/0). 28/28 targeted tests pass.

Proof: docs/cencon/proof/issue-291/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)