### PR TITLE
feat: keep screen alive over lock screen during voice mode (driving)

### DIFF
--- a/phone/CcDirectorClient/Platforms/Android/AndroidVoiceForeground.cs
+++ b/phone/CcDirectorClient/Platforms/Android/AndroidVoiceForeground.cs
@@ -1,4 +1,5 @@
 using Android.Content;
+using Android.Views;
 using CcDirectorClient.Voice;
 using AndroidApp = Android.App.Application;
 
@@ -8,6 +9,19 @@ namespace CcDirectorClient.Platforms.Android;
 /// Android implementation of <see cref="IVoiceForeground"/>: starts and stops the
 /// <see cref="VoiceForegroundService"/> so the voice round-trip and TTS survive
 /// backgrounding and screen-off.
+///
+/// Also manages the driving-mode window flags so the screen stays on and the app
+/// shows over the lock screen while voice is active (same approach as Waze / Maps):
+///   - FLAG_KEEP_SCREEN_ON  — already set by TalkPage via DeviceDisplay.KeepScreenOn;
+///     we don't duplicate it here.
+///   - SetShowWhenLocked(true) + SetTurnScreenOn(true) (API 27+) — shows the app on
+///     top of the lock screen and wakes the display when a turn arrives, so a glance
+///     at the phone in a car mount is enough. Cleared in Stop() so the lock screen
+///     resumes normal behaviour after voice mode ends.
+///   - FLAG_SHOW_WHEN_LOCKED + FLAG_TURN_SCREEN_ON (API 24-26) — same intent via the
+///     older deprecated window-flag path for devices that don't have the API 27 methods.
+///
+/// Both paths require no additional permissions.
 /// </summary>
 public sealed class AndroidVoiceForeground : IVoiceForeground
 {
@@ -29,6 +43,7 @@ public sealed class AndroidVoiceForeground : IVoiceForeground
             IsActive = true;
             ClientLog.Write("[AndroidVoiceForeground] started");
         }
+        SetDrivingFlags(true);
     }
 
     public void Stop()
@@ -41,5 +56,45 @@ public sealed class AndroidVoiceForeground : IVoiceForeground
             IsActive = false;
             ClientLog.Write("[AndroidVoiceForeground] stopped");
         }
+        SetDrivingFlags(false);
+    }
+
+    // ===== lock-screen bypass =============================================
+
+    private static void SetDrivingFlags(bool enable)
+    {
+        // Window flag changes must happen on the UI thread.
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            try
+            {
+                var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+                if (activity is null) return;
+
+                if (OperatingSystem.IsAndroidVersionAtLeast(27))
+                {
+                    // API 27+: clean, non-deprecated path.
+                    activity.SetShowWhenLocked(enable);
+                    activity.SetTurnScreenOn(enable);
+                }
+                else
+                {
+                    // API 24-26: older window-flag path (deprecated at 27 but still works).
+                    const WindowManagerFlags flags =
+                        WindowManagerFlags.ShowWhenLocked |
+                        WindowManagerFlags.TurnScreenOn;
+                    if (enable)
+                        activity.Window?.AddFlags(flags);
+                    else
+                        activity.Window?.ClearFlags(flags);
+                }
+
+                ClientLog.Write($"[AndroidVoiceForeground] driving flags {(enable ? "ON" : "OFF")}");
+            }
+            catch (Exception ex)
+            {
+                ClientLog.Write($"[AndroidVoiceForeground] SetDrivingFlags({enable}) FAILED: {ex.Message}");
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary

Extends `AndroidVoiceForeground.Start()`/`Stop()` to apply driving-mode window flags while voice is active:

- **API 27+**: `SetShowWhenLocked(true)` + `SetTurnScreenOn(true)` — the recommended path
- **API 24-26**: `FLAG_SHOW_WHEN_LOCKED` + `FLAG_TURN_SCREEN_ON` window flags — deprecated at 27 but still functional

Combined with the existing `DeviceDisplay.KeepScreenOn = true` in TalkPage, the phone now behaves like a car mount app: screen stays on, app shows over the lock screen, and the screen wakes up if it did turn off. No new permissions required.

Flags are cleared in `Stop()` so normal lock behaviour resumes once voice mode ends.

## Test plan
- [ ] Start a voice turn - screen stays on indefinitely (no timeout)
- [ ] If lock screen activates, app shows on top of it (no PIN needed to see the UI)
- [ ] After voice ends, lock screen returns to normal behaviour