### PR TITLE
fix: stop forcing WingmanEnabled=true on voice mode entry

### DIFF
--- a/phone/CcDirectorClient/Controls/VoiceSessionView.xaml.cs
+++ b/phone/CcDirectorClient/Controls/VoiceSessionView.xaml.cs
@@ -221,10 +221,6 @@ public partial class VoiceSessionView : ContentView
         var voiceClient = new DirectorVoiceClient(_tokenProvider());
         _ = voiceClient.SetVoiceModeAsync(session.TailnetEndpoint, session.SessionId, true);
 
-        // Walkie-talkie mode requires the wingman for reply summarization: ensure it is
-        // active for this session regardless of the gateway's default. Best-effort.
-        if (WalkieTalkieMode)
-            _ = voiceClient.SetWingmanEnabledAsync(session.TailnetEndpoint, session.SessionId, true);
 
         SetBusy(false);
 

--- a/phone/CcDirectorClient/TalkPage.xaml.cs
+++ b/phone/CcDirectorClient/TalkPage.xaml.cs
@@ -495,11 +495,6 @@ public partial class TalkPage : ContentPage
         _voiceTurnBusy = true;
         VoiceRecordButton.IsEnabled = false;
 
-        // Ensure the wingman is active for this session - voice mode requires it for
-        // reply summarization, regardless of the gateway default. Best-effort.
-        _ = new DirectorVoiceClient(TokenEntry.Text ?? "")
-            .SetWingmanEnabledAsync(session.TailnetEndpoint, session.SessionId, true);
-
         var convo = new VoiceConversation(new DirectorVoiceClient(TokenEntry.Text ?? ""), _tts);
         _voiceTurnCts?.Cancel();
         _voiceTurnCts = new CancellationTokenSource();

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -344,23 +344,7 @@ internal static class ControlEndpoints
             var wasVoice = session.VoiceMode;
             session.ViewMode = enabled ? MobileViewMode.Voice : MobileViewMode.Text;
 
-            if (enabled && !wasVoice)
-            {
-                // Entering voice mode: capture the prior WingmanEnabled state so we can
-                // restore it when voice mode ends, then force the wingman ON - voice mode
-                // requires it for reply summarization regardless of the gateway default.
-                session.PreVoiceWingmanEnabled = session.WingmanEnabled;
-                session.WingmanEnabled = true;
-                FileLog.Write($"[ControlEndpoints] /voice-mode: session={guid} entering voice mode, wingman forced ON (was {session.PreVoiceWingmanEnabled})");
-            }
-            else if (!enabled && wasVoice && session.PreVoiceWingmanEnabled.HasValue)
-            {
-                // Leaving voice mode: restore the wingman to whatever the user had it set
-                // to before voice mode was entered.
-                session.WingmanEnabled = session.PreVoiceWingmanEnabled.Value;
-                session.PreVoiceWingmanEnabled = null;
-                FileLog.Write($"[ControlEndpoints] /voice-mode: session={guid} leaving voice mode, wingman restored to {session.WingmanEnabled}");
-            }
+            FileLog.Write($"[ControlEndpoints] /voice-mode: session={guid} entering={enabled}, wingmanEnabled unchanged ({session.WingmanEnabled})");
 
             FileLog.Write($"[ControlEndpoints] /voice-mode: session={guid} enabled={enabled} viewMode={session.ViewMode}");
             proactiveExplain?.TriggerBackgroundExplain(session);


### PR DESCRIPTION
Removes three places that silently set WingmanEnabled=true whenever voice mode started. WingmanEnabled stays false by default as designed.