### PR TITLE
feat: voice UX - recording indicators, status cues, thinking sound, TTS timeout fix

### DIFF
--- a/docs/cencon/proof/issue-347/report.html
+++ b/docs/cencon/proof/issue-347/report.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Issue #347 - Voice recording-state indicator - Implementation Proof</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; background: #1e1e1e; color: #cccccc; margin: 0; padding: 24px; }
+  h1 { color: #007acc; font-size: 22px; border-bottom: 1px solid #3c3c3c; padding-bottom: 8px; }
+  h2 { color: #9cdcfe; font-size: 16px; margin-top: 28px; }
+  h3 { color: #ce9178; font-size: 14px; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  th { background: #252526; color: #9cdcfe; text-align: left; padding: 8px 12px; border: 1px solid #3c3c3c; }
+  td { padding: 8px 12px; border: 1px solid #3c3c3c; vertical-align: top; }
+  tr:nth-child(even) { background: #252526; }
+  .pass { color: #22c55e; font-weight: bold; }
+  .code { font-family: Cascadia Mono, Consolas, monospace; background: #252526; padding: 12px; border-radius: 6px; border: 1px solid #3c3c3c; font-size: 13px; white-space: pre; overflow-x: auto; }
+  .badge { display: inline-block; padding: 2px 10px; border-radius: 8px; font-size: 12px; font-weight: bold; }
+  .badge-green { background: #1b3a2a; color: #22c55e; }
+  .badge-blue { background: #1b2a3a; color: #3b82f6; }
+  .section { margin-top: 24px; padding: 16px; background: #252526; border-radius: 8px; border: 1px solid #3c3c3c; }
+  .mock-dialog { background: #0b1020; border: 1px solid #2a3550; border-radius: 18px; padding: 24px 28px; width: 280px; margin: 0 auto; }
+  .mock-row { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
+  .mock-dot { width: 16px; height: 16px; border-radius: 50%; background: #f44747; display: inline-block; }
+  .mock-label { font-size: 20px; font-weight: bold; color: #f44747; flex: 1; text-align: center; }
+  .mock-timer { font-size: 13px; color: #8a93a6; font-family: Consolas; }
+  .mock-bars { display: flex; gap: 5px; height: 60px; align-items: flex-end; justify-content: center; margin: 12px 0; }
+  .mock-bar-well { width: 10px; height: 60px; background: #33333a; border-radius: 3px; display: flex; align-items: flex-end; }
+  .mock-bar { width: 10px; border-radius: 3px; background: #f44747; }
+  .mock-hint { font-size: 12px; color: #d97706; text-align: center; height: 18px; margin-bottom: 10px; }
+  .mock-btn-submit { background: #5fd08a; color: #06210f; font-size: 18px; font-weight: bold; height: 56px; width: 100%; border-radius: 14px; border: none; margin-bottom: 8px; }
+  .mock-btn-cancel { background: #e5484d; color: white; font-size: 18px; font-weight: bold; height: 56px; width: 100%; border-radius: 14px; border: none; }
+  .mock-label-recorded { color: #5fd08a; }
+  .diagram-container { display: flex; gap: 40px; flex-wrap: wrap; justify-content: center; margin: 16px 0; }
+  .diagram-label { text-align: center; color: #888888; font-size: 12px; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<h1>Issue #347 Implementation Proof</h1>
+<p>
+  <span class="badge badge-blue">PR branch: issue-347-voice-dictation-recording-indicator</span>&nbsp;
+  <span class="badge badge-green">Build: PASS (0 errors, 0 new warnings)</span>
+</p>
+
+<h2>What was implemented</h2>
+<div class="section">
+  <p>Four recording-state indicators were added to <code>VoiceDictationDialog</code> (the mobile Mode-A voice dialog):</p>
+  <ol>
+    <li><strong>Elapsed timer</strong> &mdash; <code>m:ss</code> label (Consolas 14pt, muted blue-gray) at top-right. Starts from the moment <code>OnAppearing</code> fires (same frame as <code>StartAsync</code>). Updates on a 100 ms IDispatcherTimer tick.</li>
+    <li><strong>RECORDING state label</strong> &mdash; Large label (24pt Bold, red <code>#F44747</code>) centered in the top row. Transitions to "Recorded" (green <code>#5FD08A</code>) immediately when the user taps SUBMIT, before <code>StopAsync</code> completes, giving instant visual confirmation.</li>
+    <li><strong>Pulsing dot</strong> &mdash; 16px red circle (BoxView, CornerRadius=8) at top-left. Toggles Opacity between 1 and 0 on a 500 ms IDispatcherTimer tick (~1 Hz). Hidden (<code>IsVisible=false</code>) on SUBMIT/CANCEL/back-gesture. Stopped in <code>OnDisappearing</code> and <code>ResolveAsync</code>.</li>
+    <li><strong>Speak-up hint</strong> &mdash; Amber label (<code>#D97706</code>, 13pt) below the bouncing bars. Fires when <code>ReadLevel()</code> returns below <code>VoicePresentLevel=0.025</code> (mirrors desktop threshold: sqrt(20/32767) ~ 0.025 on the 0..1 sqrt-scaled range) for more than 2 continuous seconds. Hides immediately when level recovers.</li>
+  </ol>
+  <p>All timers share the same <code>StopTimers()</code> helper called from both <code>OnDisappearing</code> and <code>ResolveAsync</code> to ensure no timer leaks.</p>
+</div>
+
+<h2>Files changed</h2>
+<table>
+  <tr>
+    <th>File</th>
+    <th>Change</th>
+  </tr>
+  <tr>
+    <td><code>phone/CcDirectorClient/Voice/VoiceDictationDialog.xaml</code></td>
+    <td>Added top row (Grid 3-col): PulseDot (BoxView), RecordingLabel (Label), TimerLabel (Label). Added LevelHintLabel below BouncingBarsView. VerticalStackLayout spacing adjusted from 22 to 16.</td>
+  </tr>
+  <tr>
+    <td><code>phone/CcDirectorClient/Voice/VoiceDictationDialog.xaml.cs</code></td>
+    <td>Added _timer, _pulseTimer, _startedUtc, _lowLevelSince, _pulseVisible fields. OnTimerTick() updates elapsed label + drives level-hint tracking. OnPulseTick() toggles dot opacity. OnSubmitClicked() transitions label to "Recorded" / hides dot before StopAsync. StopTimers() cleans up both timers. VoicePresentLevel and LowLevelGracePeriod constants documented.</td>
+  </tr>
+</table>
+
+<h2>UI mockup - Before and After</h2>
+<div class="diagram-container">
+
+  <div>
+    <div class="mock-dialog">
+      <div style="display:flex;justify-content:center;margin-bottom:14px;">
+        <div class="mock-bars">
+          <div class="mock-bar-well"><div class="mock-bar" style="height:30px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:45px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:52px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:58px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:60px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:58px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:52px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:45px;"></div></div>
+          <div class="mock-bar-well"><div class="mock-bar" style="height:30px;"></div></div>
+        </div>
+      </div>
+      <button class="mock-btn-submit">SUBMIT</button>
+      <button class="mock-btn-cancel">CANCEL</button>
+    </div>
+    <div class="diagram-label">BEFORE: no state feedback</div>
+  </div>
+
+  <div>
+    <div class="mock-dialog">
+      <div class="mock-row">
+        <div class="mock-dot"></div>
+        <div class="mock-label">RECORDING</div>
+        <div class="mock-timer">0:07</div>
+      </div>
+      <div class="mock-bars">
+        <div class="mock-bar-well"><div class="mock-bar" style="height:30px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:45px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:52px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:58px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:60px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:58px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:52px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:45px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:30px;"></div></div>
+      </div>
+      <div class="mock-hint">&nbsp;</div>
+      <button class="mock-btn-submit">SUBMIT</button>
+      <button class="mock-btn-cancel">CANCEL</button>
+    </div>
+    <div class="diagram-label">AFTER: recording (healthy level)</div>
+  </div>
+
+  <div>
+    <div class="mock-dialog">
+      <div class="mock-row">
+        <div class="mock-dot" style="opacity:0.2;"></div>
+        <div class="mock-label">RECORDING</div>
+        <div class="mock-timer">0:14</div>
+      </div>
+      <div class="mock-bars">
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;"></div></div>
+      </div>
+      <div class="mock-hint">Speak up or move closer to the mic</div>
+      <button class="mock-btn-submit">SUBMIT</button>
+      <button class="mock-btn-cancel">CANCEL</button>
+    </div>
+    <div class="diagram-label">AFTER: speak-up hint (quiet for &gt;2s, dot pulse off-phase)</div>
+  </div>
+
+  <div>
+    <div class="mock-dialog">
+      <div class="mock-row">
+        <div class="mock-dot" style="background:#5fd08a;opacity:0;"></div>
+        <div class="mock-label mock-label-recorded">Recorded</div>
+        <div class="mock-timer" style="color:#5fd08a;">0:21</div>
+      </div>
+      <div class="mock-bars">
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+        <div class="mock-bar-well"><div class="mock-bar" style="height:8px;background:#5fd08a;"></div></div>
+      </div>
+      <div class="mock-hint">&nbsp;</div>
+      <button class="mock-btn-submit" style="opacity:0.5;">SUBMIT</button>
+      <button class="mock-btn-cancel" style="opacity:0.5;">CANCEL</button>
+    </div>
+    <div class="diagram-label">AFTER: just after SUBMIT tap ("Recorded" green, dot hidden)</div>
+  </div>
+
+</div>
+
+<h2>Acceptance criteria verification</h2>
+<table>
+  <tr>
+    <th>Criterion</th>
+    <th>Code evidence</th>
+    <th>Status</th>
+  </tr>
+  <tr>
+    <td>Elapsed timer visible from first audio frame</td>
+    <td>IDispatcherTimer started in OnAppearing immediately after StartAsync, format m:ss, 100 ms ticks. TimerLabel is in XAML top row.</td>
+    <td><span class="pass">PASS</span></td>
+  </tr>
+  <tr>
+    <td>RECORDING label clearly visible during capture (FontSize &gt;= 22)</td>
+    <td>RecordingLabel: FontSize="24", FontAttributes="Bold", TextColor="#F44747". Horizontally centered between PulseDot and TimerLabel.</td>
+    <td><span class="pass">PASS</span></td>
+  </tr>
+  <tr>
+    <td>Pulsing indicator present during capture, stops on SUBMIT/CANCEL</td>
+    <td>PulseDot BoxView toggles Opacity 1/0 on 500 ms timer. OnSubmitClicked sets PulseDot.IsVisible=false immediately. StopTimers() called in ResolveAsync (all exit paths).</td>
+    <td><span class="pass">PASS</span></td>
+  </tr>
+  <tr>
+    <td>Speak-up hint fires when level too low for &gt; 2 s</td>
+    <td>OnTimerTick calls ReadLevel() each 100 ms. _lowLevelSince tracks start of quiet stretch. After LowLevelGracePeriod (2s) LevelHintLabel becomes visible with "Speak up or move closer to the mic". Clears when level recovers.</td>
+    <td><span class="pass">PASS</span></td>
+  </tr>
+  <tr>
+    <td>RECORDING -&gt; "Recorded" on SUBMIT</td>
+    <td>OnSubmitClicked sets RecordingLabel.Text="Recorded" and TextColor=#5FD08A before awaiting StopAsync.</td>
+    <td><span class="pass">PASS (bonus: instant, pre-StopAsync)</span></td>
+  </tr>
+</table>
+
+<h2>Build verification</h2>
+<div class="section">
+  <p><strong>Main solution (cc-director.sln):</strong></p>
+  <div class="code">dotnet build cc-director.sln
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)</div>
+  <p><strong>Phone app (CcDirectorClient.csproj, net10.0-android):</strong></p>
+  <div class="code">dotnet build CcDirectorClient.csproj -f net10.0-android
+Build succeeded.
+    0 Error(s)
+  (pre-existing warnings in TalkPage.xaml.cs and platform files unchanged)</div>
+</div>
+
+<h2>CenCon impact</h2>
+<p>No drift. Change confined to <code>phone/CcDirectorClient/Voice/</code>. No architecture or security posture changes. No new dependencies.</p>
+
+<h2>I believe this is finished</h2>
+<p>All four acceptance criteria are met by the implementation. The build is clean (0 errors, 0 new warnings). The UI is consistent with the existing dialog palette and with SpeakIntoTextboxDialog patterns.</p>
+</body>
+</html>

--- a/phone/CcDirectorClient/Platforms/Android/AndroidAudioCue.cs
+++ b/phone/CcDirectorClient/Platforms/Android/AndroidAudioCue.cs
@@ -1,57 +1,111 @@
 using Android.Media;
 using CcDirectorClient.Voice;
+using ATts = Android.Speech.Tts;
 
 namespace CcDirectorClient.Platforms.Android;
 
 /// <summary>
-/// Android audio cues for the voice recording flow. Uses <see cref="ToneGenerator"/>
-/// (no file assets, no extra permissions beyond MODIFY_AUDIO_SETTINGS which is normal
-/// for tone generation). All three methods are fire-and-forget: ToneGenerator.StartTone
-/// is synchronous but brief, so each call is dispatched onto a background thread via
-/// Task.Run to keep the UI thread free.
+/// Android audio cues for the voice recording flow.
+///
+/// Beep cues (Start/Stop/Error): ToneGenerator on a background thread - no permissions,
+/// no file assets, instant playback.
+///
+/// Status announcements (Sent/Reply): Android's on-device TextToSpeech - local, offline,
+/// no network call, no OpenAI timeout risk. Initialized lazily on first use.
+///
+/// Thinking sound: soft repeating beep every 3 seconds while the agent is working,
+/// cancelled by StopThinking(). Gives the user a "still alive" pulse without being
+/// intrusive.
 /// </summary>
-public sealed class AndroidAudioCue : IAudioCue
+public sealed class AndroidAudioCue : IAudioCue, IDisposable
 {
-    // ToneGenerator volume scale is 0..100; the Android binding exposes it as Android.Media.Volume
-    // (an enum over int). 80 is clearly audible without being jarring.
-    private const global::Android.Media.Volume ToneVolume = (global::Android.Media.Volume)80;
+    private const global::Android.Media.Volume ToneVolume  = (global::Android.Media.Volume)80;
+    private const global::Android.Media.Volume ThinkVolume = (global::Android.Media.Volume)40;
 
-    // Durations chosen for minimum perceptible confirmation while driving:
-    // start=150ms (distinctive short beep), stop=100ms (higher pitch, punchy), error=300ms (unmissable).
-    private const int StartMs = 150;
-    private const int StopMs  = 100;
-    private const int ErrorMs = 300;
+    private const int StartMs    = 150;
+    private const int StopMs     = 100;
+    private const int ErrorMs    = 300;
+    private const int ThinkMs    = 80;
+    private const int ThinkGapMs = 3000;
 
-    public void PlayStart()
+    private ATts.TextToSpeech? _tts;
+    private readonly object _ttsLock = new();
+    private bool _ttsReady;
+
+    private CancellationTokenSource? _thinkingCts;
+
+    // ===== recording beeps =================================================
+
+    public void PlayStart() => _ = Task.Run(() => PlayTone(Tone.PropBeep,  StartMs, ToneVolume));
+    public void PlayStop()  => _ = Task.Run(() => PlayTone(Tone.PropBeep2, StopMs,  ToneVolume));
+    public void PlayError() => _ = Task.Run(() => PlayTone(Tone.PropNack,  ErrorMs, ToneVolume));
+
+    // ===== status announcements (local TTS) ================================
+
+    public void PlaySent()  => SpeakPhrase("Sent");
+    public void PlayReply() => SpeakPhrase("Agent replied");
+
+    // ===== thinking sound ==================================================
+
+    public void StartThinking()
     {
-        // Beep (mid pitch) - recording started.
-        _ = Task.Run(() => PlayTone(Tone.PropBeep, StartMs));
+        _thinkingCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _thinkingCts = cts;
+        _ = Task.Run(async () =>
+        {
+            while (!cts.Token.IsCancellationRequested)
+            {
+                PlayTone(Tone.PropBeep, ThinkMs, ThinkVolume);
+                try { await Task.Delay(ThinkGapMs, cts.Token); }
+                catch (OperationCanceledException) { break; }
+            }
+        });
     }
 
-    public void PlayStop()
+    public void StopThinking()
     {
-        // Higher pitch beep - submitted successfully.
-        _ = Task.Run(() => PlayTone(Tone.PropBeep2, StopMs));
+        _thinkingCts?.Cancel();
+        _thinkingCts = null;
     }
 
-    public void PlayError()
+    // ===== internals =======================================================
+
+    private void SpeakPhrase(string text)
     {
-        // Negative acknowledgement tone - turn failed.
-        _ = Task.Run(() => PlayTone(Tone.PropNack, ErrorMs));
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                EnsureTts();
+                if (_ttsReady)
+                    _tts?.Speak(text, ATts.QueueMode.Flush, null, null);
+            }
+            catch (Exception ex)
+            {
+                ClientLog.Write($"[AndroidAudioCue] SpeakPhrase({text}) FAILED: {ex.Message}");
+            }
+        });
     }
 
-    private static void PlayTone(Tone tone, int durationMs)
+    private void EnsureTts()
+    {
+        lock (_ttsLock)
+        {
+            if (_tts != null) return;
+            var ctx = global::Android.App.Application.Context;
+            _tts = new ATts.TextToSpeech(ctx, new TtsInitListener(ready => _ttsReady = ready));
+        }
+    }
+
+    private static void PlayTone(Tone tone, int durationMs, global::Android.Media.Volume volume)
     {
         ToneGenerator? gen = null;
         try
         {
-            gen = new ToneGenerator(global::Android.Media.Stream.Notification, ToneVolume);
+            gen = new ToneGenerator(global::Android.Media.Stream.Notification, volume);
             gen.StartTone(tone, durationMs);
-            // Block the background thread for the duration so the generator is not
-            // disposed before the tone finishes. ToneGenerator.StartTone is async
-            // internally; the documented approach is to wait the duration or call
-            // StopTone, then release.
-            System.Threading.Thread.Sleep(durationMs + 50); // +50ms safety margin
+            System.Threading.Thread.Sleep(durationMs + 50);
             gen.StopTone();
         }
         catch (Exception ex)
@@ -63,5 +117,19 @@ public sealed class AndroidAudioCue : IAudioCue
             try { gen?.Release(); } catch { }
             try { gen?.Dispose(); } catch { }
         }
+    }
+
+    public void Dispose()
+    {
+        StopThinking();
+        try { _tts?.Shutdown(); } catch { }
+        _tts?.Dispose();
+    }
+
+    private sealed class TtsInitListener : Java.Lang.Object, ATts.TextToSpeech.IOnInitListener
+    {
+        private readonly Action<bool> _onReady;
+        public TtsInitListener(Action<bool> onReady) => _onReady = onReady;
+        public void OnInit(ATts.OperationResult status) => _onReady(status == ATts.OperationResult.Success);
     }
 }

--- a/phone/CcDirectorClient/TalkPage.xaml.cs
+++ b/phone/CcDirectorClient/TalkPage.xaml.cs
@@ -31,6 +31,7 @@ public partial class TalkPage : ContentPage
     private readonly IUtteranceRecorder _recorder;
     private readonly IReplySpeaker _tts;
     private readonly IVoiceForeground _foreground;
+    private readonly IAudioCue _audioCue;
 
     private SessionInfo? _selected;
 
@@ -56,12 +57,13 @@ public partial class TalkPage : ContentPage
     // Cancels the Wingman brief poll loop when the tab or page is left.
     private CancellationTokenSource? _wingmanPollCts;
 
-    public TalkPage(IUtteranceRecorder recorder, IReplySpeaker tts, IVoiceForeground foreground)
+    public TalkPage(IUtteranceRecorder recorder, IReplySpeaker tts, IVoiceForeground foreground, IAudioCue audioCue)
     {
         InitializeComponent();
         _recorder = recorder;
         _tts = tts;
         _foreground = foreground;
+        _audioCue = audioCue;
 
         var savedServer = Preferences.Get(PrefServer, "");
         if (string.IsNullOrWhiteSpace(savedServer))
@@ -477,13 +479,15 @@ public partial class TalkPage : ContentPage
                                 break;
                             case "thinking":
                                 VoiceStatusLabel.Text = "Thinking...";
+                                _audioCue.PlaySent();
+                                _audioCue.StartThinking();
                                 break;
                             case "summarizing":
                                 VoiceStatusLabel.Text = "Summarizing...";
                                 break;
                             case "reply":
-                                // Update the on-screen reply label only.
-                                // Status is updated by the "speaking" stage after summarization.
+                                _audioCue.StopThinking();
+                                _audioCue.PlayReply();
                                 VoiceReplyLabel.Text = u.Text;
                                 VoiceReplyCard.IsVisible = true;
                                 break;
@@ -520,6 +524,7 @@ public partial class TalkPage : ContentPage
         }
         finally
         {
+            _audioCue.StopThinking();
             _voiceTurnBusy = false;
             VoiceRecordButton.IsEnabled = true;
             _foreground.Stop();

--- a/phone/CcDirectorClient/Voice/IAudioCue.cs
+++ b/phone/CcDirectorClient/Voice/IAudioCue.cs
@@ -17,4 +17,16 @@ public interface IAudioCue
 
     /// <summary>Play the "error" cue (transcription or send failure).</summary>
     void PlayError();
+
+    /// <summary>Announce that text was sent to the agent (spoken via local TTS).</summary>
+    void PlaySent();
+
+    /// <summary>Announce that the agent reply has arrived (spoken via local TTS).</summary>
+    void PlayReply();
+
+    /// <summary>Start a soft repeating "thinking" ambient sound while the agent is working.</summary>
+    void StartThinking();
+
+    /// <summary>Stop the thinking sound started by <see cref="StartThinking"/>.</summary>
+    void StopThinking();
 }

--- a/phone/CcDirectorClient/Voice/NullAudioCue.cs
+++ b/phone/CcDirectorClient/Voice/NullAudioCue.cs
@@ -6,7 +6,11 @@ namespace CcDirectorClient.Voice;
 /// </summary>
 public sealed class NullAudioCue : IAudioCue
 {
-    public void PlayStart()  { }
-    public void PlayStop()   { }
-    public void PlayError()  { }
+    public void PlayStart()      { }
+    public void PlayStop()       { }
+    public void PlayError()      { }
+    public void PlaySent()       { }
+    public void PlayReply()      { }
+    public void StartThinking()  { }
+    public void StopThinking()   { }
 }

--- a/phone/CcDirectorClient/Voice/VoiceDictationDialog.xaml
+++ b/phone/CcDirectorClient/Voice/VoiceDictationDialog.xaml
@@ -10,7 +10,13 @@
     <!-- Voice-mode dictation dialog (Mode A). Used everywhere the user is already in
          voice mode (FIFO Ask Agent / Ask Wingman). Stripped to the bone for glance /
          driving use: bouncing bars to confirm the mic is hot, a big SUBMIT, a big
-         CANCEL. No timer, no transcript, no other controls.
+         CANCEL. No transcript, no other controls.
+
+         Added indicators (issue #347):
+           - Elapsed m:ss timer (top-right) so the user can see how long they have talked.
+           - Large RECORDING label (red, 24pt) that flips to Recorded (green) on SUBMIT.
+           - Pulsing red dot at ~1 Hz: a glance-able "alive" signal beyond the bars.
+           - Amber "Speak up" hint when mic input is present but too quiet for >2 seconds.
 
          The Page background is a semi-transparent black so the page underneath
          shows through as a dimmed backdrop - the dialog itself is the centred card
@@ -23,9 +29,59 @@
                 StrokeShape="RoundRectangle 18"
                 Padding="24,28" WidthRequest="320">
 
-            <VerticalStackLayout Spacing="22" HorizontalOptions="Center">
+            <VerticalStackLayout Spacing="16" HorizontalOptions="Center">
+
+                <!-- Top row: pulsing dot (left) + state label (centre) + timer (right) -->
+                <Grid ColumnDefinitions="Auto,*,Auto" VerticalOptions="Center">
+
+                    <!-- Pulsing dot: 1 Hz on/off during recording, hidden after SUBMIT/CANCEL.
+                         Sized so it is visible from a driving distance. -->
+                    <BoxView x:Name="PulseDot"
+                             Grid.Column="0"
+                             WidthRequest="16" HeightRequest="16"
+                             CornerRadius="8"
+                             Color="#F44747"
+                             VerticalOptions="Center"
+                             Margin="0,0,8,0" />
+
+                    <!-- RECORDING / Recorded label.
+                         Red while capturing, switches to green text "Recorded" on SUBMIT.
+                         FontSize >= 22 per spec so it is readable at a glance / while driving. -->
+                    <Label x:Name="RecordingLabel"
+                           Grid.Column="1"
+                           Text="RECORDING"
+                           FontSize="24"
+                           FontAttributes="Bold"
+                           TextColor="#F44747"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center" />
+
+                    <!-- Elapsed timer. Same m:ss format as SpeakIntoTextboxDialog.
+                         Subdued color (matches SpeakIntoTextboxDialog) - for orientation only. -->
+                    <Label x:Name="TimerLabel"
+                           Grid.Column="2"
+                           Text="0:00"
+                           FontFamily="Consolas"
+                           FontSize="14"
+                           TextColor="#8A93A6"
+                           HorizontalOptions="End"
+                           VerticalOptions="Center"
+                           Margin="8,0,0,0" />
+                </Grid>
 
                 <voice:BouncingBarsView x:Name="Bars" HorizontalOptions="Center" />
+
+                <!-- Speak-up hint. Amber label shown only when input level has been
+                     below the voice-present threshold for more than 2 seconds.
+                     MinimumHeightRequest reserves a row so the layout does not jump. -->
+                <Label x:Name="LevelHintLabel"
+                       Text=""
+                       FontSize="13"
+                       TextColor="#D97706"
+                       HorizontalOptions="Center"
+                       HorizontalTextAlignment="Center"
+                       MinimumHeightRequest="18"
+                       IsVisible="False" />
 
                 <Button x:Name="SubmitButton" Text="SUBMIT"
                         BackgroundColor="#5FD08A" TextColor="#06210F"

--- a/phone/CcDirectorClient/Voice/VoiceDictationDialog.xaml.cs
+++ b/phone/CcDirectorClient/Voice/VoiceDictationDialog.xaml.cs
@@ -8,12 +8,35 @@ namespace CcDirectorClient.Voice;
 /// dims into a backdrop and the centred card looks like a dialog rather than a
 /// new screen. The bouncing-bars equaliser runs while the mic is recording so
 /// the user has a constant visual that the mic is hearing them.
+///
+/// Issue #347 additions:
+///   - Elapsed m:ss timer, 100 ms ticks, starts when recording starts.
+///   - RECORDING label (red, 24pt) -> "Recorded" (green) on SUBMIT.
+///   - Pulsing red dot at ~1 Hz during recording.
+///   - Amber "Speak up" hint when mic level is below VoicePresentLevel for > 2 s.
 /// </summary>
 public partial class VoiceDictationDialog : ContentPage
 {
+    private static readonly TimeSpan TimerInterval  = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan PulseInterval  = TimeSpan.FromMilliseconds(500);
+
+    // ReadLevel() returns 0..1. Below this threshold and the mic is considered
+    // silent / too quiet for clean capture (mirrors the desktop VoicePresentRms
+    // threshold: desktop uses 20.0 / 32767 raw int16, mobile maps to ~0.025 on
+    // the sqrt-scaled 0..1 range: sqrt(20/32767) ~ 0.025).
+    private const double VoicePresentLevel = 0.025;
+    // How long the level must stay below VoicePresentLevel before the hint fires.
+    private static readonly TimeSpan LowLevelGracePeriod = TimeSpan.FromSeconds(2);
+
     private readonly IUtteranceRecorder _recorder;
     private readonly TaskCompletionSource<UtteranceAudio?> _tcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private IDispatcherTimer? _timer;
+    private IDispatcherTimer? _pulseTimer;
+    private DateTime _startedUtc;
+    private DateTime? _lowLevelSince;
+    private bool _pulseVisible;
 
     // Guards against the user double-tapping SUBMIT (or the OS firing an extra
     // Disappearing after a button click). The mic is stopped exactly once and
@@ -53,6 +76,23 @@ public partial class VoiceDictationDialog : ContentPage
             if (!_recorder.IsRecording)
                 await _recorder.StartAsync();
             Bars.Start(_recorder);
+
+            // Start elapsed timer.
+            _startedUtc = DateTime.UtcNow;
+            TimerLabel.Text = "0:00";
+            _timer = Dispatcher.CreateTimer();
+            _timer.Interval = TimerInterval;
+            _timer.Tick += OnTimerTick;
+            _timer.Start();
+
+            // Start pulsing dot.
+            _pulseVisible = true;
+            PulseDot.Opacity = 1.0;
+            _pulseTimer = Dispatcher.CreateTimer();
+            _pulseTimer.Interval = PulseInterval;
+            _pulseTimer.Tick += OnPulseTick;
+            _pulseTimer.Start();
+
             ClientLog.Write("[VoiceDictationDialog] mic on");
         }
         catch (Exception ex)
@@ -67,13 +107,64 @@ public partial class VoiceDictationDialog : ContentPage
 
     protected override void OnDisappearing()
     {
+        StopTimers();
         Bars.Stop();
         base.OnDisappearing();
+    }
+
+    private void OnTimerTick(object? sender, EventArgs e)
+    {
+        // Update elapsed label.
+        var elapsed = DateTime.UtcNow - _startedUtc;
+        if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+        if (elapsed.TotalMinutes >= 100) elapsed = TimeSpan.FromMinutes(99) + TimeSpan.FromSeconds(59);
+        TimerLabel.Text = elapsed.ToString(@"m\:ss");
+
+        // Level-hint tracking: sample the recorder once per 100 ms tick.
+        // The hint fires when input has been continuously below VoicePresentLevel
+        // for at least LowLevelGracePeriod - enough time to distinguish a brief
+        // silent pause from genuinely inaudible input.
+        if (!_resolved)
+        {
+            var level = _recorder.ReadLevel();
+            if (level < VoicePresentLevel)
+            {
+                // Level is low: start (or keep) tracking the quiet stretch.
+                _lowLevelSince ??= DateTime.UtcNow;
+
+                if (DateTime.UtcNow - _lowLevelSince.Value >= LowLevelGracePeriod)
+                {
+                    LevelHintLabel.Text = "Speak up or move closer to the mic";
+                    LevelHintLabel.IsVisible = true;
+                }
+            }
+            else
+            {
+                // Level is healthy: reset the quiet-streak tracker and hide the hint.
+                _lowLevelSince = null;
+                LevelHintLabel.Text = "";
+                LevelHintLabel.IsVisible = false;
+            }
+        }
+    }
+
+    private void OnPulseTick(object? sender, EventArgs e)
+    {
+        _pulseVisible = !_pulseVisible;
+        PulseDot.Opacity = _pulseVisible ? 1.0 : 0.0;
     }
 
     private async void OnSubmitClicked(object? sender, EventArgs e)
     {
         ClientLog.Write("[VoiceDictationDialog] SUBMIT");
+
+        // Transition label to "Recorded" immediately so the user gets instant
+        // visual confirmation that the clip was accepted.
+        RecordingLabel.Text = "Recorded";
+        RecordingLabel.TextColor = Color.FromArgb("#5FD08A");
+        PulseDot.IsVisible = false;
+        LevelHintLabel.IsVisible = false;
+
         UtteranceAudio? audio = null;
         try
         {
@@ -112,8 +203,25 @@ public partial class VoiceDictationDialog : ContentPage
     {
         if (_resolved) return;
         _resolved = true;
+        StopTimers();
         _tcs.TrySetResult(audio);
         try { await Navigation.PopModalAsync(animated: false); }
         catch (Exception ex) { ClientLog.Write($"[VoiceDictationDialog] PopModalAsync FAILED: {ex.Message}"); }
+    }
+
+    private void StopTimers()
+    {
+        if (_timer is not null)
+        {
+            _timer.Tick -= OnTimerTick;
+            _timer.Stop();
+            _timer = null;
+        }
+        if (_pulseTimer is not null)
+        {
+            _pulseTimer.Tick -= OnPulseTick;
+            _pulseTimer.Stop();
+            _pulseTimer = null;
+        }
     }
 }

--- a/src/CcDirector.Core/Voice/TtsService.cs
+++ b/src/CcDirector.Core/Voice/TtsService.cs
@@ -65,7 +65,7 @@ public sealed class TtsService
 
         try
         {
-            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(180) };
             http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
 
             // Single-chunk fast path: no parallelism overhead.


### PR DESCRIPTION
## Summary

- **Issue #347**: VoiceDictationDialog now shows elapsed timer, RECORDING label (red during capture, green on submit), pulsing dot at ~1 Hz, and amber speak-up hint after 2s of low mic level
- **Status audio cues**: device local TTS speaks "Sent" when text lands with agent, "Agent replied" when reply arrives (no network/OpenAI call)
- **Thinking sound**: soft beep every 3s while agent is working so user knows it's alive
- **TTS timeout**: raised 60s -> 180s to fix 500 errors on long agent replies

## Test plan
- [ ] Tap Record, verify RECORDING label + pulsing dot + timer visible
- [ ] Send a voice message, hear "Sent" spoken, then soft beeps while waiting
- [ ] Hear "Agent replied" when reply arrives, then the spoken reply
- [ ] Confirm no 500 timeout errors on long replies

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>