### PR TITLE
feat(#299): per-session isolation of test slot / build output / Control API port

### DIFF
--- a/.claude/skills/developer-agent/skill.md
+++ b/.claude/skills/developer-agent/skill.md
@@ -135,24 +135,40 @@ If, while planning, you discover the spec is underspecified after all, go back t
    dotnet build cc-director.sln
    ```
    Must show `Build succeeded.` and `0 Error(s)`. Fix and rebuild until clean.
-4. **Proof-based verification** (per CLAUDE.md - non-negotiable):
-   - Build a runnable test binary into **slot 5** (reserved for agent test Directors - never the
-     main build or slots 1-4, CLAUDE.md rule 0b):
-     ```powershell
-     scripts\local-build-avalonia.ps1 -Slot 5
-     ```
-   - Launch it via the **`cc-director-launch` scheduled task** - NEVER spawn cc-director.exe from
-     your own process tree (nested ConPTY kills grandchild claudes; CLAUDE.md rule 0b):
-     ```powershell
-     Start-ScheduledTask -TaskName "cc-director-launch"
-     ```
-     Find its Control API port in the latest
-     `%LOCALAPPDATA%\cc-director\logs\director\director-*.log` (`Kestrel listening on http://0.0.0.0:<port>`).
-   - Drive it via the Control API (loopback REST) and/or screenshots; capture a screenshot showing
-     the expected result. State Expected vs Actual for each acceptance criterion.
+4. **Proof-based verification** (per CLAUDE.md - non-negotiable). Your test Director is
+   **per-session isolated** (issue #299): you allocate your OWN slot (>= 6), build inside your OWN
+   worktree, and launch via your OWN per-slot scheduled task - so a concurrent session on this
+   machine never collides with you on slot, build output, or Control API port. The flow is
+   `scripts/agent-session-isolation.ps1` (ASCII output, machine-readable JSON manifest):
+   ```powershell
+   # 1. Allocate + RESERVE a free slot (>= 6; slot 5 is the legacy/manual default and may be
+   #    in use by a human - the allocator never assumes it is free; slots 1-4 and the main
+   #    build are absolutely off-limits, CLAUDE.md rule 0b):
+   powershell -NoProfile -File scripts\agent-session-isolation.ps1 allocate -Worktree <your-worktree>
+   #    -> prints SLOT=<N> and MANIFEST=<worktree>\local_builds\agent-session-slot<N>.json
+
+   # 2. Build the slot exe FROM YOUR WORKTREE ROOT (bin/obj + local_builds stay inside the
+   #    worktree - no shared-tree publish race, the proven #290 fix):
+   powershell -NoProfile -File <your-worktree>\scripts\local-build-avalonia.ps1 -Slot <N>
+
+   # 3. Launch via YOUR per-slot scheduled task (cc-director<N>-launch; clean svchost
+   #    parentage - NEVER spawn cc-director.exe from your own process tree, rule 0b).
+   #    The Director self-allocates its Control API port; launch resolves the PID by exact
+   #    image path and reads the port from the Director's own log:
+   powershell -NoProfile -File scripts\agent-session-isolation.ps1 launch -Manifest <manifest>
+   #    -> prints PID=<pid> and PORT=<port>
+   ```
+   - Drive it via the Control API (loopback REST, `http://127.0.0.1:<port>`) and/or screenshots;
+     capture a screenshot showing the expected result. State Expected vs Actual for each
+     acceptance criterion.
    - If you cannot prove it, it is not done.
-   - Clean up ONLY your slot-5 test Director afterward (confirm the path is `cc-director5.exe`
-     before `Stop-Process`); never kill the main build or the user's slots 1-4 (CLAUDE.md rule 0).
+   - Tear down with the same script - it stops ONLY processes whose image path is exactly your
+     session's exe, unregisters YOUR task, and never touches the main build, slots 1-5, or any
+     other session's Director (CLAUDE.md rule 0):
+     ```powershell
+     powershell -NoProfile -File scripts\agent-session-isolation.ps1 teardown -Manifest <manifest>
+     # add -RemoveWorktree ONLY for a scratch worktree; your primary worktree stays for QA
+     ```
 
 ### Step 5: Hand off to QA with proof (on the PR branch)
 
@@ -250,10 +266,11 @@ match it (standing rule: write code that reads like the surrounding code).
 
 ---
 
-**Skill Version:** 0.4 (DRAFT - second of the four CenCon agents, cc-director)
+**Skill Version:** 0.5 (DRAFT - second of the four CenCon agents, cc-director)
 **Implements:** Developer Agent role in docs/cencon/DEVELOPMENT_METHOD.md
 **Builds on:** review-code (mandatory)
 **Created:** 2026-06-09
 **Changes in 0.2:** Step 5 now commits the IMPLEMENTATION first (not just proof) and adds a mandatory clean-tree gate (git status --porcelain MUST be empty + branch pushed) before the flow:ready-qa hand-off. Added the no-orphan rule: never stop for any reason leaving uncommitted WIP or an unpushed branch.
 **Changes in 0.3:** Banned `git stash` as a way to fake a clean tree (a prior run hid WIP in a stash, which the human had to clean up). The clean-tree gate now also asserts `git stash list` is empty, and the no-orphan rule forbids leaving a stash behind. Also inlined the branch/PR mechanics and issue-comment format previously cited from the deleted implement-issue/bug-fixer skills.
 **Changes in 0.4 (issue #298):** Under the `implementation-loop` the input issue is now `flow:in-progress` (the loop's issue-level claim), not `flow:ready-dev`. The hand-off (Step 5.6), reject (Step 2), and weak-spec escalation now remove BOTH `flow:in-progress` and `flow:ready-dev` so the loop's claim is always released and never left stuck (the loop's Step 4 claim-release gate enforces this).
+**Changes in 0.5 (issue #299):** Replaced the fixed "slot 5 + cc-director-launch" proof instructions with the per-session isolation flow (`scripts/agent-session-isolation.ps1`): each session allocates its own slot (>= 6, reserved atomically via the per-slot scheduled-task registration), builds inside its own worktree, launches via its own `cc-director<N>-launch` task, and discovers the self-allocated Control API port from the Director log - so two implementation sessions can run concurrently on one machine without colliding on slot, build output, or port.

--- a/.claude/skills/implementation-loop/skill.md
+++ b/.claude/skills/implementation-loop/skill.md
@@ -152,11 +152,22 @@ entry. You do not absorb the sub-agent's working detail.
 
 ### Concurrency rule (why this is safe on one machine)
 
-Phases run strictly one at a time - DEV completes and returns before QA is spawned - and in `--all`
-mode issues are processed one at a time. So two sub-agents never run at once and never collide on
-the slot-5 test Director, the build output, or a Control API port. Never spawn the DEV and QA
-sub-agents in parallel. (Isolated git worktrees would only be needed if we ever parallelized across
-issues, which this loop deliberately does not.)
+Phases within ONE loop run strictly one at a time - DEV completes and returns before QA is spawned -
+and in `--all` mode issues are processed one at a time. Never spawn the DEV and QA sub-agents in
+parallel.
+
+Safety against OTHER loops on the same machine is **per-session isolation** (issue #299), not a
+single reserved slot: every DEV/QA sub-agent works in its own git worktree (own bin/obj + own
+`local_builds`), allocates its own test slot >= 6 via `scripts/agent-session-isolation.ps1` (the
+slot is reserved atomically by registering the per-slot `cc-director<N>-launch` scheduled task -
+a registration race has exactly one winner), and the test Director self-allocates its Control API
+port (discovered from the Director's own log; launches are serialized through a machine-wide mutex
+inside the script so one Director has BOUND its port before the next one probes - the Director's
+PortAllocator picks a port before Kestrel binds it, so unserialized simultaneous startups can pick
+the same port). Two concurrent implementation sessions therefore get different slots, different
+build outputs, and different ports by construction. The issue-level
+claim (Step 0, #298) keeps two loops off the same ISSUE; the session isolation keeps them off the
+same MACHINE resources.
 
 ## Quick Reference
 
@@ -433,13 +444,14 @@ your own ledger has grown large over a very long queue).
   prove, hand to `flow:ready-qa`).
 - `qa-agent` skill - the role a QA sub-agent reads and follows (independent verify,
   pass+squash-merge / fail-bounce).
-- The Control API (loopback REST) + slot-5 test Director via `cc-director-launch` - the shared
-  runtime the sub-agents drive for proof (CLAUDE.md rule 0b). Because phases are sequential, only one
-  sub-agent uses slot 5 at a time.
+- The Control API (loopback REST) + a per-session test Director via
+  `scripts/agent-session-isolation.ps1` (allocate / launch / teardown; CLAUDE.md rule 0b) - each
+  sub-agent allocates its own slot >= 6 in its own worktree, so concurrent loops on one machine
+  never share a test Director, a build output, or a port (issue #299).
 
 ---
 
-**Skill Version:** 0.6 (DRAFT - thin supervisor + fresh sub-agent per phase; realizes issue #259)
+**Skill Version:** 0.7 (DRAFT - thin supervisor + fresh sub-agent per phase; realizes issue #259)
 **Implements:** the Implementation session loop in docs/cencon/DEVELOPMENT_METHOD.md (D2, D5, terminal-signal contract Section 7a)
 **Builds on:** the `Agent` tool (per-phase sub-agents), developer-agent (DEV role), qa-agent (QA role + merge), DEVELOPMENT_METHOD.md
 **Created:** 2026-06-10
@@ -448,3 +460,4 @@ your own ledger has grown large over a very long queue).
 **Changes in 0.4:** Closed the stash loophole. A prior run "parked by cleanup" via `git stash` - the tree looked clean (`git status --porcelain` empty) while WIP sat hidden in the stash list, and the human had to clean it up. Banned `git stash` as a cleanup/park mechanism, extended the Step 0a pre-flight and Step 4 gate to also assert `git stash list` is empty, and updated the Leave-clean guard accordingly.
 **Changes in 0.5 (issue #272):** Added the machine-readable terminal signal. The loop now emits exactly one `IMPL-LOOP-TERMINAL` sentinel block (`signal: done | needs-human | failed`) as its final output on EVERY terminal path - in addition to the human one-line report - so the autonomous queue runner (#270) can detect a finished run without parsing prose. Mapping: MERGED -> `done`; PARKED/ESCALATED/conflict/dirty-build -> `needs-human`; pre-flight stop / abnormal exit -> `failed`. Wired into Step 0a, Step 1, Step 2, Step 3, and Step 4; contract recorded in DEVELOPMENT_METHOD.md Section 7a.
 **Changes in 0.6 (issue #298):** Added the issue-level CLAIM (duplicate-prevention). Step 0 now select-THEN-claims: a stale-claim sweep (Step 0.0) reclaims crashed `flow:in-progress` claims older than 60 min, selection reads `flow:ready-dev` only, and the chosen issue is claimed `flow:ready-dev` -> `flow:in-progress` with a verify-after-claim re-read (oldest `CLAIM` comment wins; the loser backs off). Step 4 adds a claim-release gate (no `flow:in-progress` may linger at a terminal stop). New guards: Issue-claim, Stale-claim, Claim-release. Closes the #199 duplicate-PR race. Mechanism + honest residual-window note in DEVELOPMENT_METHOD.md Section 4a / D6.
+**Changes in 0.7 (issue #299):** Rewrote the concurrency rule: same-machine safety now comes from per-session isolation (own worktree, own slot >= 6 reserved via the per-slot scheduled-task registration in `scripts/agent-session-isolation.ps1`, self-allocated Control API port) instead of the old "single slot-5 so nothing can collide" claim. Two loops on one machine are safe on resources (#299) and on issues (#298).

--- a/.claude/skills/qa-agent/skill.md
+++ b/.claude/skills/qa-agent/skill.md
@@ -101,20 +101,27 @@ proof target, the linked PR, and the Developer Agent's "How to Test" and proof (
 
 ### Step 2: Verify independently, one criterion at a time
 
-Build and run the change yourself - do not reuse the developer's binary or screenshots:
+Build and run the change yourself - do not reuse the developer's binary or screenshots. Your test
+Director is **per-session isolated** (issue #299): you allocate your OWN slot (>= 6), build in your
+OWN checkout of the PR branch, and launch via your OWN per-slot scheduled task - so you never
+collide with a concurrent session's slot, build output, or Control API port:
 
-1. Build a runnable test binary into **slot 5** (reserved for agent test Directors; never the main
-   build or slots 1-4, CLAUDE.md rule 0b):
+1. Check out / pull the PR branch first so you are testing the actual change, then allocate and
+   reserve a free slot with `scripts/agent-session-isolation.ps1` (slot 5 is the legacy/manual
+   default and may be in use by a human - never assume it is free; slots 1-4 and the main build
+   are absolutely off-limits, CLAUDE.md rule 0b):
    ```powershell
-   scripts\local-build-avalonia.ps1 -Slot 5
+   powershell -NoProfile -File scripts\agent-session-isolation.ps1 allocate -Worktree <your-checkout>
+   #  -> prints SLOT=<N> and MANIFEST=<checkout>\local_builds\agent-session-slot<N>.json
+   powershell -NoProfile -File scripts\local-build-avalonia.ps1 -Slot <N>   # from the checkout root
    ```
-   (Check out / pull the PR branch first so you are testing the actual change.)
-2. Launch it via the **`cc-director-launch` scheduled task** - NEVER spawn cc-director.exe from your
-   own process tree (CLAUDE.md rule 0b):
+2. Launch via YOUR per-slot scheduled task (`cc-director<N>-launch`) - NEVER spawn cc-director.exe
+   from your own process tree (CLAUDE.md rule 0b). The Director self-allocates its Control API
+   port; the script resolves the PID by exact image path and reads the port from the Director log:
    ```powershell
-   Start-ScheduledTask -TaskName "cc-director-launch"
+   powershell -NoProfile -File scripts\agent-session-isolation.ps1 launch -Manifest <manifest>
+   #  -> prints PID=<pid> and PORT=<port>; Control API at http://127.0.0.1:<port>
    ```
-   Find its Control API port in the latest `%LOCALAPPDATA%\cc-director\logs\director\director-*.log`.
 3. For each acceptance criterion: reproduce it yourself (drive the UI / call the Control API /
    inspect logs), capture a screenshot of the actual result, and READ the screenshot - judge
    Expected vs Actual. (Standing rule: read every screenshot; a blank render is a STOP-and-diagnose,
@@ -125,8 +132,12 @@ Also run the regression and method checks:
 - CenCon not violated: no blocking security rule (DT-01..DT-NN) broken, and if architecture/security
   changed the `docs/cencon/` docs were updated (use the `review-code` lens for this).
 
-Clean up ONLY your slot-5 test Director afterward (confirm the path is `cc-director5.exe` before
-`Stop-Process`); never kill the main build or the user's slots 1-4 (CLAUDE.md rule 0).
+Tear down with the same script - it stops ONLY processes whose image path is exactly your session's
+exe, unregisters YOUR `cc-director<N>-launch` task, and never touches the main build, slots 1-5, or
+any other session's Director (CLAUDE.md rule 0):
+```powershell
+powershell -NoProfile -File scripts\agent-session-isolation.ps1 teardown -Manifest <manifest>
+```
 
 ### Step 3a: PASS path (and merge - the authorized exception)
 
@@ -253,10 +264,11 @@ item, or you `/clear` between items. (Mechanism is OPEN DECISION D2 in DEVELOPME
 
 ---
 
-**Skill Version:** 0.4 (DRAFT - third of the four CenCon agents, cc-director)
+**Skill Version:** 0.5 (DRAFT - third of the four CenCon agents, cc-director)
 **Implements:** QA Agent role in docs/cencon/DEVELOPMENT_METHOD.md
 **Builds on:** playwright-cli / ui-test (UI verification), review-code (method lens), Control API (proof)
 **Created:** 2026-06-09
 **Changes in 0.2:** Added the no-orphans law (law 6), the PASS cleanup gate (branch deleted + clean tree confirmed), the FAIL clean-tree check, and Step 3c PARK-on-needs-human (the one sanctioned open PR). QA is the cleanup gate: PASS merges-and-deletes, FAIL leaves committed code on the PR branch, needs-human parks - never an orphan or loose WIP.
 **Changes in 0.3:** Closed the stash loophole. A prior run "parked by cleanup" via `git stash`, which left `git status --porcelain` empty (gate passed) while hiding WIP in the stash list - a mess the human had to clean up. Added the LEAVE ZERO MESS banner at the top, banned `git stash` as a cleanup/park mechanism everywhere (law 6 + the do-NOT list), and extended all three cleanup gates (PASS/FAIL/PARK) to also assert `git stash list` is empty and (on PASS) that local `main` == `origin/main`.
 **Changes in 0.4 (issue #298):** Noted the new `flow:in-progress` claim label (issue-level duplicate-prevention). QA never normally sees it - the Developer hand-off releases the claim to `flow:ready-qa` before QA picks the item up - so QA's own transitions are unchanged; a stuck `flow:in-progress` on a QA item is a Developer defect to bounce.
+**Changes in 0.5 (issue #299):** Replaced the fixed "slot 5 + cc-director-launch" verification instructions with the per-session isolation flow (`scripts/agent-session-isolation.ps1`): QA allocates its own slot (>= 6), builds the PR branch in its own checkout, launches via its own `cc-director<N>-launch` task with the Control API port discovered from the Director log, and tears down only its own exact-path process - safe to run concurrently with another session on the same machine.

--- a/docs/cencon/DEVELOPMENT_METHOD.md
+++ b/docs/cencon/DEVELOPMENT_METHOD.md
@@ -330,14 +330,23 @@ Before labeling `flow:ready-qa`, the Developer Agent must have ALL of:
 1. Code implemented against every acceptance criterion in the issue.
 2. `review-code` skill invoked and `docs/CodingStyle.md` + `docs/VisualStyle.md` honored before/while
    writing code (per CLAUDE.md). UI changes must comply with `docs/VisualStyle.md`.
-3. Solution builds clean: `dotnet build cc-director.sln`. For a runnable test binary, build a
-   dev slot with `scripts\local-build-avalonia.ps1 -Slot 5` (slot 5+ is reserved for agent test
-   Directors; never use the main build or slots 1-4 - CLAUDE.md rule 0b).
+3. Solution builds clean: `dotnet build cc-director.sln`, run inside the session's OWN git
+   worktree (per-session build isolation, issue #299). For a runnable test binary, allocate a
+   per-session dev slot with `scripts\agent-session-isolation.ps1 allocate` (slots are taken
+   dynamically from 6 upward; slot 5 is the legacy/manual default and may be in use by a human -
+   never assume it is free; never use the main build or slots 1-4 - CLAUDE.md rule 0b), then build
+   it with `scripts\local-build-avalonia.ps1 -Slot <N>` from the worktree root so bin/obj and
+   local_builds stay inside the worktree.
 4. **Proof-based verification** performed (per CLAUDE.md): the change exercised in the running app.
-   Launch the test Director via the `cc-director-launch` scheduled task (NEVER spawn cc-director.exe
-   from inside the agent's own process tree - CLAUDE.md rule 0b), drive it via the Control API
-   (loopback REST) and/or screenshots, and capture a screenshot showing the expected result. State
-   Expected vs Actual for each acceptance criterion.
+   Launch the test Director via the session's OWN per-slot scheduled task -
+   `scripts\agent-session-isolation.ps1 launch` registers and starts `cc-director<N>-launch`
+   (NEVER spawn cc-director.exe from inside the agent's own process tree - CLAUDE.md rule 0b) and
+   resolves the Director's self-allocated Control API port from its log. Drive it via the Control
+   API (loopback REST) and/or screenshots, and capture a screenshot showing the expected result.
+   State Expected vs Actual for each acceptance criterion. Afterward,
+   `scripts\agent-session-isolation.ps1 teardown` stops only the session's own exact-path process
+   and unregisters the session's task - concurrent sessions on one machine never collide on slot,
+   build output, or port.
 5. **CenCon not drifted:** if the change altered architecture or security posture, the relevant
    `docs/cencon/` files are updated in the same change, and no blocking security rule
    (DT-01..DT-NN in `security_profile.yaml`) is violated.
@@ -390,8 +399,9 @@ drive many items without the supervisor's context filling up. The handoff betwee
 relies on the method's existing durable state (the `flow:*` label, issue comments, and the PR
 branch), not on shared memory - so a fresh QA sub-agent is also a more honestly independent verifier.
 The 3-strike `flow:qa-failed` guard and the weak-spec `flow:needs-human` escalation live in the
-supervisor; one phase runs at a time (DEV then QA), so sub-agents never collide on the slot-5 test
-Director.
+supervisor; one phase runs at a time (DEV then QA) within a loop, and across loops each session's
+test Director is isolated per-session (own worktree, own slot >= 6, own self-allocated Control API
+port - issue #299), so sub-agents never collide on a test Director.
 
 ---
 

--- a/docs/cencon/proof/issue-299/fleet-after.txt
+++ b/docs/cencon/proof/issue-299/fleet-after.txt
@@ -1,0 +1,17 @@
+LIVE FLEET SNAPSHOT (AFTER) - 2026-06-11T08:42:27Z
+
+Processes (cc-director* / gateway / cockpit):
+  PID=21128   NAME=cc-director                START=2026-06-10 13:34:24 PATH=C:\Users\soren\AppData\Local\cc-director\app\cc-director.exe
+  PID=42928   NAME=cc-director-gateway        START=2026-06-10 21:32:30 PATH=C:\Users\soren\AppData\Local\cc-director\gateway\cc-director-gateway.exe
+  PID=65232   NAME=cc-director-cockpit        START=2026-06-10 21:32:32 PATH=C:\Users\soren\AppData\Local\cc-director\cockpit\cc-director-cockpit.exe
+
+Listeners on protected ports 7878 (Gateway) / 7470 (Cockpit) / 7887 (Director):
+  PORT=7470    OWNINGPID=65232   OWNER=cc-director-cockpit
+  PORT=7878    OWNINGPID=42928   OWNER=cc-director-gateway
+  PORT=7887    OWNINGPID=8640    OWNER=tailscaled
+  PORT=7887    OWNINGPID=21128   OWNER=cc-director
+
+Registered cc-director*-launch scheduled tasks:
+  TASK=cc-director2-launch               STATE=Ready
+  TASK=cc-director-gateway-launch        STATE=Ready
+  TASK=cc-director-launch                STATE=Ready

--- a/docs/cencon/proof/issue-299/fleet-before.txt
+++ b/docs/cencon/proof/issue-299/fleet-before.txt
@@ -1,0 +1,17 @@
+LIVE FLEET SNAPSHOT (BEFORE) - 2026-06-11T08:33:56Z
+
+Processes (cc-director* / gateway / cockpit):
+  PID=21128   NAME=cc-director                START=2026-06-10 13:34:24 PATH=C:\Users\soren\AppData\Local\cc-director\app\cc-director.exe
+  PID=42928   NAME=cc-director-gateway        START=2026-06-10 21:32:30 PATH=C:\Users\soren\AppData\Local\cc-director\gateway\cc-director-gateway.exe
+  PID=65232   NAME=cc-director-cockpit        START=2026-06-10 21:32:32 PATH=C:\Users\soren\AppData\Local\cc-director\cockpit\cc-director-cockpit.exe
+
+Listeners on protected ports 7878 (Gateway) / 7470 (Cockpit) / 7887 (Director):
+  PORT=7470    OWNINGPID=65232   OWNER=cc-director-cockpit
+  PORT=7878    OWNINGPID=42928   OWNER=cc-director-gateway
+  PORT=7887    OWNINGPID=8640    OWNER=tailscaled
+  PORT=7887    OWNINGPID=21128   OWNER=cc-director
+
+Registered cc-director*-launch scheduled tasks:
+  TASK=cc-director2-launch               STATE=Ready
+  TASK=cc-director-gateway-launch        STATE=Ready
+  TASK=cc-director-launch                STATE=Ready

--- a/docs/cencon/proof/issue-299/proof-runner.ps1
+++ b/docs/cencon/proof/issue-299/proof-runner.ps1
@@ -1,0 +1,106 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Proof harness for issue #299 - one isolated agent-session run.
+
+.DESCRIPTION
+    Executes the full per-session isolation lifecycle once, with timestamped
+    logging, so two instances of this script started concurrently prove the
+    acceptance criteria of issue #299:
+
+      allocate (distinct slot >= 6) -> build the slot exe inside the run's own
+      worktree -> launch via the run's own per-slot scheduled task -> probe the
+      run's own Control API port (GET /healthz) -> hold (overlap window) ->
+      teardown (process gone, task unregistered, scratch worktree removed).
+
+    ASCII output only. Windows PowerShell 5.1.
+#>
+param(
+    [Parameter(Mandatory = $true)] [string]$RunName,
+    [Parameter(Mandatory = $true)] [string]$Worktree,
+    [Parameter(Mandatory = $true)] [string]$IsolationScript,
+    [Parameter(Mandatory = $true)] [string]$LogPath,
+    [int]$HoldSeconds = 20,
+    [switch]$RemoveWorktree
+)
+
+$ErrorActionPreference = "Stop"
+
+function Log([string]$Message) {
+    $line = "{0} [{1}] {2}" -f (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ"), $RunName, $Message
+    Add-Content -Path $LogPath -Value $line -Encoding Ascii
+    Write-Host $line
+}
+
+function LogLines($Lines, [string]$Prefix) {
+    foreach ($l in @($Lines)) { Log ("{0}{1}" -f $Prefix, $l) }
+}
+
+Log "RUN START worktree=$Worktree pid_of_runner=$PID"
+
+# ---- 1. allocate ----
+Log "STEP allocate"
+$allocOut = & powershell.exe -NoProfile -File $IsolationScript allocate -Worktree $Worktree
+LogLines $allocOut "  "
+if ($LASTEXITCODE -ne 0) { Log "FAIL allocate exit=$LASTEXITCODE"; exit 1 }
+$slotLine = @($allocOut) | Where-Object { $_ -match "SLOT=(\d+)" } | Select-Object -First 1
+$slot = [int]([regex]::Match($slotLine, "SLOT=(\d+)").Groups[1].Value)
+$manifestLine = @($allocOut) | Where-Object { $_ -match "MANIFEST=" } | Select-Object -First 1
+$manifest = ($manifestLine -split "MANIFEST=", 2)[1].Trim()
+Log "ALLOCATED slot=$slot manifest=$manifest"
+
+# ---- 2. build the slot exe inside THIS run's worktree ----
+Log "STEP build (local-build-avalonia.ps1 -Slot $slot, cwd=$Worktree)"
+Push-Location $Worktree
+$buildOut = & powershell.exe -NoProfile -File (Join-Path $Worktree "scripts\local-build-avalonia.ps1") -Slot $slot
+$buildExit = $LASTEXITCODE
+Pop-Location
+LogLines $buildOut "  "
+if ($buildExit -ne 0) { Log "FAIL build exit=$buildExit"; exit 1 }
+Log "BUILD OK slot=$slot"
+
+# ---- 3. launch via the run's own per-slot scheduled task ----
+Log "STEP launch"
+$launchOut = & powershell.exe -NoProfile -File $IsolationScript launch -Manifest $manifest
+LogLines $launchOut "  "
+if ($LASTEXITCODE -ne 0) { Log "FAIL launch exit=$LASTEXITCODE"; exit 1 }
+$pidLine = @($launchOut) | Where-Object { $_ -match "PID=(\d+)" } | Select-Object -First 1
+$dirPid = [int]([regex]::Match($pidLine, "PID=(\d+)").Groups[1].Value)
+$portLine = @($launchOut) | Where-Object { $_ -match "PORT=(\d+)" } | Select-Object -First 1
+$port = [int]([regex]::Match($portLine, "PORT=(\d+)").Groups[1].Value)
+Log "LAUNCHED pid=$dirPid port=$port"
+
+# ---- 4. probe the run's own Control API port ----
+Log "STEP probe GET http://127.0.0.1:$port/healthz"
+$resp = Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -UseBasicParsing -TimeoutSec 15
+Log "PROBE status=$($resp.StatusCode) body=$($resp.Content)"
+if ($resp.StatusCode -ne 200) { Log "FAIL probe"; exit 1 }
+
+# ---- 5. hold so the two concurrent runs overlap with both Directors alive ----
+Log "STEP hold ${HoldSeconds}s (overlap window, Director alive on port $port)"
+Start-Sleep -Seconds $HoldSeconds
+
+# ---- 6. teardown ----
+Log "STEP teardown (RemoveWorktree=$($RemoveWorktree.IsPresent))"
+if ($RemoveWorktree) {
+    $tdOut = & powershell.exe -NoProfile -File $IsolationScript teardown -Manifest $manifest -RemoveWorktree
+} else {
+    $tdOut = & powershell.exe -NoProfile -File $IsolationScript teardown -Manifest $manifest
+}
+LogLines $tdOut "  "
+if ($LASTEXITCODE -ne 0) { Log "FAIL teardown exit=$LASTEXITCODE"; exit 1 }
+
+# ---- 7. post-teardown asserts ----
+$gone = Get-Process -Id $dirPid -ErrorAction SilentlyContinue
+if ($null -ne $gone) { Log "FAIL process pid=$dirPid still alive after teardown"; exit 1 }
+Log "ASSERT process pid=$dirPid gone"
+$task = Get-ScheduledTask -TaskName "cc-director$slot-launch" -ErrorAction SilentlyContinue
+if ($null -ne $task) { Log "FAIL scheduled task cc-director$slot-launch still registered"; exit 1 }
+Log "ASSERT scheduled task cc-director$slot-launch unregistered"
+if ($RemoveWorktree) {
+    if (Test-Path $Worktree) { Log "FAIL worktree $Worktree still exists"; exit 1 }
+    Log "ASSERT worktree $Worktree removed"
+}
+
+Log "RUN END slot=$slot port=$port pid=$dirPid result=SUCCESS"
+exit 0

--- a/docs/cencon/proof/issue-299/qa-fleet-after.txt
+++ b/docs/cencon/proof/issue-299/qa-fleet-after.txt
@@ -1,0 +1,22 @@
+=== FLEET AFTER (QA) 2026-06-11T04:51:43.6568655-04:00 ===
+--- cc-director processes ---
+
+   Id ProcessName         Path                                                                    
+   -- -----------         ----                                                                    
+21128 cc-director         C:\Users\soren\AppData\Local\cc-director\app\cc-director.exe            
+65232 cc-director-cockpit C:\Users\soren\AppData\Local\cc-director\cockpit\cc-director-cockpit.exe
+42928 cc-director-gateway C:\Users\soren\AppData\Local\cc-director\gateway\cc-director-gateway.exe
+--- listeners 7878/7470/7887 ---
+
+LocalAddress              LocalPort OwningProcess
+------------              --------- -------------
+127.0.0.1                      7470         65232
+0.0.0.0                        7878         42928
+fd7a:115c:a1e0::c038:501a      7887          8640
+--- cc-director*-launch scheduled tasks ---
+
+TaskName                   State
+--------                   -----
+cc-director-gateway-launch Ready
+cc-director-launch         Ready
+cc-director2-launch        Ready

--- a/docs/cencon/proof/issue-299/qa-fleet-before.txt
+++ b/docs/cencon/proof/issue-299/qa-fleet-before.txt
@@ -1,0 +1,22 @@
+=== FLEET BEFORE (QA) 2026-06-11T04:48:49.8262774-04:00 ===
+--- cc-director processes ---
+
+   Id ProcessName         Path                                                                    
+   -- -----------         ----                                                                    
+21128 cc-director         C:\Users\soren\AppData\Local\cc-director\app\cc-director.exe            
+65232 cc-director-cockpit C:\Users\soren\AppData\Local\cc-director\cockpit\cc-director-cockpit.exe
+42928 cc-director-gateway C:\Users\soren\AppData\Local\cc-director\gateway\cc-director-gateway.exe
+--- listeners 7878/7470/7887 ---
+
+LocalAddress              LocalPort OwningProcess
+------------              --------- -------------
+127.0.0.1                      7470         65232
+0.0.0.0                        7878         42928
+fd7a:115c:a1e0::c038:501a      7887          8640
+--- cc-director*-launch scheduled tasks ---
+
+TaskName                   State
+--------                   -----
+cc-director-gateway-launch Ready
+cc-director-launch         Ready
+cc-director2-launch        Ready

--- a/docs/cencon/proof/issue-299/qa-report.html
+++ b/docs/cencon/proof/issue-299/qa-report.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Report - Issue #299 - Per-session isolation of test slot / build output / Control API port</title>
+<style>
+  body { font-family: Georgia, 'Times New Roman', serif; margin: 0; background: #f4f2ee; color: #1a1a1a; }
+  .page { max-width: 1100px; margin: 0 auto; padding: 32px 40px 64px; background: #ffffff; box-shadow: 0 0 24px rgba(0,0,0,0.08); }
+  h1 { font-size: 26px; border-bottom: 3px solid #1f3a5f; padding-bottom: 10px; }
+  h2 { font-size: 20px; color: #1f3a5f; margin-top: 36px; border-bottom: 1px solid #c9c4ba; padding-bottom: 6px; }
+  h3 { font-size: 16px; color: #333; }
+  .meta { color: #555; font-size: 14px; }
+  .verdict { display: inline-block; padding: 6px 18px; font-weight: bold; font-size: 18px; border-radius: 4px; }
+  .pass { background: #1e6e3c; color: #fff; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; font-size: 14px; }
+  th, td { border: 1px solid #c9c4ba; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #1f3a5f; color: #fff; }
+  tr:nth-child(even) td { background: #f7f5f1; }
+  .ok { color: #1e6e3c; font-weight: bold; }
+  .note { background: #fdf6e3; border-left: 4px solid #b58900; padding: 10px 14px; font-size: 14px; margin: 12px 0; }
+  pre { background: #1d1f21; color: #c5c8c6; padding: 14px; font-size: 12px; overflow-x: auto; border-radius: 4px; line-height: 1.45; }
+  code { font-family: Consolas, monospace; }
+  .small { font-size: 12px; color: #666; }
+</style>
+</head>
+<body>
+<div class="page">
+
+<h1>QA Verification Report - Issue #299</h1>
+<p class="meta">
+  <strong>Issue:</strong> [Loop] Same-machine parallelism: isolate test slot / build output / Control API port per implementation session<br>
+  <strong>PR:</strong> #318 (branch <code>issue-299-session-isolation</code>, head <code>4950077</code>)<br>
+  <strong>QA Agent:</strong> independent verification in detached QA worktree <code>D:\ReposFred\wt-issue-299-qa</code> (own checkout of the PR head - the Developer's binary, worktree, and logs were NOT reused)<br>
+  <strong>Machine:</strong> SOREN_NORTH &nbsp; <strong>Date:</strong> 2026-06-11 (08:48-08:52 UTC)
+</p>
+<p><span class="verdict pass">VERIFIED - ALL ACCEPTANCE CRITERIA MET</span></p>
+
+<h2>1. Contract verified against</h2>
+<p>The issue body plus the binding "Product sharpening (Definition of Ready)" comment: two CONCURRENT
+isolated harness runs on one machine, distinct slots (&gt;= 6) / worktrees / ports, zero contention
+errors, live fleet untouched, and skills + DEVELOPMENT_METHOD.md updated per Deliverables 2-4.
+The Developer's committed proof (run-a.log / run-b.log / report.html) was treated as context only;
+the result below was reproduced from scratch by the QA Agent with its own worktrees, runs, and logs.</p>
+
+<h2>2. Independent reproduction - two concurrent isolated runs</h2>
+<p>Both runs were started simultaneously (same second) by one launcher, each driving
+<code>docs/cencon/proof/issue-299/proof-runner.ps1</code> with the NEW
+<code>scripts/agent-session-isolation.ps1</code> taken from the QA checkout of the PR head:</p>
+<table>
+  <tr><th></th><th>QA-RUN-A</th><th>QA-RUN-B</th></tr>
+  <tr><td>Worktree</td><td><code>D:\ReposFred\wt-issue-299-qa</code> (PR head 4950077)</td><td><code>D:\ReposFred\wt-issue-299-qa-b</code> (PR head 4950077, scratch)</td></tr>
+  <tr><td>Start (UTC)</td><td>08:50:01.812Z</td><td>08:50:01.815Z</td></tr>
+  <tr><td>Slot allocated</td><td><strong>6</strong></td><td><strong>7</strong> (lost the slot-6 registration race to Run A and moved on - the designed atomic arbiter, observed live)</td></tr>
+  <tr><td>Slot exe built</td><td><code>...\wt-issue-299-qa\local_builds\cc-director6.exe</code> (0 warn / 0 err)</td><td><code>...\wt-issue-299-qa-b\local_builds\cc-director7.exe</code> (0 warn / 0 err)</td></tr>
+  <tr><td>Launch task</td><td><code>cc-director6-launch</code> (Start-ScheduledTask only, rule 0b)</td><td><code>cc-director7-launch</code> (Start-ScheduledTask only, rule 0b)</td></tr>
+  <tr><td>Director PID</td><td>44152</td><td>48208</td></tr>
+  <tr><td>Control API port (self-allocated, read from Director log)</td><td><strong>7894</strong></td><td><strong>7895</strong></td></tr>
+  <tr><td>Probe GET /healthz</td><td class="ok">200, status ok, v0.6.22</td><td class="ok">200, status ok, v0.6.22</td></tr>
+  <tr><td>Director alive window (UTC)</td><td>08:50:20.8 - 08:50:42.5</td><td>08:50:24.5 - 08:50:46.8</td></tr>
+  <tr><td>Teardown asserts</td><td class="ok">process gone + task unregistered</td><td class="ok">process gone + task unregistered + worktree removed</td></tr>
+  <tr><td>Result</td><td class="ok">SUCCESS (exit 0)</td><td class="ok">SUCCESS (exit 0)</td></tr>
+</table>
+<p><strong>Concurrency proof:</strong> both Directors were alive simultaneously from 08:50:24.5Z to
+08:50:42.5Z (about 18 seconds of overlap), with interleaved timestamps across both logs from the
+first allocate (08:50:01Z) to the last teardown assert (08:50:47Z).
+Full logs: <code>qa-run-a.log</code>, <code>qa-run-b.log</code> (this directory).</p>
+
+<h2>3. Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion (DoR proof bar)</th><th>Expected</th><th>Actual</th><th>Verdict</th></tr>
+  <tr>
+    <td>AC1</td>
+    <td>Run A and Run B execute CONCURRENTLY, each: allocate distinct slot (&gt;= 6) -&gt; own worktree -&gt; build -&gt; launch via its own per-slot scheduled task -&gt; probe its own Control API port -&gt; teardown (process gone, task unregistered, worktree removed).</td>
+    <td>Overlapping timestamps; full lifecycle completes in both runs.</td>
+    <td>Started 3 ms apart; Directors concurrently alive 18 s; every lifecycle step logged and asserted in both runs; both exit 0. Slots 6 and 7, both &gt;= 6.</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>AC2</td>
+    <td>The two runs got DIFFERENT slots, DIFFERENT worktrees, DIFFERENT ports; neither log contains port-in-use, file-locked (bin/obj), or slot-collision errors.</td>
+    <td>Distinct resources, zero contention errors.</td>
+    <td>Slots 6 vs 7; worktrees wt-issue-299-qa vs wt-issue-299-qa-b; ports 7894 vs 7895. Grep of both logs: no "address already in use", no file-lock, no collision. (Run B's "slot 6 lost in registration race ... trying next" is the designed atomic arbitration message, not a contention error - exactly one winner, the loser moved on cleanly.)</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>AC3</td>
+    <td>The LIVE fleet (Gateway :7878, Cockpit :7470, Directors incl. :7887, main build + slots 1-4) is untouched: same PIDs before/after, no binds attempted on 7878/7470/7887.</td>
+    <td>Byte-identical fleet table.</td>
+    <td>Before and after (qa-fleet-before.txt / qa-fleet-after.txt): cc-director 21128, cc-director-cockpit 65232 (:7470), cc-director-gateway 42928 (:7878), :7887 owner 8640 - all identical. Test Directors used 7894/7895 only. Gateway /healthz returned 200 after the runs. Scheduled tasks unchanged (cc-director-launch / 2-launch / gateway-launch only).</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>AC4</td>
+    <td>Skills + DEVELOPMENT_METHOD.md updated per Deliverables 2-4.</td>
+    <td>developer-agent + qa-agent skills replace the fixed "slot 5 + cc-director-launch" flow; implementation-loop concurrency rule rewritten to per-session isolation; DEVELOPMENT_METHOD.md Section 6 DoD items 3/4 updated.</td>
+    <td>Diff vs origin/main reviewed file by file: developer-agent v0.5 (Step 4 = allocate/build/launch/teardown flow), qa-agent v0.5 (Step 2 = same flow), implementation-loop v0.7 (concurrency rule now per-session isolation + #298 issue claim), DEVELOPMENT_METHOD.md Section 6 DoD 3/4 rewritten. All consistent with the script's actual behavior.</td>
+    <td class="ok">PASS</td>
+  </tr>
+</table>
+
+<h2>4. Static checks</h2>
+<table>
+  <tr><th>Check</th><th>Result</th></tr>
+  <tr><td>ASCII-only: <code>scripts/agent-session-isolation.ps1</code>, <code>proof-runner.ps1</code>, all 3 skill files, DEVELOPMENT_METHOD.md</td><td class="ok">PASS - byte scan found zero bytes &gt; 127 in all six files</td></tr>
+  <tr><td>PowerShell 5.1 compatibility</td><td class="ok">PASS - <code>#Requires -Version 5.1</code>; parser reports 0 errors; no pipeline-chain operators, no ternary/null-coalescing, manifest written with <code>-Encoding ascii</code></td></tr>
+  <tr><td>Allocator can never pick slot 5 or below</td><td class="ok">PASS - hard floor <code>$script:SlotFloor = 6</code>; <code>-MinSlot</code> below 6 is rejected; <code>Read-Manifest</code> refuses any manifest with slot &lt; 6 (so launch/teardown cannot be pointed at slots 1-5 either); allocation loop starts at MinSlot</td></tr>
+  <tr><td>Teardown safety</td><td class="ok">PASS - stops ONLY processes whose image path exactly equals the manifest exe (case-insensitive full-path match); foreign-path processes are logged and left alone; only the session's own task is unregistered</td></tr>
+  <tr><td>Failed-launch orphan handling</td><td class="ok">PASS - port-not-found path stops the just-launched, path-confirmed PID before failing; launch refuses to stack a second instance on a running slot</td></tr>
+  <tr><td>Launch mutex (PortAllocator probe-before-bind race)</td><td class="ok">PASS - machine-wide named mutex held from task start until the port is read from the Director log; AbandonedMutexException handled; released in finally</td></tr>
+  <tr><td>review-code lens (obvious defects)</td><td class="ok">PASS - no fallback programming (every failure exits 1 with an actionable message), explicit error paths, no secrets, no PII</td></tr>
+  <tr><td>CenCon drift</td><td class="ok">PASS - zero changes under <code>src/</code> or <code>tools/</code> (script/skill/doc-only change); no architecture or security-posture change, so no <code>docs/cencon/</code> yaml updates required; DEVELOPMENT_METHOD.md updated as the deliverable demanded</td></tr>
+</table>
+
+<h2>5. Regression</h2>
+<table>
+  <tr><th>Check</th><th>Result</th></tr>
+  <tr><td><code>dotnet build cc-director.sln</code> in the QA worktree (PR head)</td><td class="ok">PASS - Build succeeded, 0 Warning(s), 0 Error(s)</td></tr>
+  <tr><td>PR CI run 27335037967</td><td>One failed test: <code>RecordingIngestServiceTests.Worker_TranscribesQueuedRecording_EndToEnd</code>. Judged PRE-EXISTING FLAKE, not a regression: this PR contains zero C# changes (scripts/skills/docs only), and main's own CI is red on 5 of the last 8 push runs including already-merged #290/#291/#298. Local build of the PR head is clean.</td></tr>
+</table>
+
+<h2>6. Key evidence excerpts</h2>
+<h3>Run B losing the slot-6 race (the atomic arbiter, observed live)</h3>
+<pre>2026-06-11T08:50:02.951Z [QA-RUN-A]   [allocate] SLOT=6
+2026-06-11T08:50:03.477Z [QA-RUN-B]   [allocate] slot 6 lost in registration race (Cannot create a file when that file already exists.
+2026-06-11T08:50:03.479Z [QA-RUN-B]   [allocate] SLOT=7</pre>
+<h3>Both Directors alive concurrently on distinct self-allocated ports</h3>
+<pre>2026-06-11T08:50:20.894Z [QA-RUN-A] PROBE status=200 body={"status":"ok",...,"directorId":"3a2323c7-...","machineName":"SOREN_NORTH"}  (port 7894, pid 44152)
+2026-06-11T08:50:24.642Z [QA-RUN-B] PROBE status=200 body={"status":"ok",...,"directorId":"e69218bc-...","machineName":"SOREN_NORTH"}  (port 7895, pid 48208)
+2026-06-11T08:50:42.540Z [QA-RUN-A]   [teardown] stopping PID 44152 (...\wt-issue-299-qa\local_builds\cc-director6.exe)
+2026-06-11T08:50:46.833Z [QA-RUN-B]   [teardown] stopping PID 48208 (...\wt-issue-299-qa-b\local_builds\cc-director7.exe)</pre>
+<h3>Fleet unchanged (qa-fleet-before.txt == qa-fleet-after.txt on PIDs/ports/tasks)</h3>
+<pre>21128 cc-director          C:\Users\soren\AppData\Local\cc-director\app\cc-director.exe
+65232 cc-director-cockpit  C:\Users\soren\AppData\Local\cc-director\cockpit\cc-director-cockpit.exe   (:7470)
+42928 cc-director-gateway  C:\Users\soren\AppData\Local\cc-director\gateway\cc-director-gateway.exe   (:7878)
+tasks: cc-director-gateway-launch, cc-director-launch, cc-director2-launch   (no slot&gt;=6 task remains)</pre>
+
+<h2>7. Verdict</h2>
+<p><span class="verdict pass">VERIFIED - all acceptance criteria met. PASS.</span></p>
+<p class="small">Evidence files in this directory: qa-run-a.log, qa-run-b.log, qa-fleet-before.txt, qa-fleet-after.txt.
+Developer evidence (context only): run-a.log, run-b.log, report.html, proof-runner.ps1, fleet-before.txt, fleet-after.txt.</p>
+
+</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-299/qa-run-a.log
+++ b/docs/cencon/proof/issue-299/qa-run-a.log
@@ -1,0 +1,53 @@
+2026-06-11T08:50:01.812Z [QA-RUN-A] RUN START worktree=D:\ReposFred\wt-issue-299-qa pid_of_runner=12048
+2026-06-11T08:50:01.845Z [QA-RUN-A] STEP allocate
+2026-06-11T08:50:02.951Z [QA-RUN-A]   [allocate] SLOT=6
+2026-06-11T08:50:02.951Z [QA-RUN-A]   [allocate] TASK=cc-director6-launch
+2026-06-11T08:50:02.952Z [QA-RUN-A]   [allocate] MANIFEST=D:\ReposFred\wt-issue-299-qa\local_builds\agent-session-slot6.json
+2026-06-11T08:50:02.953Z [QA-RUN-A]   [allocate] Next: build the slot exe from the worktree root:
+2026-06-11T08:50:02.954Z [QA-RUN-A]   [allocate]   powershell -NoProfile -File "D:\ReposFred\wt-issue-299-qa\scripts\local-build-avalonia.ps1" -Slot 6
+2026-06-11T08:50:02.969Z [QA-RUN-A] ALLOCATED slot=6 manifest=D:\ReposFred\wt-issue-299-qa\local_builds\agent-session-slot6.json
+2026-06-11T08:50:03.060Z [QA-RUN-A] STEP build (local-build-avalonia.ps1 -Slot 6, cwd=D:\ReposFred\wt-issue-299-qa)
+2026-06-11T08:50:17.126Z [QA-RUN-A]   Building CC Director Avalonia v0.6.22 (Release)
+2026-06-11T08:50:17.126Z [QA-RUN-A]     Mode: Framework-dependent (.NET 10 runtime required)
+2026-06-11T08:50:17.128Z [QA-RUN-A]     Cleaning previous build...
+2026-06-11T08:50:17.129Z [QA-RUN-A]     Pre-building Core dependency...
+2026-06-11T08:50:17.130Z [QA-RUN-A]   
+2026-06-11T08:50:17.131Z [QA-RUN-A]   Build succeeded.
+2026-06-11T08:50:17.131Z [QA-RUN-A]       0 Warning(s)
+2026-06-11T08:50:17.133Z [QA-RUN-A]       0 Error(s)
+2026-06-11T08:50:17.134Z [QA-RUN-A]   
+2026-06-11T08:50:17.135Z [QA-RUN-A]   Time Elapsed 00:00:02.31
+2026-06-11T08:50:17.136Z [QA-RUN-A]     Building Avalonia project...
+2026-06-11T08:50:17.137Z [QA-RUN-A]   
+2026-06-11T08:50:17.137Z [QA-RUN-A]   Build succeeded.
+2026-06-11T08:50:17.138Z [QA-RUN-A]       0 Warning(s)
+2026-06-11T08:50:17.139Z [QA-RUN-A]       0 Error(s)
+2026-06-11T08:50:17.140Z [QA-RUN-A]   
+2026-06-11T08:50:17.140Z [QA-RUN-A]   Time Elapsed 00:00:08.09
+2026-06-11T08:50:17.141Z [QA-RUN-A]     Publishing...
+2026-06-11T08:50:17.142Z [QA-RUN-A]   MSBuild version 18.6.4+96856fd72 for .NET
+2026-06-11T08:50:17.143Z [QA-RUN-A]     CcDirector.Avalonia -> D:\ReposFred\wt-issue-299-qa\src\CcDirector.Avalonia\bin\Release\net10.0\win-x64\publish\
+2026-06-11T08:50:17.144Z [QA-RUN-A]   
+2026-06-11T08:50:17.145Z [QA-RUN-A]   Build complete: 38.3 MB
+2026-06-11T08:50:17.146Z [QA-RUN-A]     D:\ReposFred\wt-issue-299-qa\local_builds\cc-director6.exe
+2026-06-11T08:50:17.147Z [QA-RUN-A] BUILD OK slot=6
+2026-06-11T08:50:17.148Z [QA-RUN-A] STEP launch
+2026-06-11T08:50:20.814Z [QA-RUN-A]   [launch] starting scheduled task cc-director6-launch
+2026-06-11T08:50:20.818Z [QA-RUN-A]   [launch] PID=44152
+2026-06-11T08:50:20.820Z [QA-RUN-A]   [launch] PORT=7894
+2026-06-11T08:50:20.821Z [QA-RUN-A]   [launch] LOG=C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-06-11-44152.log
+2026-06-11T08:50:20.837Z [QA-RUN-A]   [launch] Control API: http://127.0.0.1:7894 (probe GET /healthz)
+2026-06-11T08:50:20.839Z [QA-RUN-A]   [launch] MANIFEST=D:\ReposFred\wt-issue-299-qa\local_builds\agent-session-slot6.json (updated)
+2026-06-11T08:50:20.843Z [QA-RUN-A] LAUNCHED pid=44152 port=7894
+2026-06-11T08:50:20.844Z [QA-RUN-A] STEP probe GET http://127.0.0.1:7894/healthz
+2026-06-11T08:50:20.894Z [QA-RUN-A] PROBE status=200 body={"status":"ok","directors":1,"sessions":0,"version":"0.6.22","serverTime":"2026-06-11T08:50:20.8734137Z","directorId":"3a2323c7-61b7-4734-95f2-fb54a2b39f01","machineName":"SOREN_NORTH"}
+2026-06-11T08:50:20.896Z [QA-RUN-A] STEP hold 20s (overlap window, Director alive on port 7894)
+2026-06-11T08:50:40.913Z [QA-RUN-A] STEP teardown (RemoveWorktree=False)
+2026-06-11T08:50:42.540Z [QA-RUN-A]   [teardown] stopping PID 44152 (D:\ReposFred\wt-issue-299-qa\local_builds\cc-director6.exe)
+2026-06-11T08:50:42.542Z [QA-RUN-A]   [teardown] PID 44152 exited
+2026-06-11T08:50:42.543Z [QA-RUN-A]   [teardown] unregistered scheduled task cc-director6-launch
+2026-06-11T08:50:42.544Z [QA-RUN-A]   [teardown] deleted manifest D:\ReposFred\wt-issue-299-qa\local_builds\agent-session-slot6.json
+2026-06-11T08:50:42.546Z [QA-RUN-A]   [teardown] done (slot 6 is free again)
+2026-06-11T08:50:42.549Z [QA-RUN-A] ASSERT process pid=44152 gone
+2026-06-11T08:50:43.183Z [QA-RUN-A] ASSERT scheduled task cc-director6-launch unregistered
+2026-06-11T08:50:43.185Z [QA-RUN-A] RUN END slot=6 port=7894 pid=44152 result=SUCCESS

--- a/docs/cencon/proof/issue-299/qa-run-b.log
+++ b/docs/cencon/proof/issue-299/qa-run-b.log
@@ -1,0 +1,56 @@
+2026-06-11T08:50:01.815Z [QA-RUN-B] RUN START worktree=D:\ReposFred\wt-issue-299-qa-b pid_of_runner=56620
+2026-06-11T08:50:01.846Z [QA-RUN-B] STEP allocate
+2026-06-11T08:50:03.477Z [QA-RUN-B]   [allocate] slot 6 lost in registration race (Cannot create a file when that file already exists.
+2026-06-11T08:50:03.478Z [QA-RUN-B]   ); trying next
+2026-06-11T08:50:03.479Z [QA-RUN-B]   [allocate] SLOT=7
+2026-06-11T08:50:03.479Z [QA-RUN-B]   [allocate] TASK=cc-director7-launch
+2026-06-11T08:50:03.480Z [QA-RUN-B]   [allocate] MANIFEST=D:\ReposFred\wt-issue-299-qa-b\local_builds\agent-session-slot7.json
+2026-06-11T08:50:03.481Z [QA-RUN-B]   [allocate] Next: build the slot exe from the worktree root:
+2026-06-11T08:50:03.482Z [QA-RUN-B]   [allocate]   powershell -NoProfile -File "D:\ReposFred\wt-issue-299-qa-b\scripts\local-build-avalonia.ps1" -Slot 7
+2026-06-11T08:50:03.538Z [QA-RUN-B] ALLOCATED slot=7 manifest=D:\ReposFred\wt-issue-299-qa-b\local_builds\agent-session-slot7.json
+2026-06-11T08:50:03.539Z [QA-RUN-B] STEP build (local-build-avalonia.ps1 -Slot 7, cwd=D:\ReposFred\wt-issue-299-qa-b)
+2026-06-11T08:50:17.468Z [QA-RUN-B]   Building CC Director Avalonia v0.6.22 (Release)
+2026-06-11T08:50:17.470Z [QA-RUN-B]     Mode: Framework-dependent (.NET 10 runtime required)
+2026-06-11T08:50:17.471Z [QA-RUN-B]     Cleaning previous build...
+2026-06-11T08:50:17.471Z [QA-RUN-B]     Pre-building Core dependency...
+2026-06-11T08:50:17.472Z [QA-RUN-B]   
+2026-06-11T08:50:17.474Z [QA-RUN-B]   Build succeeded.
+2026-06-11T08:50:17.474Z [QA-RUN-B]       0 Warning(s)
+2026-06-11T08:50:17.476Z [QA-RUN-B]       0 Error(s)
+2026-06-11T08:50:17.477Z [QA-RUN-B]   
+2026-06-11T08:50:17.478Z [QA-RUN-B]   Time Elapsed 00:00:02.57
+2026-06-11T08:50:17.479Z [QA-RUN-B]     Building Avalonia project...
+2026-06-11T08:50:17.480Z [QA-RUN-B]   
+2026-06-11T08:50:17.481Z [QA-RUN-B]   Build succeeded.
+2026-06-11T08:50:17.482Z [QA-RUN-B]       0 Warning(s)
+2026-06-11T08:50:17.482Z [QA-RUN-B]       0 Error(s)
+2026-06-11T08:50:17.484Z [QA-RUN-B]   
+2026-06-11T08:50:17.485Z [QA-RUN-B]   Time Elapsed 00:00:08.06
+2026-06-11T08:50:17.486Z [QA-RUN-B]     Publishing...
+2026-06-11T08:50:17.487Z [QA-RUN-B]   MSBuild version 18.6.4+96856fd72 for .NET
+2026-06-11T08:50:17.488Z [QA-RUN-B]     CcDirector.Avalonia -> D:\ReposFred\wt-issue-299-qa-b\src\CcDirector.Avalonia\bin\Release\net10.0\win-x64\publish\
+2026-06-11T08:50:17.489Z [QA-RUN-B]   
+2026-06-11T08:50:17.490Z [QA-RUN-B]   Build complete: 38.3 MB
+2026-06-11T08:50:17.490Z [QA-RUN-B]     D:\ReposFred\wt-issue-299-qa-b\local_builds\cc-director7.exe
+2026-06-11T08:50:17.491Z [QA-RUN-B] BUILD OK slot=7
+2026-06-11T08:50:17.492Z [QA-RUN-B] STEP launch
+2026-06-11T08:50:24.558Z [QA-RUN-B]   [launch] starting scheduled task cc-director7-launch
+2026-06-11T08:50:24.562Z [QA-RUN-B]   [launch] PID=48208
+2026-06-11T08:50:24.577Z [QA-RUN-B]   [launch] PORT=7895
+2026-06-11T08:50:24.579Z [QA-RUN-B]   [launch] LOG=C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-06-11-48208.log
+2026-06-11T08:50:24.581Z [QA-RUN-B]   [launch] Control API: http://127.0.0.1:7895 (probe GET /healthz)
+2026-06-11T08:50:24.582Z [QA-RUN-B]   [launch] MANIFEST=D:\ReposFred\wt-issue-299-qa-b\local_builds\agent-session-slot7.json (updated)
+2026-06-11T08:50:24.587Z [QA-RUN-B] LAUNCHED pid=48208 port=7895
+2026-06-11T08:50:24.589Z [QA-RUN-B] STEP probe GET http://127.0.0.1:7895/healthz
+2026-06-11T08:50:24.642Z [QA-RUN-B] PROBE status=200 body={"status":"ok","directors":1,"sessions":0,"version":"0.6.22","serverTime":"2026-06-11T08:50:24.6256761Z","directorId":"e69218bc-5420-4c0c-a8f7-4f56f53a703b","machineName":"SOREN_NORTH"}
+2026-06-11T08:50:24.691Z [QA-RUN-B] STEP hold 20s (overlap window, Director alive on port 7895)
+2026-06-11T08:50:44.708Z [QA-RUN-B] STEP teardown (RemoveWorktree=True)
+2026-06-11T08:50:46.833Z [QA-RUN-B]   [teardown] stopping PID 48208 (D:\ReposFred\wt-issue-299-qa-b\local_builds\cc-director7.exe)
+2026-06-11T08:50:46.836Z [QA-RUN-B]   [teardown] PID 48208 exited
+2026-06-11T08:50:46.836Z [QA-RUN-B]   [teardown] unregistered scheduled task cc-director7-launch
+2026-06-11T08:50:46.837Z [QA-RUN-B]   [teardown] removed worktree D:\ReposFred\wt-issue-299-qa-b
+2026-06-11T08:50:46.838Z [QA-RUN-B]   [teardown] done (slot 7 is free again)
+2026-06-11T08:50:46.842Z [QA-RUN-B] ASSERT process pid=48208 gone
+2026-06-11T08:50:47.465Z [QA-RUN-B] ASSERT scheduled task cc-director7-launch unregistered
+2026-06-11T08:50:47.468Z [QA-RUN-B] ASSERT worktree D:\ReposFred\wt-issue-299-qa-b removed
+2026-06-11T08:50:47.469Z [QA-RUN-B] RUN END slot=7 port=7895 pid=48208 result=SUCCESS

--- a/docs/cencon/proof/issue-299/report.html
+++ b/docs/cencon/proof/issue-299/report.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof - Issue #299: Per-session isolation of test slot / build output / Control API port</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 1200px; color: #1c2733; line-height: 1.45; }
+  h1 { font-size: 1.5rem; border-bottom: 3px solid #0b6e4f; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #cfd8dc; padding-bottom: .25rem; }
+  h3 { font-size: 1rem; margin-top: 1.2rem; }
+  table { border-collapse: collapse; width: 100%; margin: .75rem 0; font-size: .9rem; }
+  th, td { border: 1px solid #b0bec5; padding: .4rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #eceff1; }
+  pre { background: #10151a; color: #d7e3ea; padding: .8rem; overflow-x: auto; font-size: .72rem; line-height: 1.35; border-radius: 4px; }
+  .pass { color: #0b6e4f; font-weight: 600; }
+  .note { background: #fff8e1; border-left: 4px solid #f9a825; padding: .6rem .8rem; margin: .8rem 0; font-size: .9rem; }
+  .logs { display: grid; grid-template-columns: 1fr 1fr; gap: .8rem; }
+  @media (max-width: 1000px) { .logs { grid-template-columns: 1fr; } }
+  .meta { color: #546e7a; font-size: .85rem; }
+  code { background: #eceff1; padding: 0 .25rem; border-radius: 3px; }
+</style>
+</head>
+<body>
+
+<h1>Proof - Issue #299: Per-session isolation of test slot / build output / Control API port</h1>
+<p class="meta">
+  Repo: thefrederiksen/cc-director | Branch: issue-299-session-isolation | Machine: SOREN_NORTH |
+  Date: 2026-06-11 | Proof run: 08:41:07Z - 08:42:00Z (concurrent Run A + Run B)
+</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li><code>scripts/agent-session-isolation.ps1</code> (NEW) - allocate / launch / teardown lifecycle for a per-session
+      test Director. Allocation probes BOTH running <code>cc-director&lt;N&gt;.exe</code> processes AND registered
+      <code>cc-director&lt;N&gt;-launch</code> scheduled tasks from slot 6 upward; the reservation IS the task
+      registration without <code>-Force</code>, so a race between two sessions has exactly one winner. Launch is
+      scheduled-task-only (rule 0b), resolves the PID by exact image path, and reads the self-allocated Control API
+      port from the Director's own log. Teardown stops ONLY exact-image-path matches, unregisters only the session's
+      own task, and optionally removes a scratch worktree. Slots 1-5 and the main build are protected by a hard floor
+      (any manifest or -MinSlot below 6 is refused). ASCII-only output.</li>
+  <li><code>.claude/skills/developer-agent/skill.md</code> v0.5 - Step 4 proof flow replaced with the per-session
+      isolation flow (Deliverable 2).</li>
+  <li><code>.claude/skills/qa-agent/skill.md</code> v0.5 - Step 2 verification flow replaced with the per-session
+      isolation flow (Deliverable 2).</li>
+  <li><code>.claude/skills/implementation-loop/skill.md</code> v0.7 - concurrency-rule section rewritten: same-machine
+      safety now comes from per-session isolation, not a single reserved slot-5 (Deliverable 3).</li>
+  <li><code>docs/cencon/DEVELOPMENT_METHOD.md</code> - Section 6 DoD items 3 and 4 updated to the per-session flow
+      (Deliverable 4).</li>
+</ul>
+
+<div class="note">
+<strong>Defect discovered and mitigated during proof:</strong> the Director's own <code>PortAllocator</code>
+(src/CcDirector.ControlApi/PortAllocator.cs) probes for a free port and persists its pick, but Kestrel binds the port
+LATER. Two Directors starting in the same instant both picked port 7892 (observed live at 08:34:53.9Z in
+director-2026-06-11-62912.log and director-2026-06-11-22216.log); the loser logged
+"Control API failed to start: Failed to bind to address http://127.0.0.1:7892: address already in use" and ran with no
+Control API. Director C# changes are explicitly OUT OF SCOPE per the sharpened spec, so the in-scope mitigation is in
+the harness: <code>launch</code> holds a machine-wide named mutex (<code>Global\cc-director-agent-session-launch</code>)
+from task start until the port is read from the log (i.e. Kestrel has bound it), so one Director has BOUND its port
+before the next one probes. A failed launch now also stops its own (exact-path-confirmed) process so it never leaks an
+orphan. A Director-side fix to PortAllocator (bind-and-hold allocation) is recommended as a follow-up issue.
+</div>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th style="width:38%">Criterion (sharpened spec)</th><th>Expected</th><th>Actual</th><th style="width:6%">Verdict</th></tr>
+  <tr>
+    <td>Run A and Run B execute CONCURRENTLY, each: allocate distinct slot (&gt;= 6) -&gt; own worktree off origin/main -&gt;
+        build -&gt; launch via its own per-slot scheduled task -&gt; probe its own Control API port (GET succeeds) -&gt;
+        teardown (process gone, task unregistered, worktree removed).</td>
+    <td>Both run logs show the full lifecycle with overlapping timestamps and SUCCESS.</td>
+    <td>Both runners started 08:41:07Z. Builds overlapped (A: 08:41:08-08:41:20, B: 08:41:09-08:41:21). Both Directors
+        were alive simultaneously 08:41:26.7Z - 08:41:54.2Z (A held port 7893 from 08:41:24 to 08:41:54 teardown; B held
+        port 7891 from 08:41:26 to 08:41:56 teardown). Both probes returned HTTP 200 from /healthz. Both logs end with
+        ASSERT process gone + ASSERT task unregistered + ASSERT worktree removed + RUN END result=SUCCESS.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>The two runs got DIFFERENT slots, DIFFERENT worktrees, DIFFERENT ports; neither run's log contains port-in-use,
+        file-locked (bin/obj), or slot-collision errors.</td>
+    <td>Distinct slot/worktree/port per run; clean logs.</td>
+    <td>A: slot 6, D:\ReposFred\wt-issue-299-proof-a, port 7893. B: slot 7, D:\ReposFred\wt-issue-299-proof-b, port 7891.
+        B lost the slot-6 registration race and moved to slot 7 - that race message IS the atomic reservation working,
+        not a collision (exactly one session can hold a slot's task). Zero port-in-use, file-locked, or build errors in
+        either log (both builds: "Build succeeded. 0 Error(s)").</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>The LIVE fleet (Gateway :7878, Cockpit :7470, the user's Directors incl. :7887, main build + slots 1-4) is
+        untouched: same PIDs before and after, no binds attempted on 7878/7470/7887.</td>
+    <td>Identical fleet snapshot before and after.</td>
+    <td>Gateway PID 42928 (:7878), Cockpit PID 65232 (:7470), main Director PID 21128 (:7887, alongside tailscaled 8640)
+        identical in both snapshots, same start times. Scheduled tasks cc-director-launch / cc-director2-launch /
+        cc-director-gateway-launch present and Ready in both. Test ports used were 7891/7893 - never 7878/7470/7887.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Skills + DEVELOPMENT_METHOD.md updated as in Deliverables 2-4.</td>
+    <td>developer-agent, qa-agent, implementation-loop skills and DEVELOPMENT_METHOD.md Section 6 reference the
+        per-session flow.</td>
+    <td>All four files updated on the branch (see "What was implemented"); version footers bumped with #299 changelog
+        entries. Full solution builds clean inside the worktree: "Build succeeded. 0 Error(s)".</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Slot / port / worktree table</h2>
+<table>
+  <tr><th>Run</th><th>Slot</th><th>Worktree</th><th>Exe</th><th>Director PID</th><th>Control API port</th><th>Probe</th><th>Result</th></tr>
+  <tr><td>RUN-A</td><td>6</td><td>D:\ReposFred\wt-issue-299-proof-a</td><td>local_builds\cc-director6.exe</td><td>40124</td><td>7893</td><td>200 /healthz</td><td>SUCCESS, fully torn down</td></tr>
+  <tr><td>RUN-B</td><td>7</td><td>D:\ReposFred\wt-issue-299-proof-b</td><td>local_builds\cc-director7.exe</td><td>35984</td><td>7891</td><td>200 /healthz</td><td>SUCCESS, fully torn down</td></tr>
+</table>
+
+<h2>Concurrency timeline (from the run logs)</h2>
+<table>
+  <tr><th>Time (UTC)</th><th>RUN-A (slot 6)</th><th>RUN-B (slot 7)</th></tr>
+  <tr><td>08:41:07.5</td><td>RUN START</td><td>RUN START</td></tr>
+  <tr><td>08:41:08-09</td><td>allocate wins slot 6</td><td>loses slot-6 registration race, takes slot 7</td></tr>
+  <tr><td>08:41:09-21</td><td>build cc-director6.exe (concurrent)</td><td>build cc-director7.exe (concurrent)</td></tr>
+  <tr><td>08:41:24</td><td>launched PID 40124, port 7893, probe 200</td><td>(launch waiting on machine-wide mutex)</td></tr>
+  <tr><td>08:41:26</td><td>holding (Director alive)</td><td>launched PID 35984, port 7891, probe 200</td></tr>
+  <tr><td>08:41:26 - 08:41:54</td><td colspan="2"><strong>BOTH Directors alive concurrently on different ports</strong></td></tr>
+  <tr><td>08:41:54-57</td><td>teardown + all asserts, SUCCESS</td><td>holding</td></tr>
+  <tr><td>08:41:56-60</td><td>-</td><td>teardown + all asserts, SUCCESS</td></tr>
+</table>
+
+<h2>Live-fleet PID table (before / after)</h2>
+<table>
+  <tr><th>Component</th><th>Before (08:33:56Z)</th><th>After (08:42:27Z)</th><th>Verdict</th></tr>
+  <tr><td>Main Director (cc-director.exe)</td><td>PID 21128, started 2026-06-10 13:34:24</td><td>PID 21128, started 2026-06-10 13:34:24</td><td class="pass">UNCHANGED</td></tr>
+  <tr><td>Gateway (cc-director-gateway.exe)</td><td>PID 42928, started 2026-06-10 21:32:30</td><td>PID 42928, started 2026-06-10 21:32:30</td><td class="pass">UNCHANGED</td></tr>
+  <tr><td>Cockpit (cc-director-cockpit.exe)</td><td>PID 65232, started 2026-06-10 21:32:32</td><td>PID 65232, started 2026-06-10 21:32:32</td><td class="pass">UNCHANGED</td></tr>
+  <tr><td>Port 7878 listener</td><td>42928 (gateway)</td><td>42928 (gateway)</td><td class="pass">UNCHANGED</td></tr>
+  <tr><td>Port 7470 listener</td><td>65232 (cockpit)</td><td>65232 (cockpit)</td><td class="pass">UNCHANGED</td></tr>
+  <tr><td>Port 7887 listeners</td><td>8640 (tailscaled) + 21128 (cc-director)</td><td>8640 (tailscaled) + 21128 (cc-director)</td><td class="pass">UNCHANGED</td></tr>
+  <tr><td>Scheduled tasks</td><td>cc-director-launch, cc-director2-launch, cc-director-gateway-launch (Ready)</td><td>same three, Ready; zero cc-director&lt;6+&gt;-launch leftovers</td><td class="pass">UNCHANGED</td></tr>
+</table>
+
+<h2>Run logs (complete, end to end)</h2>
+<div class="logs">
+<div>
+<h3>run-a.log</h3>
+<pre>2026-06-11T08:41:07.499Z [RUN-A] RUN START worktree=D:\ReposFred\wt-issue-299-proof-a pid_of_runner=60100
+2026-06-11T08:41:07.531Z [RUN-A] STEP allocate
+2026-06-11T08:41:08.583Z [RUN-A]   [allocate] SLOT=6
+2026-06-11T08:41:08.583Z [RUN-A]   [allocate] TASK=cc-director6-launch
+2026-06-11T08:41:08.585Z [RUN-A]   [allocate] MANIFEST=D:\ReposFred\wt-issue-299-proof-a\local_builds\agent-session-slot6.json
+2026-06-11T08:41:08.586Z [RUN-A]   [allocate] Next: build the slot exe from the worktree root:
+2026-06-11T08:41:08.586Z [RUN-A]   [allocate]   powershell -NoProfile -File "D:\ReposFred\wt-issue-299-proof-a\scripts\local-build-avalonia.ps1" -Slot 6
+2026-06-11T08:41:08.601Z [RUN-A] ALLOCATED slot=6 manifest=D:\ReposFred\wt-issue-299-proof-a\local_builds\agent-session-slot6.json
+2026-06-11T08:41:08.668Z [RUN-A] STEP build (local-build-avalonia.ps1 -Slot 6, cwd=D:\ReposFred\wt-issue-299-proof-a)
+2026-06-11T08:41:20.765Z [RUN-A]   Building CC Director Avalonia v0.6.22 (Release)
+2026-06-11T08:41:20.767Z [RUN-A]     Mode: Framework-dependent (.NET 10 runtime required)
+2026-06-11T08:41:20.769Z [RUN-A]     Cleaning previous build...
+2026-06-11T08:41:20.770Z [RUN-A]     Pre-building Core dependency...
+2026-06-11T08:41:20.771Z [RUN-A]   
+2026-06-11T08:41:20.773Z [RUN-A]   Build succeeded.
+2026-06-11T08:41:20.774Z [RUN-A]       0 Warning(s)
+2026-06-11T08:41:20.775Z [RUN-A]       0 Error(s)
+2026-06-11T08:41:20.777Z [RUN-A]   
+2026-06-11T08:41:20.778Z [RUN-A]   Time Elapsed 00:00:02.12
+2026-06-11T08:41:20.779Z [RUN-A]     Building Avalonia project...
+2026-06-11T08:41:20.781Z [RUN-A]   
+2026-06-11T08:41:20.782Z [RUN-A]   Build succeeded.
+2026-06-11T08:41:20.783Z [RUN-A]       0 Warning(s)
+2026-06-11T08:41:20.785Z [RUN-A]       0 Error(s)
+2026-06-11T08:41:20.786Z [RUN-A]   
+2026-06-11T08:41:20.787Z [RUN-A]   Time Elapsed 00:00:07.63
+2026-06-11T08:41:20.789Z [RUN-A]     Publishing...
+2026-06-11T08:41:20.790Z [RUN-A]   MSBuild version 18.6.4+96856fd72 for .NET
+2026-06-11T08:41:20.793Z [RUN-A]     CcDirector.Avalonia -&gt; D:\ReposFred\wt-issue-299-proof-a\src\CcDirector.Avalonia\bin\Release\net10.0\win-x64\publish\
+2026-06-11T08:41:20.795Z [RUN-A]   
+2026-06-11T08:41:20.796Z [RUN-A]   Build complete: 38.3 MB
+2026-06-11T08:41:20.797Z [RUN-A]     D:\ReposFred\wt-issue-299-proof-a\local_builds\cc-director6.exe
+2026-06-11T08:41:20.799Z [RUN-A] BUILD OK slot=6
+2026-06-11T08:41:20.800Z [RUN-A] STEP launch
+2026-06-11T08:41:23.998Z [RUN-A]   [launch] starting scheduled task cc-director6-launch
+2026-06-11T08:41:24.000Z [RUN-A]   [launch] PID=40124
+2026-06-11T08:41:24.001Z [RUN-A]   [launch] PORT=7893
+2026-06-11T08:41:24.002Z [RUN-A]   [launch] LOG=C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-06-11-40124.log
+2026-06-11T08:41:24.003Z [RUN-A]   [launch] Control API: http://127.0.0.1:7893 (probe GET /healthz)
+2026-06-11T08:41:24.015Z [RUN-A]   [launch] MANIFEST=D:\ReposFred\wt-issue-299-proof-a\local_builds\agent-session-slot6.json (updated)
+2026-06-11T08:41:24.019Z [RUN-A] LAUNCHED pid=40124 port=7893
+2026-06-11T08:41:24.020Z [RUN-A] STEP probe GET http://127.0.0.1:7893/healthz
+2026-06-11T08:41:24.236Z [RUN-A] PROBE status=200 body={"status":"ok","directors":1,"sessions":0,"version":"0.6.22","serverTime":"2026-06-11T08:41:24.2200517Z","directorId":"e4937462-b7d3-4b0b-976a-db8a2f5550d1","machineName":"SOREN_NORTH"}
+2026-06-11T08:41:24.238Z [RUN-A] STEP hold 30s (overlap window, Director alive on port 7893)
+2026-06-11T08:41:54.242Z [RUN-A] STEP teardown (RemoveWorktree=True)
+2026-06-11T08:41:56.865Z [RUN-A]   [teardown] stopping PID 40124 (D:\ReposFred\wt-issue-299-proof-a\local_builds\cc-director6.exe)
+2026-06-11T08:41:56.867Z [RUN-A]   [teardown] PID 40124 exited
+2026-06-11T08:41:56.868Z [RUN-A]   [teardown] unregistered scheduled task cc-director6-launch
+2026-06-11T08:41:56.869Z [RUN-A]   [teardown] removed worktree D:\ReposFred\wt-issue-299-proof-a
+2026-06-11T08:41:56.870Z [RUN-A]   [teardown] done (slot 6 is free again)
+2026-06-11T08:41:56.874Z [RUN-A] ASSERT process pid=40124 gone
+2026-06-11T08:41:57.533Z [RUN-A] ASSERT scheduled task cc-director6-launch unregistered
+2026-06-11T08:41:57.535Z [RUN-A] ASSERT worktree D:\ReposFred\wt-issue-299-proof-a removed
+2026-06-11T08:41:57.536Z [RUN-A] RUN END slot=6 port=7893 pid=40124 result=SUCCESS</pre>
+</div>
+<div>
+<h3>run-b.log</h3>
+<pre>2026-06-11T08:41:07.506Z [RUN-B] RUN START worktree=D:\ReposFred\wt-issue-299-proof-b pid_of_runner=46240
+2026-06-11T08:41:07.538Z [RUN-B] STEP allocate
+2026-06-11T08:41:09.258Z [RUN-B]   [allocate] slot 6 lost in registration race (Cannot create a file when that file already exists.
+2026-06-11T08:41:09.259Z [RUN-B]   ); trying next
+2026-06-11T08:41:09.260Z [RUN-B]   [allocate] SLOT=7
+2026-06-11T08:41:09.261Z [RUN-B]   [allocate] TASK=cc-director7-launch
+2026-06-11T08:41:09.262Z [RUN-B]   [allocate] MANIFEST=D:\ReposFred\wt-issue-299-proof-b\local_builds\agent-session-slot7.json
+2026-06-11T08:41:09.263Z [RUN-B]   [allocate] Next: build the slot exe from the worktree root:
+2026-06-11T08:41:09.263Z [RUN-B]   [allocate]   powershell -NoProfile -File "D:\ReposFred\wt-issue-299-proof-b\scripts\local-build-avalonia.ps1" -Slot 7
+2026-06-11T08:41:09.279Z [RUN-B] ALLOCATED slot=7 manifest=D:\ReposFred\wt-issue-299-proof-b\local_builds\agent-session-slot7.json
+2026-06-11T08:41:09.280Z [RUN-B] STEP build (local-build-avalonia.ps1 -Slot 7, cwd=D:\ReposFred\wt-issue-299-proof-b)
+2026-06-11T08:41:21.153Z [RUN-B]   Building CC Director Avalonia v0.6.22 (Release)
+2026-06-11T08:41:21.154Z [RUN-B]     Mode: Framework-dependent (.NET 10 runtime required)
+2026-06-11T08:41:21.155Z [RUN-B]     Cleaning previous build...
+2026-06-11T08:41:21.157Z [RUN-B]     Pre-building Core dependency...
+2026-06-11T08:41:21.158Z [RUN-B]   
+2026-06-11T08:41:21.159Z [RUN-B]   Build succeeded.
+2026-06-11T08:41:21.160Z [RUN-B]       0 Warning(s)
+2026-06-11T08:41:21.161Z [RUN-B]       0 Error(s)
+2026-06-11T08:41:21.162Z [RUN-B]   
+2026-06-11T08:41:21.163Z [RUN-B]   Time Elapsed 00:00:02.06
+2026-06-11T08:41:21.164Z [RUN-B]     Building Avalonia project...
+2026-06-11T08:41:21.165Z [RUN-B]   
+2026-06-11T08:41:21.166Z [RUN-B]   Build succeeded.
+2026-06-11T08:41:21.167Z [RUN-B]       0 Warning(s)
+2026-06-11T08:41:21.169Z [RUN-B]       0 Error(s)
+2026-06-11T08:41:21.170Z [RUN-B]   
+2026-06-11T08:41:21.171Z [RUN-B]   Time Elapsed 00:00:07.33
+2026-06-11T08:41:21.173Z [RUN-B]     Publishing...
+2026-06-11T08:41:21.174Z [RUN-B]   MSBuild version 18.6.4+96856fd72 for .NET
+2026-06-11T08:41:21.175Z [RUN-B]     CcDirector.Avalonia -&gt; D:\ReposFred\wt-issue-299-proof-b\src\CcDirector.Avalonia\bin\Release\net10.0\win-x64\publish\
+2026-06-11T08:41:21.176Z [RUN-B]   
+2026-06-11T08:41:21.177Z [RUN-B]   Build complete: 38.3 MB
+2026-06-11T08:41:21.178Z [RUN-B]     D:\ReposFred\wt-issue-299-proof-b\local_builds\cc-director7.exe
+2026-06-11T08:41:21.179Z [RUN-B] BUILD OK slot=7
+2026-06-11T08:41:21.181Z [RUN-B] STEP launch
+2026-06-11T08:41:26.688Z [RUN-B]   [launch] starting scheduled task cc-director7-launch
+2026-06-11T08:41:26.690Z [RUN-B]   [launch] PID=35984
+2026-06-11T08:41:26.691Z [RUN-B]   [launch] PORT=7891
+2026-06-11T08:41:26.705Z [RUN-B]   [launch] LOG=C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-06-11-35984.log
+2026-06-11T08:41:26.706Z [RUN-B]   [launch] Control API: http://127.0.0.1:7891 (probe GET /healthz)
+2026-06-11T08:41:26.708Z [RUN-B]   [launch] MANIFEST=D:\ReposFred\wt-issue-299-proof-b\local_builds\agent-session-slot7.json (updated)
+2026-06-11T08:41:26.710Z [RUN-B] LAUNCHED pid=35984 port=7891
+2026-06-11T08:41:26.712Z [RUN-B] STEP probe GET http://127.0.0.1:7891/healthz
+2026-06-11T08:41:26.745Z [RUN-B] PROBE status=200 body={"status":"ok","directors":1,"sessions":0,"version":"0.6.22","serverTime":"2026-06-11T08:41:26.7286452Z","directorId":"ff388894-6949-40c3-b15d-6f5446de9068","machineName":"SOREN_NORTH"}
+2026-06-11T08:41:26.746Z [RUN-B] STEP hold 30s (overlap window, Director alive on port 7891)
+2026-06-11T08:41:56.757Z [RUN-B] STEP teardown (RemoveWorktree=True)
+2026-06-11T08:41:59.414Z [RUN-B]   [teardown] stopping PID 35984 (D:\ReposFred\wt-issue-299-proof-b\local_builds\cc-director7.exe)
+2026-06-11T08:41:59.415Z [RUN-B]   [teardown] PID 35984 exited
+2026-06-11T08:41:59.417Z [RUN-B]   [teardown] unregistered scheduled task cc-director7-launch
+2026-06-11T08:41:59.418Z [RUN-B]   [teardown] removed worktree D:\ReposFred\wt-issue-299-proof-b
+2026-06-11T08:41:59.419Z [RUN-B]   [teardown] done (slot 7 is free again)
+2026-06-11T08:41:59.422Z [RUN-B] ASSERT process pid=35984 gone
+2026-06-11T08:42:00.081Z [RUN-B] ASSERT scheduled task cc-director7-launch unregistered
+2026-06-11T08:42:00.084Z [RUN-B] ASSERT worktree D:\ReposFred\wt-issue-299-proof-b removed
+2026-06-11T08:42:00.085Z [RUN-B] RUN END slot=7 port=7891 pid=35984 result=SUCCESS</pre>
+</div>
+</div>
+
+<h2>Fleet snapshots (raw)</h2>
+<div class="logs">
+<div>
+<h3>fleet-before.txt</h3>
+<pre>LIVE FLEET SNAPSHOT (BEFORE) - 2026-06-11T08:33:56Z
+
+Processes (cc-director* / gateway / cockpit):
+  PID=21128   NAME=cc-director                START=2026-06-10 13:34:24 PATH=C:\Users\soren\AppData\Local\cc-director\app\cc-director.exe
+  PID=42928   NAME=cc-director-gateway        START=2026-06-10 21:32:30 PATH=C:\Users\soren\AppData\Local\cc-director\gateway\cc-director-gateway.exe
+  PID=65232   NAME=cc-director-cockpit        START=2026-06-10 21:32:32 PATH=C:\Users\soren\AppData\Local\cc-director\cockpit\cc-director-cockpit.exe
+
+Listeners on protected ports 7878 (Gateway) / 7470 (Cockpit) / 7887 (Director):
+  PORT=7470    OWNINGPID=65232   OWNER=cc-director-cockpit
+  PORT=7878    OWNINGPID=42928   OWNER=cc-director-gateway
+  PORT=7887    OWNINGPID=8640    OWNER=tailscaled
+  PORT=7887    OWNINGPID=21128   OWNER=cc-director
+
+Registered cc-director*-launch scheduled tasks:
+  TASK=cc-director2-launch               STATE=Ready
+  TASK=cc-director-gateway-launch        STATE=Ready
+  TASK=cc-director-launch                STATE=Ready</pre>
+</div>
+<div>
+<h3>fleet-after.txt</h3>
+<pre>LIVE FLEET SNAPSHOT (AFTER) - 2026-06-11T08:42:27Z
+
+Processes (cc-director* / gateway / cockpit):
+  PID=21128   NAME=cc-director                START=2026-06-10 13:34:24 PATH=C:\Users\soren\AppData\Local\cc-director\app\cc-director.exe
+  PID=42928   NAME=cc-director-gateway        START=2026-06-10 21:32:30 PATH=C:\Users\soren\AppData\Local\cc-director\gateway\cc-director-gateway.exe
+  PID=65232   NAME=cc-director-cockpit        START=2026-06-10 21:32:32 PATH=C:\Users\soren\AppData\Local\cc-director\cockpit\cc-director-cockpit.exe
+
+Listeners on protected ports 7878 (Gateway) / 7470 (Cockpit) / 7887 (Director):
+  PORT=7470    OWNINGPID=65232   OWNER=cc-director-cockpit
+  PORT=7878    OWNINGPID=42928   OWNER=cc-director-gateway
+  PORT=7887    OWNINGPID=8640    OWNER=tailscaled
+  PORT=7887    OWNINGPID=21128   OWNER=cc-director
+
+Registered cc-director*-launch scheduled tasks:
+  TASK=cc-director2-launch               STATE=Ready
+  TASK=cc-director-gateway-launch        STATE=Ready
+  TASK=cc-director-launch                STATE=Ready</pre>
+</div>
+</div>
+
+<h2>Build gate</h2>
+<p><code>dotnet build cc-director.sln</code> inside D:\ReposFred\wt-issue-299: <span class="pass">Build succeeded. 0 Warning(s), 0 Error(s).</span></p>
+
+<h2>CenCon impact</h2>
+<p>Process/method change only: docs/cencon/DEVELOPMENT_METHOD.md Section 6 (DoD items 3-4) updated in this change.
+No architecture containers or security posture altered; no blocking security rule (DT-01..DT-NN) touched. Zero C#
+changes (the Director's port-allocation code is explicitly out of scope; the discovered PortAllocator startup race is
+mitigated at the harness level and recommended as a follow-up issue).</p>
+
+<h2>Verdict</h2>
+<p class="pass">All acceptance criteria PASS. I believe this is finished.</p>
+
+</body>
+</html>
+

--- a/docs/cencon/proof/issue-299/run-a.log
+++ b/docs/cencon/proof/issue-299/run-a.log
@@ -1,0 +1,54 @@
+2026-06-11T08:41:07.499Z [RUN-A] RUN START worktree=D:\ReposFred\wt-issue-299-proof-a pid_of_runner=60100
+2026-06-11T08:41:07.531Z [RUN-A] STEP allocate
+2026-06-11T08:41:08.583Z [RUN-A]   [allocate] SLOT=6
+2026-06-11T08:41:08.583Z [RUN-A]   [allocate] TASK=cc-director6-launch
+2026-06-11T08:41:08.585Z [RUN-A]   [allocate] MANIFEST=D:\ReposFred\wt-issue-299-proof-a\local_builds\agent-session-slot6.json
+2026-06-11T08:41:08.586Z [RUN-A]   [allocate] Next: build the slot exe from the worktree root:
+2026-06-11T08:41:08.586Z [RUN-A]   [allocate]   powershell -NoProfile -File "D:\ReposFred\wt-issue-299-proof-a\scripts\local-build-avalonia.ps1" -Slot 6
+2026-06-11T08:41:08.601Z [RUN-A] ALLOCATED slot=6 manifest=D:\ReposFred\wt-issue-299-proof-a\local_builds\agent-session-slot6.json
+2026-06-11T08:41:08.668Z [RUN-A] STEP build (local-build-avalonia.ps1 -Slot 6, cwd=D:\ReposFred\wt-issue-299-proof-a)
+2026-06-11T08:41:20.765Z [RUN-A]   Building CC Director Avalonia v0.6.22 (Release)
+2026-06-11T08:41:20.767Z [RUN-A]     Mode: Framework-dependent (.NET 10 runtime required)
+2026-06-11T08:41:20.769Z [RUN-A]     Cleaning previous build...
+2026-06-11T08:41:20.770Z [RUN-A]     Pre-building Core dependency...
+2026-06-11T08:41:20.771Z [RUN-A]   
+2026-06-11T08:41:20.773Z [RUN-A]   Build succeeded.
+2026-06-11T08:41:20.774Z [RUN-A]       0 Warning(s)
+2026-06-11T08:41:20.775Z [RUN-A]       0 Error(s)
+2026-06-11T08:41:20.777Z [RUN-A]   
+2026-06-11T08:41:20.778Z [RUN-A]   Time Elapsed 00:00:02.12
+2026-06-11T08:41:20.779Z [RUN-A]     Building Avalonia project...
+2026-06-11T08:41:20.781Z [RUN-A]   
+2026-06-11T08:41:20.782Z [RUN-A]   Build succeeded.
+2026-06-11T08:41:20.783Z [RUN-A]       0 Warning(s)
+2026-06-11T08:41:20.785Z [RUN-A]       0 Error(s)
+2026-06-11T08:41:20.786Z [RUN-A]   
+2026-06-11T08:41:20.787Z [RUN-A]   Time Elapsed 00:00:07.63
+2026-06-11T08:41:20.789Z [RUN-A]     Publishing...
+2026-06-11T08:41:20.790Z [RUN-A]   MSBuild version 18.6.4+96856fd72 for .NET
+2026-06-11T08:41:20.793Z [RUN-A]     CcDirector.Avalonia -> D:\ReposFred\wt-issue-299-proof-a\src\CcDirector.Avalonia\bin\Release\net10.0\win-x64\publish\
+2026-06-11T08:41:20.795Z [RUN-A]   
+2026-06-11T08:41:20.796Z [RUN-A]   Build complete: 38.3 MB
+2026-06-11T08:41:20.797Z [RUN-A]     D:\ReposFred\wt-issue-299-proof-a\local_builds\cc-director6.exe
+2026-06-11T08:41:20.799Z [RUN-A] BUILD OK slot=6
+2026-06-11T08:41:20.800Z [RUN-A] STEP launch
+2026-06-11T08:41:23.998Z [RUN-A]   [launch] starting scheduled task cc-director6-launch
+2026-06-11T08:41:24.000Z [RUN-A]   [launch] PID=40124
+2026-06-11T08:41:24.001Z [RUN-A]   [launch] PORT=7893
+2026-06-11T08:41:24.002Z [RUN-A]   [launch] LOG=C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-06-11-40124.log
+2026-06-11T08:41:24.003Z [RUN-A]   [launch] Control API: http://127.0.0.1:7893 (probe GET /healthz)
+2026-06-11T08:41:24.015Z [RUN-A]   [launch] MANIFEST=D:\ReposFred\wt-issue-299-proof-a\local_builds\agent-session-slot6.json (updated)
+2026-06-11T08:41:24.019Z [RUN-A] LAUNCHED pid=40124 port=7893
+2026-06-11T08:41:24.020Z [RUN-A] STEP probe GET http://127.0.0.1:7893/healthz
+2026-06-11T08:41:24.236Z [RUN-A] PROBE status=200 body={"status":"ok","directors":1,"sessions":0,"version":"0.6.22","serverTime":"2026-06-11T08:41:24.2200517Z","directorId":"e4937462-b7d3-4b0b-976a-db8a2f5550d1","machineName":"SOREN_NORTH"}
+2026-06-11T08:41:24.238Z [RUN-A] STEP hold 30s (overlap window, Director alive on port 7893)
+2026-06-11T08:41:54.242Z [RUN-A] STEP teardown (RemoveWorktree=True)
+2026-06-11T08:41:56.865Z [RUN-A]   [teardown] stopping PID 40124 (D:\ReposFred\wt-issue-299-proof-a\local_builds\cc-director6.exe)
+2026-06-11T08:41:56.867Z [RUN-A]   [teardown] PID 40124 exited
+2026-06-11T08:41:56.868Z [RUN-A]   [teardown] unregistered scheduled task cc-director6-launch
+2026-06-11T08:41:56.869Z [RUN-A]   [teardown] removed worktree D:\ReposFred\wt-issue-299-proof-a
+2026-06-11T08:41:56.870Z [RUN-A]   [teardown] done (slot 6 is free again)
+2026-06-11T08:41:56.874Z [RUN-A] ASSERT process pid=40124 gone
+2026-06-11T08:41:57.533Z [RUN-A] ASSERT scheduled task cc-director6-launch unregistered
+2026-06-11T08:41:57.535Z [RUN-A] ASSERT worktree D:\ReposFred\wt-issue-299-proof-a removed
+2026-06-11T08:41:57.536Z [RUN-A] RUN END slot=6 port=7893 pid=40124 result=SUCCESS

--- a/docs/cencon/proof/issue-299/run-b.log
+++ b/docs/cencon/proof/issue-299/run-b.log
@@ -1,0 +1,56 @@
+2026-06-11T08:41:07.506Z [RUN-B] RUN START worktree=D:\ReposFred\wt-issue-299-proof-b pid_of_runner=46240
+2026-06-11T08:41:07.538Z [RUN-B] STEP allocate
+2026-06-11T08:41:09.258Z [RUN-B]   [allocate] slot 6 lost in registration race (Cannot create a file when that file already exists.
+2026-06-11T08:41:09.259Z [RUN-B]   ); trying next
+2026-06-11T08:41:09.260Z [RUN-B]   [allocate] SLOT=7
+2026-06-11T08:41:09.261Z [RUN-B]   [allocate] TASK=cc-director7-launch
+2026-06-11T08:41:09.262Z [RUN-B]   [allocate] MANIFEST=D:\ReposFred\wt-issue-299-proof-b\local_builds\agent-session-slot7.json
+2026-06-11T08:41:09.263Z [RUN-B]   [allocate] Next: build the slot exe from the worktree root:
+2026-06-11T08:41:09.263Z [RUN-B]   [allocate]   powershell -NoProfile -File "D:\ReposFred\wt-issue-299-proof-b\scripts\local-build-avalonia.ps1" -Slot 7
+2026-06-11T08:41:09.279Z [RUN-B] ALLOCATED slot=7 manifest=D:\ReposFred\wt-issue-299-proof-b\local_builds\agent-session-slot7.json
+2026-06-11T08:41:09.280Z [RUN-B] STEP build (local-build-avalonia.ps1 -Slot 7, cwd=D:\ReposFred\wt-issue-299-proof-b)
+2026-06-11T08:41:21.153Z [RUN-B]   Building CC Director Avalonia v0.6.22 (Release)
+2026-06-11T08:41:21.154Z [RUN-B]     Mode: Framework-dependent (.NET 10 runtime required)
+2026-06-11T08:41:21.155Z [RUN-B]     Cleaning previous build...
+2026-06-11T08:41:21.157Z [RUN-B]     Pre-building Core dependency...
+2026-06-11T08:41:21.158Z [RUN-B]   
+2026-06-11T08:41:21.159Z [RUN-B]   Build succeeded.
+2026-06-11T08:41:21.160Z [RUN-B]       0 Warning(s)
+2026-06-11T08:41:21.161Z [RUN-B]       0 Error(s)
+2026-06-11T08:41:21.162Z [RUN-B]   
+2026-06-11T08:41:21.163Z [RUN-B]   Time Elapsed 00:00:02.06
+2026-06-11T08:41:21.164Z [RUN-B]     Building Avalonia project...
+2026-06-11T08:41:21.165Z [RUN-B]   
+2026-06-11T08:41:21.166Z [RUN-B]   Build succeeded.
+2026-06-11T08:41:21.167Z [RUN-B]       0 Warning(s)
+2026-06-11T08:41:21.169Z [RUN-B]       0 Error(s)
+2026-06-11T08:41:21.170Z [RUN-B]   
+2026-06-11T08:41:21.171Z [RUN-B]   Time Elapsed 00:00:07.33
+2026-06-11T08:41:21.173Z [RUN-B]     Publishing...
+2026-06-11T08:41:21.174Z [RUN-B]   MSBuild version 18.6.4+96856fd72 for .NET
+2026-06-11T08:41:21.175Z [RUN-B]     CcDirector.Avalonia -> D:\ReposFred\wt-issue-299-proof-b\src\CcDirector.Avalonia\bin\Release\net10.0\win-x64\publish\
+2026-06-11T08:41:21.176Z [RUN-B]   
+2026-06-11T08:41:21.177Z [RUN-B]   Build complete: 38.3 MB
+2026-06-11T08:41:21.178Z [RUN-B]     D:\ReposFred\wt-issue-299-proof-b\local_builds\cc-director7.exe
+2026-06-11T08:41:21.179Z [RUN-B] BUILD OK slot=7
+2026-06-11T08:41:21.181Z [RUN-B] STEP launch
+2026-06-11T08:41:26.688Z [RUN-B]   [launch] starting scheduled task cc-director7-launch
+2026-06-11T08:41:26.690Z [RUN-B]   [launch] PID=35984
+2026-06-11T08:41:26.691Z [RUN-B]   [launch] PORT=7891
+2026-06-11T08:41:26.705Z [RUN-B]   [launch] LOG=C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-06-11-35984.log
+2026-06-11T08:41:26.706Z [RUN-B]   [launch] Control API: http://127.0.0.1:7891 (probe GET /healthz)
+2026-06-11T08:41:26.708Z [RUN-B]   [launch] MANIFEST=D:\ReposFred\wt-issue-299-proof-b\local_builds\agent-session-slot7.json (updated)
+2026-06-11T08:41:26.710Z [RUN-B] LAUNCHED pid=35984 port=7891
+2026-06-11T08:41:26.712Z [RUN-B] STEP probe GET http://127.0.0.1:7891/healthz
+2026-06-11T08:41:26.745Z [RUN-B] PROBE status=200 body={"status":"ok","directors":1,"sessions":0,"version":"0.6.22","serverTime":"2026-06-11T08:41:26.7286452Z","directorId":"ff388894-6949-40c3-b15d-6f5446de9068","machineName":"SOREN_NORTH"}
+2026-06-11T08:41:26.746Z [RUN-B] STEP hold 30s (overlap window, Director alive on port 7891)
+2026-06-11T08:41:56.757Z [RUN-B] STEP teardown (RemoveWorktree=True)
+2026-06-11T08:41:59.414Z [RUN-B]   [teardown] stopping PID 35984 (D:\ReposFred\wt-issue-299-proof-b\local_builds\cc-director7.exe)
+2026-06-11T08:41:59.415Z [RUN-B]   [teardown] PID 35984 exited
+2026-06-11T08:41:59.417Z [RUN-B]   [teardown] unregistered scheduled task cc-director7-launch
+2026-06-11T08:41:59.418Z [RUN-B]   [teardown] removed worktree D:\ReposFred\wt-issue-299-proof-b
+2026-06-11T08:41:59.419Z [RUN-B]   [teardown] done (slot 7 is free again)
+2026-06-11T08:41:59.422Z [RUN-B] ASSERT process pid=35984 gone
+2026-06-11T08:42:00.081Z [RUN-B] ASSERT scheduled task cc-director7-launch unregistered
+2026-06-11T08:42:00.084Z [RUN-B] ASSERT worktree D:\ReposFred\wt-issue-299-proof-b removed
+2026-06-11T08:42:00.085Z [RUN-B] RUN END slot=7 port=7891 pid=35984 result=SUCCESS

--- a/scripts/agent-session-isolation.ps1
+++ b/scripts/agent-session-isolation.ps1
@@ -1,0 +1,392 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Per-session isolation harness for agent test Directors (issue #299).
+
+.DESCRIPTION
+    Gives each implementation/QA session its own test slot, build output, and
+    Control API port so two sessions can run concurrently on one machine without
+    colliding. Three subcommands:
+
+      allocate  - Find and RESERVE the lowest free slot N >= 6 for a worktree.
+                  "Free" means: no running process whose image is cc-director<N>.exe
+                  AND no registered scheduled task cc-director<N>-launch. The
+                  reservation IS the task registration (Register-ScheduledTask
+                  WITHOUT -Force): if two sessions race for the same N, exactly one
+                  registration succeeds and the loser moves to N+1. Emits a
+                  machine-readable session manifest (JSON) into the worktree's
+                  local_builds directory.
+
+      launch    - Start the session's test Director via ITS OWN scheduled task
+                  (clean svchost parentage, CLAUDE.md rule 0b - never from the
+                  agent's process tree). Resolves the new PID by exact image path,
+                  then reads the Director's own log for the self-allocated Control
+                  API port ("Kestrel listening on ..."). Updates the manifest with
+                  pid/port/logFile. The whole start->port-discovered window runs
+                  under a machine-wide named mutex: the Director's PortAllocator
+                  probes for a free port BEFORE Kestrel binds it, so two Directors
+                  starting in the same instant can pick the same port (proven
+                  live: simultaneous starts both allocated 7892 and one failed
+                  with "address already in use"). Serializing launches means each
+                  Director has BOUND its port before the next one probes. If the
+                  port never appears in the log, the just-launched process is
+                  stopped (exact image path confirmed first) so a failed launch
+                  never leaks an orphan Director.
+
+      teardown  - Stop ONLY the session's own Director (image path must match the
+                  manifest exe exactly - refuses anything else), unregister the
+                  session's task, optionally remove the worktree (-RemoveWorktree,
+                  for scratch worktrees), and delete the manifest.
+
+    Slots 1-5 and the main build are NEVER touched: slot 5 stays the legacy/manual
+    default and may be in use by a human-driven session; the allocator starts at 6.
+    This script never binds a port itself - the Director self-allocates its Control
+    API port at startup (PortAllocator), and the launch mutex guarantees the
+    allocation-to-bind window of one Director never overlaps another's, so two
+    sessions cannot collide on a port.
+
+.PARAMETER Command
+    allocate | launch | teardown
+
+.PARAMETER Worktree
+    (allocate) Absolute path to the session's git worktree. The slot exe is
+    expected at <Worktree>\local_builds\cc-director<N>.exe after the session runs
+    scripts\local-build-avalonia.ps1 -Slot <N> from the worktree root.
+
+.PARAMETER Manifest
+    (launch, teardown) Path to the session manifest JSON emitted by allocate.
+
+.PARAMETER MinSlot
+    (allocate) Lowest slot number to consider. Defaults to 6 and may not be lower.
+
+.PARAMETER RemoveWorktree
+    (teardown) Also remove the session's git worktree (git worktree remove --force).
+    Use for scratch worktrees only - a primary worktree that QA still needs must be
+    left in place.
+
+.EXAMPLE
+    # Full session lifecycle (run from anywhere; paths are explicit):
+    powershell -NoProfile -File scripts\agent-session-isolation.ps1 allocate -Worktree D:\ReposFred\wt-issue-123
+    #   -> SLOT=6, MANIFEST=D:\ReposFred\wt-issue-123\local_builds\agent-session-slot6.json
+    powershell -NoProfile -File D:\ReposFred\wt-issue-123\scripts\local-build-avalonia.ps1 -Slot 6
+    powershell -NoProfile -File scripts\agent-session-isolation.ps1 launch -Manifest D:\ReposFred\wt-issue-123\local_builds\agent-session-slot6.json
+    #   -> PID=12345, PORT=7881; probe http://127.0.0.1:7881/healthz
+    powershell -NoProfile -File scripts\agent-session-isolation.ps1 teardown -Manifest D:\ReposFred\wt-issue-123\local_builds\agent-session-slot6.json
+#>
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet("allocate", "launch", "teardown")]
+    [string]$Command,
+
+    [string]$Worktree = "",
+    [string]$Manifest = "",
+    [int]$MinSlot = 6,
+    [int]$MaxSlot = 20,
+    [switch]$RemoveWorktree
+)
+
+$ErrorActionPreference = "Stop"
+
+# The hard floor. Slots 1-5 and the main build belong to the human (CLAUDE.md rule
+# 0b; slot 5 is the legacy/manual default and may be in use). Nothing in this script
+# may ever allocate, launch, or tear down below this.
+$script:SlotFloor = 6
+
+function Fail([string]$Message) {
+    Write-Host "[agent-session-isolation] ERROR: $Message"
+    exit 1
+}
+
+function Get-SlotExeName([int]$Slot) { return "cc-director$Slot.exe" }
+function Get-SlotTaskName([int]$Slot) { return "cc-director$Slot-launch" }
+function Get-SlotProcessName([int]$Slot) { return "cc-director$Slot" }
+
+function Test-SlotProcessRunning([int]$Slot) {
+    $procs = @(Get-Process -Name (Get-SlotProcessName $Slot) -ErrorAction SilentlyContinue)
+    return ($procs.Count -gt 0)
+}
+
+function Test-SlotTaskRegistered([int]$Slot) {
+    $task = Get-ScheduledTask -TaskName (Get-SlotTaskName $Slot) -ErrorAction SilentlyContinue
+    return ($null -ne $task)
+}
+
+function Read-Manifest([string]$Path) {
+    if (-not $Path) { Fail "-Manifest is required for this command." }
+    if (-not (Test-Path $Path)) { Fail "Manifest not found: $Path" }
+    $m = Get-Content $Path -Raw | ConvertFrom-Json
+    if ($m.slot -lt $script:SlotFloor) {
+        Fail "Manifest slot $($m.slot) is below the floor ($script:SlotFloor). Slots 1-5 / main build are off-limits; refusing."
+    }
+    return $m
+}
+
+function Write-Manifest($Obj, [string]$Path) {
+    $json = $Obj | ConvertTo-Json -Depth 4
+    $json | Out-File -FilePath $Path -Encoding ascii
+}
+
+function New-SlotTaskRegistration([int]$Slot, [string]$ExePath, [string]$WorkingDir, [bool]$Force) {
+    # WorkingDirectory MUST be set or Avalonia first-run resource resolution can
+    # fail with exit -1 (see CLAUDE.md rule 0b setup notes).
+    $action = New-ScheduledTaskAction -Execute $ExePath -WorkingDirectory $WorkingDir
+    # On-demand only: trigger parked far in the future.
+    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddYears(5)
+    if ($Force) {
+        Register-ScheduledTask -TaskName (Get-SlotTaskName $Slot) -Action $action -Trigger $trigger -Force | Out-Null
+    } else {
+        # NO -Force: registration fails if the task already exists. That failure is
+        # the allocation race arbiter - the loser gets an error and tries the next slot.
+        Register-ScheduledTask -TaskName (Get-SlotTaskName $Slot) -Action $action -Trigger $trigger | Out-Null
+    }
+}
+
+# ---------------------------------------------------------------- allocate ----
+function Invoke-Allocate {
+    if (-not $Worktree) { Fail "-Worktree is required for allocate." }
+    if ($MinSlot -lt $script:SlotFloor) { Fail "-MinSlot $MinSlot is below the floor ($script:SlotFloor). Slots 1-5 / main build are off-limits." }
+    $wt = (Resolve-Path $Worktree -ErrorAction SilentlyContinue)
+    if ($null -eq $wt) { Fail "Worktree path does not exist: $Worktree" }
+    $wt = $wt.Path
+    if (-not (Test-Path (Join-Path $wt "scripts\local-build-avalonia.ps1"))) {
+        Fail "Worktree $wt does not look like a cc-director checkout (scripts\local-build-avalonia.ps1 missing)."
+    }
+
+    $localBuilds = Join-Path $wt "local_builds"
+    if (-not (Test-Path $localBuilds)) {
+        New-Item -ItemType Directory -Path $localBuilds | Out-Null
+    }
+
+    $allocated = 0
+    for ($n = $MinSlot; $n -le $MaxSlot; $n++) {
+        if (Test-SlotProcessRunning $n) {
+            Write-Host "[allocate] slot $n busy: process $(Get-SlotProcessName $n) is running"
+            continue
+        }
+        if (Test-SlotTaskRegistered $n) {
+            Write-Host "[allocate] slot $n busy: scheduled task $(Get-SlotTaskName $n) is registered"
+            continue
+        }
+        # Reserve by registering the per-slot task WITHOUT -Force. If another
+        # session registered it between our probe and now, this throws and we
+        # move on - exactly one session can hold a slot's task.
+        $exePath = Join-Path $localBuilds (Get-SlotExeName $n)
+        try {
+            New-SlotTaskRegistration -Slot $n -ExePath $exePath -WorkingDir $localBuilds -Force $false
+            $allocated = $n
+            break
+        } catch {
+            Write-Host "[allocate] slot $n lost in registration race ($($_.Exception.Message)); trying next"
+        }
+    }
+
+    if ($allocated -eq 0) { Fail "No free slot found in [$MinSlot..$MaxSlot]." }
+
+    $manifestPath = Join-Path $localBuilds "agent-session-slot$allocated.json"
+    $manifestObj = [pscustomobject]@{
+        slot        = $allocated
+        worktree    = $wt
+        exePath     = (Join-Path $localBuilds (Get-SlotExeName $allocated))
+        taskName    = (Get-SlotTaskName $allocated)
+        pid         = 0
+        port        = 0
+        logFile     = ""
+        allocatedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        launchedAt  = ""
+    }
+    Write-Manifest $manifestObj $manifestPath
+
+    Write-Host "[allocate] SLOT=$allocated"
+    Write-Host "[allocate] TASK=$(Get-SlotTaskName $allocated)"
+    Write-Host "[allocate] MANIFEST=$manifestPath"
+    Write-Host "[allocate] Next: build the slot exe from the worktree root:"
+    Write-Host "[allocate]   powershell -NoProfile -File `"$wt\scripts\local-build-avalonia.ps1`" -Slot $allocated"
+}
+
+# ------------------------------------------------------------------ launch ----
+function Stop-OwnLaunchedDirector([int]$DirectorPid, [string]$ExePath) {
+    # Stop the Director THIS launch started, after re-confirming the image path is
+    # exactly the session's exe - so a failed launch never leaks an orphan process.
+    $p = Get-Process -Id $DirectorPid -ErrorAction SilentlyContinue
+    if ($null -eq $p) { return }
+    if (-not ($p.Path -and ($p.Path -ieq $ExePath))) {
+        Write-Host "[launch] NOT stopping PID $DirectorPid - image $($p.Path) is not this session's exe"
+        return
+    }
+    Write-Host "[launch] stopping failed-launch PID $DirectorPid ($($p.Path))"
+    Stop-Process -Id $DirectorPid -Force -Confirm:$false
+}
+
+function Invoke-Launch {
+    $m = Read-Manifest $Manifest
+
+    if (-not (Test-Path $m.exePath)) {
+        Fail "Slot exe not built yet: $($m.exePath). Run scripts\local-build-avalonia.ps1 -Slot $($m.slot) from the worktree root first."
+    }
+
+    # A process already running this slot name means either a leftover from a
+    # previous launch of this session or a foreign collision. Either way we do not
+    # pile a second instance on top - the session must tear down first.
+    $existing = @(Get-Process -Name (Get-SlotProcessName $m.slot) -ErrorAction SilentlyContinue)
+    if ($existing.Count -gt 0) {
+        Fail "A $(Get-SlotProcessName $m.slot) process is already running (PID $($existing[0].Id), path $($existing[0].Path)). Run teardown first; never stack launches."
+    }
+
+    # Re-register with -Force: allocate reserved the task before the exe existed;
+    # this re-asserts the exact exe path + WorkingDirectory now that it does.
+    $localBuilds = Split-Path -Parent $m.exePath
+    New-SlotTaskRegistration -Slot $m.slot -ExePath $m.exePath -WorkingDir $localBuilds -Force $true
+
+    # MACHINE-WIDE LAUNCH MUTEX. The Director's PortAllocator probes for a free
+    # port and only LATER binds it (Kestrel). Two Directors starting in the same
+    # instant can therefore allocate the SAME port - proven live: two simultaneous
+    # launches both allocated 7892 and the loser's Control API died with "address
+    # already in use". Holding this mutex from task start until the port is read
+    # from the Director's log (i.e. Kestrel has bound it) guarantees the next
+    # session's Director sees the port as busy and picks another.
+    $mutex = New-Object System.Threading.Mutex($false, "Global\cc-director-agent-session-launch")
+    $acquired = $false
+    try {
+        try {
+            $acquired = $mutex.WaitOne([TimeSpan]::FromSeconds(300))
+        } catch [System.Threading.AbandonedMutexException] {
+            # A previous holder died while holding the mutex; we now own it.
+            $acquired = $true
+        }
+        if (-not $acquired) {
+            Fail "Could not acquire the machine-wide launch mutex within 300s (another session's launch is stuck)."
+        }
+
+        Write-Host "[launch] starting scheduled task $($m.taskName)"
+        Start-ScheduledTask -TaskName $m.taskName
+
+        # Resolve the PID: the process whose image path is EXACTLY our exe.
+        $deadlinePid = (Get-Date).AddSeconds(60)
+        $directorPid = 0
+        while ((Get-Date) -lt $deadlinePid) {
+            $procs = @(Get-Process -Name (Get-SlotProcessName $m.slot) -ErrorAction SilentlyContinue)
+            foreach ($p in $procs) {
+                if ($p.Path -and ($p.Path -ieq $m.exePath)) { $directorPid = $p.Id; break }
+            }
+            if ($directorPid -ne 0) { break }
+            Start-Sleep -Milliseconds 500
+        }
+        if ($directorPid -eq 0) {
+            Fail "Director did not appear within 60s (expected image $($m.exePath)). Check Task Scheduler history for $($m.taskName)."
+        }
+        Write-Host "[launch] PID=$directorPid"
+
+        # Discover the self-allocated Control API port from the Director's own log:
+        # %LOCALAPPDATA%\cc-director\logs\director\director-<date>-<PID>.log contains
+        # "[ControlApiHost] Kestrel listening on http://<host>:<port>".
+        $logDir = Join-Path $env:LOCALAPPDATA "cc-director\logs\director"
+        $deadlinePort = (Get-Date).AddSeconds(120)
+        $port = 0
+        $logFile = ""
+        while ((Get-Date) -lt $deadlinePort) {
+            $candidates = @(Get-ChildItem -Path $logDir -Filter "director-*-$directorPid.log" -ErrorAction SilentlyContinue)
+            foreach ($f in $candidates) {
+                $hit = Select-String -Path $f.FullName -Pattern "Kestrel listening on http://[^:]+:(\d+)" -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($hit) {
+                    $port = [int]$hit.Matches[0].Groups[1].Value
+                    $logFile = $f.FullName
+                    break
+                }
+            }
+            if ($port -ne 0) { break }
+            # The Director may have exited (bad build, startup crash) - fail fast.
+            $alive = Get-Process -Id $directorPid -ErrorAction SilentlyContinue
+            if ($null -eq $alive) {
+                Fail "Director PID $directorPid exited before reporting its Control API port. Check the newest log in $logDir."
+            }
+            Start-Sleep -Milliseconds 500
+        }
+        if ($port -eq 0) {
+            # Never leak an orphan: the Director is up but unreachable (no Control
+            # API). Stop it (exact-path confirmed) before failing.
+            Stop-OwnLaunchedDirector -DirectorPid $directorPid -ExePath $m.exePath
+            Fail "Control API port not found in Director log within 120s (PID $directorPid, dir $logDir). The just-launched process has been stopped."
+        }
+    } finally {
+        if ($acquired) { $mutex.ReleaseMutex() | Out-Null }
+        $mutex.Dispose()
+    }
+
+    $m.pid = $directorPid
+    $m.port = $port
+    $m.logFile = $logFile
+    $m.launchedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    Write-Manifest $m $Manifest
+
+    Write-Host "[launch] PORT=$port"
+    Write-Host "[launch] LOG=$logFile"
+    Write-Host "[launch] Control API: http://127.0.0.1:$port (probe GET /healthz)"
+    Write-Host "[launch] MANIFEST=$Manifest (updated)"
+}
+
+# ---------------------------------------------------------------- teardown ----
+function Invoke-Teardown {
+    $m = Read-Manifest $Manifest
+
+    # Stop ONLY processes whose image path is EXACTLY the session's exe. The
+    # manifest PID is checked first; we also sweep same-name processes in case the
+    # PID was recycled - but ONLY exact-path matches are ever stopped.
+    $targets = @()
+    $procs = @(Get-Process -Name (Get-SlotProcessName $m.slot) -ErrorAction SilentlyContinue)
+    foreach ($p in $procs) {
+        if ($p.Path -and ($p.Path -ieq $m.exePath)) {
+            $targets += $p
+        } else {
+            Write-Host "[teardown] leaving PID $($p.Id) alone: image $($p.Path) is NOT this session's exe"
+        }
+    }
+    if ($targets.Count -eq 0) {
+        Write-Host "[teardown] no running process for $($m.exePath) (already stopped)"
+    }
+    foreach ($p in $targets) {
+        Write-Host "[teardown] stopping PID $($p.Id) ($($p.Path))"
+        Stop-Process -Id $p.Id -Force -Confirm:$false
+        $deadline = (Get-Date).AddSeconds(15)
+        while ((Get-Date) -lt $deadline) {
+            $alive = Get-Process -Id $p.Id -ErrorAction SilentlyContinue
+            if ($null -eq $alive) { break }
+            Start-Sleep -Milliseconds 250
+        }
+        $alive = Get-Process -Id $p.Id -ErrorAction SilentlyContinue
+        if ($alive) { Fail "PID $($p.Id) did not exit within 15s." }
+        Write-Host "[teardown] PID $($p.Id) exited"
+    }
+
+    if (Test-SlotTaskRegistered $m.slot) {
+        Unregister-ScheduledTask -TaskName $m.taskName -Confirm:$false
+        Write-Host "[teardown] unregistered scheduled task $($m.taskName)"
+    } else {
+        Write-Host "[teardown] scheduled task $($m.taskName) not registered (already gone)"
+    }
+
+    if ($RemoveWorktree) {
+        # Resolve the main repo through the worktree's git metadata, step out of the
+        # worktree (you cannot remove the directory you are standing in), and remove.
+        $commonDir = (& git -C $m.worktree rev-parse --path-format=absolute --git-common-dir)
+        if ($LASTEXITCODE -ne 0 -or -not $commonDir) {
+            Fail "Could not resolve the main repo for worktree $($m.worktree); not removing it."
+        }
+        $mainRepo = Split-Path -Parent $commonDir
+        Set-Location $env:TEMP
+        & git -C $mainRepo worktree remove --force $m.worktree
+        if ($LASTEXITCODE -ne 0) { Fail "git worktree remove failed for $($m.worktree)." }
+        Write-Host "[teardown] removed worktree $($m.worktree)"
+    } else {
+        # Manifest lives inside the worktree; only delete it when the worktree stays.
+        Remove-Item -Path $Manifest -Force -Confirm:$false
+        Write-Host "[teardown] deleted manifest $Manifest"
+    }
+
+    Write-Host "[teardown] done (slot $($m.slot) is free again)"
+}
+
+switch ($Command) {
+    "allocate" { Invoke-Allocate }
+    "launch"   { Invoke-Launch }
+    "teardown" { Invoke-Teardown }
+}


### PR DESCRIPTION
Closes #299 (parent epic #297).

## Release Notes

Implementation/QA agent sessions are now fully isolated per session on one machine: each session allocates its own test slot (>= 6), builds inside its own git worktree, launches its test Director via its own per-slot scheduled task, and discovers the Director's self-allocated Control API port from the Director's log. Two concurrent sessions no longer collide on slot, build output, or port.

## Changes

- NEW `scripts/agent-session-isolation.ps1` - `allocate` / `launch` / `teardown` lifecycle (ASCII output, JSON session manifest):
  - `allocate`: lowest free slot >= 6, probing BOTH running `cc-director<N>.exe` processes AND registered `cc-director<N>-launch` scheduled tasks. The reservation IS the task registration WITHOUT `-Force`, so an allocation race between two sessions has exactly one winner. Slots 1-5 and the main build are protected by a hard floor (any manifest or `-MinSlot` below 6 is refused).
  - `launch`: scheduled-task-only start (CLAUDE.md rule 0b - clean svchost parentage), PID resolved by exact image path, port read from the Director's own log (`Kestrel listening on ...`). The start-to-port-discovered window runs under a machine-wide named mutex (`Global\cc-director-agent-session-launch`): the Director's `PortAllocator` picks a port BEFORE Kestrel binds it, and two simultaneous startups were observed live both allocating port 7892 (one died with `address already in use`). Serializing launches guarantees each Director has BOUND its port before the next one probes. A failed launch stops its own exact-path-confirmed process so it never leaks an orphan.
  - `teardown`: stops ONLY processes whose image path is exactly the session's exe, unregisters only the session's own task, optionally removes a scratch worktree (`-RemoveWorktree`).
- `.claude/skills/developer-agent/skill.md` (v0.5) + `.claude/skills/qa-agent/skill.md` (v0.5): fixed "slot 5 + cc-director-launch" proof/verification instructions replaced with the per-session isolation flow.
- `.claude/skills/implementation-loop/skill.md` (v0.7): concurrency-rule section rewritten - same-machine safety now comes from per-session isolation, not the old "single slot-5" claim.
- `docs/cencon/DEVELOPMENT_METHOD.md` Section 6 (DoD items 3/4): updated to the per-session flow.
- Zero C# changes (the Director's port-allocation code is explicitly out of scope per the sharpened spec; the discovered `PortAllocator` startup TOCTOU is mitigated at the harness level - a Director-side bind-and-hold fix is recommended as a follow-up issue).

## How to Test

1. Create two scratch worktrees off origin/main and run two instances of `docs/cencon/proof/issue-299/proof-runner.ps1` concurrently (one per worktree), passing `scripts/agent-session-isolation.ps1` from this branch as `-IsolationScript`.
2. Inspect the two run logs: distinct slots (>= 6), distinct ports, overlapping timestamps, probe 200 on each Control API, and teardown asserts (process gone, task unregistered, worktree removed) in both.
3. Snapshot the live fleet (Gateway :7878, Cockpit :7470, main Director :7887, scheduled tasks) before and after - it must be identical.

## Expected Result

Both runs end `result=SUCCESS` with no port-in-use / file-locked / slot-collision errors, and the live fleet is untouched.

Proof: `docs/cencon/proof/issue-299/report.html` (committed on this branch) - concurrent run logs (Run A slot 6 / port 7893, Run B slot 7 / port 7891, both Directors alive 08:41:26-08:41:54Z), slot/port/worktree table, fleet before/after PID table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
