### PR TITLE
feat(#374): route Director-scoped Cockpit calls through the Gateway (slice 3 of #372)

### DIFF
--- a/docs/cencon/proof/issue-374/qa-report.html
+++ b/docs/cencon/proof/issue-374/qa-report.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Report - Issue #374 / PR #375</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 1100px; color: #1b2733; line-height: 1.5; }
+  h1 { font-size: 1.5rem; border-bottom: 3px solid #0b6e4f; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; color: #0b3d5c; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .92rem; }
+  th, td { border: 1px solid #c8d1da; padding: .45rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #eef3f7; }
+  .pass { background: #e6f4ea; color: #137333; font-weight: 600; white-space: nowrap; }
+  .verdict { font-size: 1.2rem; font-weight: 700; color: #137333; background: #e6f4ea; border: 2px solid #137333; padding: .6rem 1rem; display: inline-block; margin: 1rem 0; }
+  code, pre { font-family: Consolas, monospace; background: #f4f6f8; border-radius: 3px; }
+  code { padding: 0 .25rem; }
+  pre { padding: .7rem; overflow-x: auto; border: 1px solid #dde4ea; font-size: .82rem; }
+  .meta td:first-child { font-weight: 600; width: 220px; }
+  .note { background: #fff8e6; border-left: 4px solid #c9a227; padding: .5rem .8rem; margin: .6rem 0; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>QA Verification Report - Issue #374 (PR #375)</h1>
+
+<table class="meta">
+  <tr><td>Issue</td><td>#374 - #372 slice 3: route Director-scoped Cockpit calls (screenshots list/delete, settings, fanout) through the Gateway</td></tr>
+  <tr><td>PR / branch / commit</td><td>#375 / <code>374-slice3-director-scoped-via-gateway</code> / <code>6be4fd8</code></td></tr>
+  <tr><td>QA identity</td><td>Independent QA Agent (CenCon method). Did NOT write the code; verified from a fresh detached worktree at the PR commit.</td></tr>
+  <tr><td>Date</td><td>2026-06-12</td></tr>
+  <tr><td>Build</td><td><code>CcDirector.Cockpit</code>, <code>CcDirector.Gateway</code>, <code>CcDirector.Gateway.Tests</code> all built from the worktree at 6be4fd8: <strong>0 warnings, 0 errors</strong> each.</td></tr>
+  <tr><td>Test run (QA-run, not dev-claimed)</td><td><code>dotnet test --filter "SessionHttpProxyRoundTripTests|SessionWsProxyEndpointsTests|ScreenshotProxyRoundTripTests|BrowserPageRoutesTests"</code> = <strong>Passed 44, Failed 0, Skipped 0</strong> (11 s). Includes the 4 new slice-3 round-trip tests.</td></tr>
+</table>
+
+<div class="verdict">VERDICT: PASS - 6/6 acceptance criteria verified independently</div>
+
+<h2>Criterion-by-criterion</h2>
+<table>
+  <tr><th style="width:42%">Acceptance criterion (from issue #374)</th><th style="width:7%">Result</th><th>Expected vs Actual (QA evidence)</th></tr>
+
+  <tr>
+    <td><strong>AC1.</strong> <code>DirectorClient</code> contains no method taking a Director base URL; no <code>TailnetEndpoint</code>/<code>ControlEndpoint</code> used as an HTTP base anywhere in the Cockpit (display-only references fine).</td>
+    <td class="pass">PASS</td>
+    <td><em>Expected:</em> zero HTTP-base usages. <em>Actual:</em> grep of <code>src/CcDirector.Cockpit/</code> at 6be4fd8: no <code>directorBase</code> parameter remains; the absolute-URL helper <code>Url(directorBase, path)</code> is deleted; the only <code>new Uri(...)</code> calls are the Gateway/GitHub BaseAddress in <code>Program.cs</code>. All 15 remaining <code>TailnetEndpoint/ControlEndpoint</code> hits judged individually: 4 log-format args (Cockpit.razor 1306/1681/2301/2475), 1 clipboard handover text (2160), display rows on DirectorDetail/Directors/SessionDetail pages, and comments. None is dialed.</td>
+  </tr>
+
+  <tr>
+    <td><strong>AC2.</strong> <code>GET /sessions/{sid}/screenshots?count=N</code> returns the owning Director's screenshot metadata; <code>DELETE /sessions/{sid}/screenshots/file?name=...</code> forwards as DELETE.</td>
+    <td class="pass">PASS</td>
+    <td><em>Expected:</em> list forwards to Director machine-wide <code>/screenshots</code> with count carried; delete forwards method+name. <em>Actual (tests, QA-run):</em> <code>Screenshot_list_forwards_to_the_directors_machine_wide_screenshots</code> asserts stub Director saw <code>GET /screenshots?count=5</code>; <code>Screenshot_delete_forwards_as_DELETE_to_the_directors_screenshots_file</code> asserts <code>DELETE /screenshots/file?name=a b.png</code> (URL-encoded name decoded correctly). <em>Actual (live, read-only):</em> <code>GET 127.0.0.1:7878/sessions/c7f2f2e0.../screenshots?count=2</code> = 200 with <code>total: 1871</code> and exactly 2 items from the real screenshots folder. Gateway log shows <code>leg=shots ... query=?count=2 ... resolved director=c99a103c... -&gt; http://127.0.0.1:7883/screenshots</code>. DELETE deliberately NOT live-fired (real folder).</td>
+  </tr>
+
+  <tr>
+    <td><strong>AC3.</strong> <code>GET</code>/<code>PUT /directors/{id}/settings</code> round-trips to that Director's <code>/settings</code>; unknown Director id is 404.</td>
+    <td class="pass">PASS</td>
+    <td><em>Expected:</em> registry lookup by id, forward to <code>/settings</code>, 404 unknown. <em>Actual (tests, QA-run):</em> <code>Director_settings_round_trip_by_director_id</code> asserts GET body <code>{"voice":{}}</code> with stub seeing <code>GET /settings</code>, and PUT body forwarded verbatim (<code>PUT /settings {"voice":{"rate":2}}</code>); <code>Unknown_director_id_is_404_for_settings</code> = 404. <em>Actual (live, read-only):</em> <code>GET 127.0.0.1:7878/directors/c99a103c.../settings</code> = 200 real settings JSON (alpha_mode, screenshots.source_directory, ...); <code>GET /directors/no-such-id/settings</code> = 404 <code>{"error":"no such director"}</code>. Log shows <code>leg=dirsettings director=c99a103c... method=GET</code> and <code>leg=dirsettings director=no-such-id</code> for both probes. PUT verified by test only (no live settings write against the production fleet).</td>
+  </tr>
+
+  <tr>
+    <td><strong>AC4.</strong> <code>DoFanout</code> makes one Gateway <code>/fanout</code> call (no per-Director grouping, no <code>TailnetEndpoint</code> filter on the selection list).</td>
+    <td class="pass">PASS</td>
+    <td><em>Expected:</em> single fleet-wide call. <em>Actual (code review at 6be4fd8; live fanout deliberately NOT fired per constraint):</em> <code>DoFanout</code> body is <code>var ids = _fanoutSelected.ToList(); var resp = await Director.FanoutAsync(ids, _fanoutText, _cts.Token);</code> - the GroupBy(TailnetEndpoint) loop is deleted. Dialog list is <code>@foreach (var s in _sessions)</code> with no endpoint filter; <code>OpenFanout</code> pre-selects the selected session without an endpoint check. <code>FanoutAsync</code> posts <code>{ sessionIds, text, appendEnter = true, waitForIdle = false }</code> to relative <code>"fanout"</code> = the Gateway's pre-existing <code>POST /fanout</code> (GatewayEndpoints.cs:1202), whose <code>FanoutRequest</code> contract carries exactly those fields; the response is deserialized into the SAME shared <code>CcDirector.Gateway.Contracts.FanoutResponse</code> type the Gateway serializes, so shapes match by construction.</td>
+  </tr>
+
+  <tr>
+    <td><strong>AC5.</strong> A session whose <code>TailnetEndpoint</code> is blank renders the full detail pane (no dead-end branch) and its handlers do not early-return.</td>
+    <td class="pass">PASS</td>
+    <td><em>Expected:</em> dead-end branch gone, no blank-endpoint early returns. <em>Actual (code review at 6be4fd8):</em> the <code>else if (string.IsNullOrWhiteSpace(Selected.TailnetEndpoint))</code> "no tailnet endpoint" pane is removed from Cockpit.razor's center pane; the render path goes straight from "no selection" to the full detail head. All ~17 handlers (SendNow, QueueIt, SendQueued, RemoveQueued, MoveQueuedUp/Down, ClearQueue, PopQueued, SaveEditQueue, Interrupt, Escape, ClearContext, ShowHistory, OnDropImages, OpenDictate, LoadScreenshots, DeleteScreenshot, LoadWingman, SendBriefFeedback, QuickReply, SaveRename, CloseSelectedFromBrief, KillSelected, OpenAwareness, GenerateRecap, OpenHandover) now guard only on <code>Selected is null</code> - zero <code>string.IsNullOrWhiteSpace(dir)</code> early-returns remain. The kebab guard with <code>ShowRailNotice("no reachable Director endpoint")</code> is gone; <code>SessionDetail.razor</code>'s two "Unavailable (no Director endpoint)" branches are gone. Corroboration that the blank-endpoint case is real and works: ALL live local Directors register with <code>tailnetEndpoint: null</code>, and the live Gateway resolved and served their sessions' legs in this verification.</td>
+  </tr>
+
+  <tr>
+    <td><strong>AC6.</strong> Route precedence intact: explicit WS/stream/dictate/screenshot routes and browser pages still win over the catch-all (existing test suites green).</td>
+    <td class="pass">PASS</td>
+    <td><em>Expected:</em> all 4 suites green. <em>Actual (QA-run):</em> 44/44 passed across <code>SessionHttpProxyRoundTripTests</code> + <code>SessionWsProxyEndpointsTests</code> + <code>ScreenshotProxyRoundTripTests</code> + <code>BrowserPageRoutesTests</code>. Precedence reasoning checked by hand: ASP.NET literal segments beat the <code>{**rest}</code> catch-all, so the new <code>GET /sessions/{sid}/screenshots</code> wins for GET (proven: the test's forward landed on the Director's <code>/screenshots</code>, not <code>/sessions/{sid}/screenshots</code>); <code>/directors/{id}/settings</code> shares no template with any GatewayEndpoints route (closest are <code>/directors/{id}/repos|facts|events|...</code> - all different literals); the browser-page middleware only intercepts GET+text/html paths of 1-2 segments, so the new 3-segment API routes are untouched.</td>
+  </tr>
+</table>
+
+<h2>Adversarial review findings (none blocking)</h2>
+<table>
+  <tr><th style="width:32%">Question</th><th>Finding</th></tr>
+  <tr>
+    <td>Screenshots-file route changed <code>MapGet</code> to <code>Map</code> (any method) - safe?</td>
+    <td>Safe. No other route exists at that template, so nothing is shadowed. Side effect: a POST/PUT to <code>/sessions/{sid}/screenshots/file</code> now forwards to the Director's <code>/screenshots/file</code> with that method instead of the catch-all path - the Director rejects unsupported methods either way, and the surface sits behind the same Gateway auth middleware (mapped after <code>AuthMiddleware</code> when <code>AuthEnabled</code>).</td>
+  </tr>
+  <tr>
+    <td><code>/directors/{id}/settings</code> is <code>Map</code> (any method) - does a stray POST/DELETE do damage?</td>
+    <td>It forwards the method to the Director's <code>/settings</code>, which only maps GET/PUT - other verbs 404/405 on the Director. Equivalent posture to the pre-existing session catch-all. Behind the same auth gate.</td>
+  </tr>
+  <tr>
+    <td>Registration order: <code>dirsettings</code> is mapped after the session catch-all - order dependency?</td>
+    <td>None. ASP.NET endpoint routing is precedence-based, not registration-order-based, and <code>/directors/...</code> shares no overlap with <code>/sessions/...</code> templates.</td>
+  </tr>
+  <tr>
+    <td>Were any removed <code>TailnetEndpoint</code> guards load-bearing beyond the endpoint check?</td>
+    <td>No. Each removed guard was purely "is the Director's address non-blank" - a reachability proxy that the Gateway now owns (404 unknown / 503 unreachable with a message the Cockpit's <code>Act()</code> error banner surfaces). The <code>Selected is null</code> half of every guard is retained. The removed blank-terminal WARNINGs (issue #199) documented a failure mode that no longer exists; <code>RowState</code> is still carried into TerminalPane connect logging.</td>
+  </tr>
+  <tr>
+    <td>Error semantics regression?</td>
+    <td>None found. <code>dirsettings</code>: 404 unknown id, 503 no-endpoint, 503 forwarder-error guarded by <code>!ctx.Response.HasStarted</code> - identical to the session legs. Settings page now reports "no Director selected" instead of the misleading "no reachable endpoint" for the empty-id case.</td>
+  </tr>
+  <tr>
+    <td>Relative-URI resolution of the new <code>sessions/{sid}/screenshots</code> / <code>directors/{id}/settings</code> paths against BaseAddress?</td>
+    <td>Same pattern as every pre-existing session-scoped call (<code>sessions/{sid}/git</code> etc.) that already works in production; live probes through port 7878 confirm resolution end-to-end.</td>
+  </tr>
+</table>
+
+<h2>Live corroboration trace (read-only, production Gateway pid 9568 port 7878)</h2>
+<pre>GET /directors                                      -> 200 (3 directors; local ones have tailnetEndpoint: null)
+GET /directors/c99a103c-.../settings                -> 200 real settings JSON
+GET /directors/no-such-id/settings                  -> 404 {"error":"no such director"}
+GET /sessions/c7f2f2e0-.../screenshots?count=2      -> 200 {"directory":"D:\\...\\Screenshots","total":1871,"items":[2 items]}
+
+Gateway log (director-2026-06-12-9568.log), QA's own probes visible:
+16:46:03.997 [SessionWsProxy] open leg=dirsettings director=c99a103c-... method=GET client=127.0.0.1
+16:46:06.349 [SessionWsProxy] open leg=dirsettings director=no-such-id method=GET client=127.0.0.1
+16:46:15.532 [SessionWsProxy] open leg=shots sid=c7f2f2e0-... query=?count=2 client=127.0.0.1
+16:46:15.566 [SessionWsProxy] leg=shots sid=c7f2f2e0-... resolved director=c99a103c-... -> http://127.0.0.1:7883/screenshots
+16:46:15.567 [SessionWsProxy] close leg=shots sid=c7f2f2e0-... director=c99a103c-...</pre>
+
+<div class="note">Per the QA constraints: fanout was NOT live-fired (it prompts real sessions), DELETE was NOT fired at the real screenshots folder, and settings PUT was NOT written to a production Director. Those legs are covered by the QA-run round-trip suite against an isolated GatewayHost with a stub Director.</div>
+
+<p><em>Standalone QA: verdict is flow:done; merge is a human decision.</em></p>
+
+</body>
+</html>

--- a/src/CcDirector.Cockpit/Components/BriefPane.razor
+++ b/src/CcDirector.Cockpit/Components/BriefPane.razor
@@ -410,7 +410,6 @@
 
 @code {
     [Parameter] public string SessionId { get; set; } = "";
-    [Parameter] public string DirectorBase { get; set; } = "";
     [Parameter] public string ActivityState { get; set; } = "";
     /// <summary>"None"|"Briefing"|"Briefed"|"Failed" from the roster poll - drives the
     /// yellow "wingman reading" window and the refresh-on-Briefed reload.</summary>

--- a/src/CcDirector.Cockpit/Components/Pages/Cockpit.razor
+++ b/src/CcDirector.Cockpit/Components/Pages/Cockpit.razor
@@ -95,17 +95,9 @@
                     <div class="right-empty-sub">Pick a session on the left to drive it: live terminal, screenshots, queue, and the composer.</div>
                 </div>
             }
-            else if (string.IsNullOrWhiteSpace(Selected.TailnetEndpoint))
-            {
-                <div class="detail-head">
-                    <span class="detail-dot" style="background:@DotColor(SessionOrdering.EffectiveColor(Selected))"></span>
-                    <span class="detail-name">@SessionTitle(Selected)</span>
-                    <span class="detail-state">@(Selected.AssessedState ?? Selected.ActivityState)</span>
-                </div>
-                <div class="right-empty">
-                    <div class="right-empty-sub">This session's Director has no tailnet endpoint, so it can't be driven over Tailscale. (Restart that Director with the current build so it registers a reachable https endpoint.)</div>
-                </div>
-            }
+            @* Issue #372: the old "no tailnet endpoint" dead-end branch is gone - every session
+               leg (terminal WS, screenshots, REST verbs) rides same-origin through the Gateway
+               now, so a loopback-only Director is fully drivable. *@
             else
             {
                 <div class="detail-head">
@@ -191,7 +183,7 @@
                             @* Lazy: the stream socket only opens when the Terminal tab is opened,
                                so flipping through briefs never pays the replay cost. *@
                             <div class="term-wrap">
-                                <TerminalPane @key="Selected.SessionId" SessionId="@Selected.SessionId" DirectorBase="@Selected.TailnetEndpoint" RowState="@(Selected.AssessedState ?? Selected.ActivityState)" />
+                                <TerminalPane @key="Selected.SessionId" SessionId="@Selected.SessionId" RowState="@(Selected.AssessedState ?? Selected.ActivityState)" />
                             </div>
                         }
                         else if (_wingmanEnabled)
@@ -213,7 +205,6 @@
                                         </div>
                                     }
                                     <BriefPane @key="Selected.SessionId" SessionId="@Selected.SessionId"
-                                               DirectorBase="@Selected.TailnetEndpoint"
                                                ActivityState="@Selected.ActivityState"
                                                BriefingState="@Selected.BriefingState"
                                                OnOpenTerminal="@(() => SetCenterTab("term"))"
@@ -837,7 +828,7 @@
                 <div class="modal-head">Fan-out a prompt to multiple sessions</div>
                 <div class="modal-body">
                     <div class="fanout-list">
-                        @foreach (var s in _sessions.Where(s => !string.IsNullOrWhiteSpace(s.TailnetEndpoint)))
+                        @foreach (var s in _sessions)
                         {
                             var sid = s.SessionId;
                             <label class="fanout-item">
@@ -1060,8 +1051,7 @@
     private async Task QuickReplyAsync(string text)
     {
         var sel = Selected;
-        var dir = DirBase;
-        if (sel is null || string.IsNullOrWhiteSpace(dir) || _quickReplying) return;
+        if (sel is null || _quickReplying) return;
         _quickReplying = true;
         _quickReplyNotice = null;
         try
@@ -1314,18 +1304,8 @@
         Log.LogInformation(
             "Cockpit action=select-session source={Source} sid={Sid} dir={Dir}",
             source, sessionId, picked?.TailnetEndpoint ?? "(none)");
-        // Blank-terminal failure mode (issue #199 / #198): a selected session whose Director
-        // advertised no reachable tailnet endpoint cannot be driven over Tailscale - the detail
-        // pane shows the "no tailnet endpoint" guard and the live terminal (TerminalPane) never
-        // mounts, so the user faces the silent ungovernable terminal we could not previously
-        // diagnose. This WARNING is emitted on the selection funnel (which every source - rail,
-        // needs-you nav, deep-link, quick-reply advance - routes through), so the degraded state
-        // is visible in the persisted log the moment the user lands on such a session, rather than
-        // hidden behind a render branch that short-circuits before any terminal logging runs.
-        if (picked is not null && string.IsNullOrWhiteSpace(picked.TailnetEndpoint))
-            Log.LogWarning(
-                "Cockpit empty DirectorBase for sid={Sid} source={Source} (rowState={RowState}); session has no tailnet endpoint, live terminal cannot connect - blank-terminal failure mode",
-                sessionId, source, picked.AssessedState ?? picked.ActivityState);
+        // Issue #372: a missing tailnet endpoint is no longer a failure mode - every session
+        // leg rides same-origin through the Gateway - so the old blank-terminal WARNING is gone.
         _selectedId = sessionId;
         // Keep the address bar deep-linkable (/cockpit/{sid}) without adding history entries.
         // OnParametersSetAsync guards on SidParam != _selectedId, so this never re-enters.
@@ -1354,12 +1334,10 @@
         if (CenterTab == "brief") await LoadWingmanAsync();
     }
 
-    private string? DirBase => Selected?.TailnetEndpoint;
-
     private async Task LoadQueueAsync()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         try
         {
             // Short cap so a hung /queue on the selected Director can't stall the poll loop for
@@ -1372,15 +1350,15 @@
         catch (Exception ex) { Log.LogDebug(ex, "LoadQueue failed"); }
     }
 
-    // Each action captures the selected session + its endpoint into locals BEFORE awaiting.
-    // `Selected`/`DirBase` are computed properties over `_sessions`, which the 2s poll loop
+    // Each action captures the selected session into a local BEFORE awaiting.
+    // `Selected` is a computed property over `_sessions`, which the 2s poll loop
     // replaces wholesale; re-reading them across an await can return null mid-action and throw
     // a spurious NRE that surfaces as a misleading error banner. Capture once, use the locals.
     private async Task SendNow()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(_compose) || string.IsNullOrWhiteSpace(dir)) return;
-        Log.LogInformation("Cockpit action=send sid={Sid} dir={Dir} chars={Chars}", sel.SessionId, dir, _compose.Length);
+        var sel = Selected;
+        if (sel is null || string.IsNullOrWhiteSpace(_compose)) return;
+        Log.LogInformation("Cockpit action=send sid={Sid} chars={Chars}", sel.SessionId, _compose.Length);
         await Act(async () =>
         {
             await Director.SendPromptAsync(sel.SessionId, _compose, _cts.Token);
@@ -1390,9 +1368,9 @@
 
     private async Task QueueIt()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(_compose) || string.IsNullOrWhiteSpace(dir)) return;
-        Log.LogInformation("Cockpit action=queue sid={Sid} dir={Dir} chars={Chars}", sel.SessionId, dir, _compose.Length);
+        var sel = Selected;
+        if (sel is null || string.IsNullOrWhiteSpace(_compose)) return;
+        Log.LogInformation("Cockpit action=queue sid={Sid} chars={Chars}", sel.SessionId, _compose.Length);
         await Act(async () =>
         {
             _queue = await Director.EnqueueAsync(sel.SessionId, _compose, _cts.Token);
@@ -1402,43 +1380,43 @@
 
     private async Task SendQueued(string itemId)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         await Act(async () => _queue = await Director.SendQueueItemAsync(sel.SessionId, itemId, _cts.Token));
     }
 
     private async Task RemoveQueued(string itemId)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         await Act(async () => _queue = await Director.DeleteQueueItemAsync(sel.SessionId, itemId, _cts.Token));
     }
 
     private async Task MoveQueuedUp(string itemId)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         await Act(async () => _queue = await Director.MoveQueueItemUpAsync(sel.SessionId, itemId, _cts.Token));
     }
 
     private async Task MoveQueuedDown(string itemId)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         await Act(async () => _queue = await Director.MoveQueueItemDownAsync(sel.SessionId, itemId, _cts.Token));
     }
 
     private async Task ClearQueue()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         await Act(async () => _queue = await Director.ClearQueueAsync(sel.SessionId, _cts.Token));
     }
 
     private async Task PopQueued(string itemId, string text)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         _compose = (_compose ?? "") + text;
         await Act(async () => _queue = await Director.DeleteQueueItemAsync(sel.SessionId, itemId, _cts.Token));
     }
@@ -1457,8 +1435,8 @@
 
     private async Task SaveEditQueue(string itemId)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         var text = _editingQueueText;
         _editingQueueId = null;
         _editingQueueText = "";
@@ -1494,36 +1472,36 @@
 
     private async Task Interrupt()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
-        Log.LogInformation("Cockpit action=interrupt sid={Sid} dir={Dir}", sel.SessionId, dir);
+        var sel = Selected;
+        if (sel is null) return;
+        Log.LogInformation("Cockpit action=interrupt sid={Sid}", sel.SessionId);
         await Act(() => Director.InterruptAsync(sel.SessionId, _cts.Token));
         if (_actError is null) ShowActionStatus("interrupted");
     }
 
     private async Task Escape()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
-        Log.LogInformation("Cockpit action=escape sid={Sid} dir={Dir}", sel.SessionId, dir);
+        var sel = Selected;
+        if (sel is null) return;
+        Log.LogInformation("Cockpit action=escape sid={Sid}", sel.SessionId);
         await Act(() => Director.EscapeAsync(sel.SessionId, _cts.Token));
         if (_actError is null) ShowActionStatus("turn stopped");
     }
 
     private async Task ClearContext()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
-        Log.LogInformation("Cockpit action=clear-context sid={Sid} dir={Dir}", sel.SessionId, dir);
+        var sel = Selected;
+        if (sel is null) return;
+        Log.LogInformation("Cockpit action=clear-context sid={Sid}", sel.SessionId);
         await Act(() => Director.ClearContextAsync(sel.SessionId, _cts.Token));
         if (_actError is null) ShowActionStatus("context cleared");
     }
 
     private async Task ShowHistory()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
-        Log.LogInformation("Cockpit action=history sid={Sid} dir={Dir}", sel.SessionId, dir);
+        var sel = Selected;
+        if (sel is null) return;
+        Log.LogInformation("Cockpit action=history sid={Sid}", sel.SessionId);
         await Act(() => Director.HistoryPickerAsync(sel.SessionId, _cts.Token));
         if (_actError is null) ShowActionStatus("history picker opened (Esc closes)");
     }
@@ -1554,8 +1532,8 @@
     // PTY) - the same end state as tapping a gallery thumbnail. A trailing space separates images.
     private async Task OnDropImages(InputFileChangeEventArgs e)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         var files = e.GetMultipleFiles(10);
         var total = files.Count;
         var sent = 0;
@@ -1565,8 +1543,8 @@
             index++;
             // One INFO line per attachment (name + size), per the issue's composer-Attach action.
             Log.LogInformation(
-                "Cockpit action=attach sid={Sid} dir={Dir} name={Name} bytes={Bytes}",
-                sel.SessionId, dir, f.Name, f.Size);
+                "Cockpit action=attach sid={Sid} name={Name} bytes={Bytes}",
+                sel.SessionId, f.Name, f.Size);
             try
             {
                 // Optimistic status: render BEFORE the upload await so a large image on a slow
@@ -1631,8 +1609,8 @@
 
     private async Task OpenDictate()
     {
-        if (Selected is null || string.IsNullOrWhiteSpace(DirBase) || _dictating) return;
-        Log.LogInformation("Cockpit action=speak-start sid={Sid} dir={Dir}", Selected.SessionId, DirBase);
+        if (Selected is null || _dictating) return;
+        Log.LogInformation("Cockpit action=speak-start sid={Sid}", Selected.SessionId);
         try
         {
             _dictating = true;
@@ -1770,8 +1748,8 @@
 
     private async Task LoadScreenshotsAsync()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         _shotsBusy = true;
         _shotsError = null;
         await InvokeAsync(StateHasChanged);
@@ -1779,7 +1757,7 @@
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
             cts.CancelAfter(TimeSpan.FromSeconds(10));
-            var r = await Director.GetScreenshotsAsync(dir!, ShotsFetchCount, cts.Token);
+            var r = await Director.GetScreenshotsAsync(sel.SessionId, ShotsFetchCount, cts.Token);
             _shots = r.Items;
             // Old Directors ignore ?count and report Total=0: everything came back, so the
             // list itself is the total.
@@ -1848,11 +1826,11 @@
 
     private async Task DeleteScreenshot(string fileName)
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         try
         {
-            await Director.DeleteScreenshotAsync(dir!, fileName, _cts.Token);
+            await Director.DeleteScreenshotAsync(sel.SessionId, fileName, _cts.Token);
             _shots = _shots.Where(s => s.FileName != fileName).ToList();
         }
         catch (Exception ex)
@@ -1888,8 +1866,8 @@
     // ===== Session Story column (Wingman center tab): headline + tokens + turn history + recap =====
     private async Task LoadWingmanAsync()
     {
-        var sel = Selected; var dir = sel?.TailnetEndpoint;
-        if (sel is null || string.IsNullOrWhiteSpace(dir)) return;
+        var sel = Selected;
+        if (sel is null) return;
         _awareError = null;
         try
         {
@@ -2014,8 +1992,8 @@
 
     private async Task SendBriefFeedback()
     {
-        var sel = Selected; var dir = DirBase;
-        if (sel is null || string.IsNullOrWhiteSpace(dir) || string.IsNullOrWhiteSpace(_briefFeedbackNote)) return;
+        var sel = Selected;
+        if (sel is null || string.IsNullOrWhiteSpace(_briefFeedbackNote)) return;
         _briefFeedbackBusy = true;
         _briefFeedbackStatus = null;
         try
@@ -2157,15 +2135,7 @@
     private async Task OnRailMenuAction(SessionRail.MenuActionArgs a)
     {
         var s = a.Session;
-        var dir = s.TailnetEndpoint;
-        Log.LogInformation(
-            "Cockpit action=kebab kebab={Kebab} sid={Sid} dir={Dir}",
-            a.Action, s.SessionId, string.IsNullOrWhiteSpace(dir) ? "(none)" : dir);
-        if (string.IsNullOrWhiteSpace(dir))
-        {
-            ShowRailNotice("This session has no reachable Director endpoint.");
-            return;
-        }
+        Log.LogInformation("Cockpit action=kebab kebab={Kebab} sid={Sid}", a.Action, s.SessionId);
         try
         {
             switch (a.Action)
@@ -2283,7 +2253,7 @@
 
     private async Task SaveRename()
     {
-        if (Selected is null || string.IsNullOrWhiteSpace(DirBase)) { _renaming = false; return; }
+        if (Selected is null) { _renaming = false; return; }
         var sid = Selected.SessionId;
         var name = _renameText.Trim();
         await Act(async () =>
@@ -2298,7 +2268,7 @@
     // happened - this is the committed click, through the SAME path as the kebab Close. -----
     private async Task CloseSelectedFromBriefAsync()
     {
-        if (Selected is null || string.IsNullOrWhiteSpace(DirBase)) return;
+        if (Selected is null) return;
         var s = Selected;
         Log.LogInformation("Cockpit: closing sid={Sid} ({Title}) on wingman mission-complete approval", s.SessionId, SessionTitle(s));
         await Act(async () =>
@@ -2313,7 +2283,7 @@
     // ----- kill -----
     private async Task KillSelected()
     {
-        if (Selected is null || string.IsNullOrWhiteSpace(DirBase)) return;
+        if (Selected is null) return;
         var sid = Selected.SessionId;
         await Act(async () =>
         {
@@ -2515,27 +2485,16 @@
 
     private void CloseSettings() => _showSettings = false;
 
-    // Resolve a Director's reachable base URL. Prefer its cross-machine TailnetEndpoint, but
-    // fall back to the ControlEndpoint when that is null/empty - the contract documents that
-    // FSW-discovered (same-machine) Directors have a null TailnetEndpoint and the ControlEndpoint
-    // must be used instead (DirectorDto.cs). Without this fallback, Settings was unusable for the
-    // common loopback case ("that Director has no reachable endpoint"), even though the session
-    // DTOs already carry the same control-endpoint fallback for the terminal/Send/queue paths.
-    private string? SettingsEndpointFor(string directorId)
-    {
-        var d = _directors.FirstOrDefault(x => x.DirectorId == directorId);
-        if (d is null) return null;
-        return !string.IsNullOrWhiteSpace(d.TailnetEndpoint) ? d.TailnetEndpoint : d.ControlEndpoint;
-    }
-
     private async Task LoadSettings()
     {
+        // Issue #372 slice 3: settings are routed by DIRECTOR id through the Gateway
+        // (/directors/{id}/settings) - no endpoint resolution here; the Gateway answers 503
+        // with a clear message if the Director is unreachable.
         _setError = null; _setStatus = null; _settingsJson = "";
-        var ep = SettingsEndpointFor(_setDirectorId);
-        if (string.IsNullOrWhiteSpace(ep)) { _setError = "that Director has no reachable endpoint"; return; }
+        if (string.IsNullOrWhiteSpace(_setDirectorId)) { _setError = "no Director selected"; return; }
         try
         {
-            var raw = await Director.GetSettingsAsync(ep!, _cts.Token);
+            var raw = await Director.GetSettingsAsync(_setDirectorId, _cts.Token);
             try
             {
                 var node = System.Text.Json.Nodes.JsonNode.Parse(raw);
@@ -2548,14 +2507,13 @@
 
     private async Task SaveSettings()
     {
-        var ep = SettingsEndpointFor(_setDirectorId);
-        if (string.IsNullOrWhiteSpace(ep)) { _setError = "that Director has no reachable endpoint"; return; }
-        Log.LogInformation("Cockpit action=settings-save director={Director} dir={Dir}", _setDirectorId, ep);
+        if (string.IsNullOrWhiteSpace(_setDirectorId)) { _setError = "no Director selected"; return; }
+        Log.LogInformation("Cockpit action=settings-save director={Director}", _setDirectorId);
         _acting = true; _setError = null; _setStatus = null;
         try
         {
             System.Text.Json.JsonDocument.Parse(_settingsJson); // validate before sending
-            await Director.PutSettingsAsync(ep!, _settingsJson, _cts.Token);
+            await Director.PutSettingsAsync(_setDirectorId, _settingsJson, _cts.Token);
             _setStatus = "saved; the Director re-applied its settings";
         }
         catch (System.Text.Json.JsonException) { _setError = "not valid JSON - fix it before saving"; }
@@ -2575,14 +2533,13 @@
 
     private async Task OpenAwareness()
     {
-        if (Selected is null || string.IsNullOrWhiteSpace(DirBase)) return;
+        if (Selected is null) return;
         _showAwareness = true;
         _awareError = null;
         _recap = null;
         _git = null;
         _turns = new();
         _awareTitle = SessionTitle(Selected);
-        var dir = DirBase!;
         var sid = Selected.SessionId;
         try
         {
@@ -2599,7 +2556,7 @@
 
     private async Task GenerateRecap()
     {
-        if (Selected is null || string.IsNullOrWhiteSpace(DirBase)) return;
+        if (Selected is null) return;
         _recapBusy = true;
         _awareError = null;
         await InvokeAsync(StateHasChanged);
@@ -2624,7 +2581,7 @@
         _fanoutResults = new();
         _fanoutText = "";
         _fanoutSelected = new();
-        if (Selected is not null && !string.IsNullOrWhiteSpace(Selected.TailnetEndpoint))
+        if (Selected is not null)
             _fanoutSelected.Add(Selected.SessionId);
     }
 
@@ -2646,18 +2603,12 @@
         await InvokeAsync(StateHasChanged);
         try
         {
-            // Group the fleet-wide selection by owning Director endpoint - /fanout-local is
-            // per-Director (its session ids must be local), so we call it once per Director.
-            var groups = _sessions
-                .Where(s => _fanoutSelected.Contains(s.SessionId) && !string.IsNullOrWhiteSpace(s.TailnetEndpoint))
-                .GroupBy(s => s.TailnetEndpoint!);
-            var all = new List<FanoutResult>();
-            foreach (var g in groups)
-            {
-                var ids = g.Select(s => s.SessionId).ToList();
-                var resp = await Director.FanoutAsync(g.Key, ids, _fanoutText, _cts.Token);
-                if (resp?.Results is not null) all.AddRange(resp.Results);
-            }
+            // Issue #372 slice 3: ONE call to the Gateway's fleet-wide /fanout - it resolves each
+            // session's owning Director itself, so no per-Director grouping (and no
+            // TailnetEndpoint dependency) here anymore.
+            var ids = _fanoutSelected.ToList();
+            var resp = await Director.FanoutAsync(ids, _fanoutText, _cts.Token);
+            var all = resp?.Results ?? new List<FanoutResult>();
             _fanoutResults = all;
             if (all.Count > 0 && all.All(r => r.Error is null)) _fanoutText = "";
         }
@@ -2686,12 +2637,11 @@
 
     private async Task OpenHandover()
     {
-        if (Selected is null || string.IsNullOrWhiteSpace(DirBase)) return;
+        if (Selected is null) return;
         _showHandover = true;
         _handoverContext = null;
         _hoError = null; _hoStatus = null;
         _hoMode = "new"; _hoRepoPath = ""; _hoToSessionId = ""; _hoExtra = ""; _hoArchive = true; _hoAgent = "ClaudeCode";
-        var dir = DirBase!;
         var sid = Selected.SessionId;
         try
         {

--- a/src/CcDirector.Cockpit/Components/Pages/SessionDetail.razor
+++ b/src/CcDirector.Cockpit/Components/Pages/SessionDetail.razor
@@ -148,11 +148,7 @@
                         <h2>On screen now</h2>
                         <a href="/cockpit/@s.SessionId">Open the terminal &rarr;</a>
                     </div>
-                    @if (string.IsNullOrWhiteSpace(s.TailnetEndpoint))
-                    {
-                        <div class="dash-quiet">This session's Director has no tailnet endpoint, so the screen can't be read from here.</div>
-                    }
-                    else if (_screenTail is null)
+                    @if (_screenTail is null)
                     {
                         <div class="dash-quiet">Reading the screen...</div>
                     }
@@ -194,7 +190,7 @@
                     <div class="dash-sec-head"><h2>Git</h2></div>
                     @if (_git is null)
                     {
-                        <div class="dash-quiet">@(string.IsNullOrWhiteSpace(s.TailnetEndpoint) ? "Unavailable (no Director endpoint)." : "Loading...")</div>
+                        <div class="dash-quiet">Loading...</div>
                     }
                     else if (_git.Status != "ok")
                     {
@@ -219,7 +215,7 @@
                     <div class="dash-sec-head"><h2>Tokens</h2></div>
                     @if (_usage is null)
                     {
-                        <div class="dash-quiet">@(string.IsNullOrWhiteSpace(s.TailnetEndpoint) ? "Unavailable (no Director endpoint)." : "Loading...")</div>
+                        <div class="dash-quiet">Loading...</div>
                     }
                     else
                     {

--- a/src/CcDirector.Cockpit/Components/TerminalPane.razor
+++ b/src/CcDirector.Cockpit/Components/TerminalPane.razor
@@ -17,9 +17,8 @@
 
 @code {
     [Parameter] public string SessionId { get; set; } = "";
-    [Parameter] public string DirectorBase { get; set; } = "";   // e.g. https://host:7887
-    // The owning session's activity/assessed state, logged with the empty-DirectorBase WARNING
-    // (issue #199) so the blank-terminal trace carries the session's state at connect time.
+    // The owning session's activity/assessed state, carried into connect-time logging so a
+    // blank-terminal trace (issue #199) shows what state the session was in.
     [Parameter] public string RowState { get; set; } = "";
 
     private ElementReference _host;
@@ -32,21 +31,11 @@
         // Connect as soon as we have a valid SessionId - NOT only on firstRender. The pane is
         // keyed by SessionId, so a Gateway restart can mount it before the session envelope is
         // populated; gating the single connect on firstRender (issue #198) left the pane blank
-        // forever because the keyed instance is never recreated to retrigger it. The stream URL
-        // is same-origin (#268) and needs only SessionId - DirectorBase is no longer required to
-        // connect (it is still used for the keystroke leg in OnInput). Guard on _connectedSid so
-        // we connect exactly once per session, with a retry on a later render if the attempt throws.
+        // forever because the keyed instance is never recreated to retrigger it. Both legs are
+        // same-origin through the Gateway (#268 stream, #372 keystrokes) and need only SessionId.
+        // Guard on _connectedSid so we connect exactly once per session, with a retry on a later
+        // render if the attempt throws.
         if (string.IsNullOrEmpty(SessionId) || _connectedSid == SessionId) return;
-
-        // Blank-terminal failure mode (issue #199 / #198): an empty DirectorBase means this
-        // session's Director advertised no reachable endpoint, so the keystroke leg can never
-        // connect and the pane is the silent blank terminal we could not previously diagnose.
-        // The stream leg is same-origin and only needs SessionId, so we still attempt it - but
-        // this WARNING makes the degraded state visible in the persisted log instead of guesswork.
-        if (string.IsNullOrEmpty(DirectorBase))
-            Log.LogWarning(
-                "TerminalPane empty DirectorBase for sid={Sid} (rowState={RowState}); keystroke leg disabled, stream leg attempted same-origin",
-                SessionId, RowState);
 
         _connectedSid = SessionId;
         try
@@ -54,8 +43,8 @@
             _selfRef = DotNetObjectReference.Create(this);
             _module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/cockpit-terminal.js");
             var wsUrl = CockpitWsUrls.Stream(Nav.BaseUri, SessionId);
-            Log.LogInformation("TerminalPane connect attempt sid={Sid} dir={Dir} wsUrl={WsUrl}",
-                SessionId, string.IsNullOrEmpty(DirectorBase) ? "(none)" : DirectorBase, wsUrl);
+            Log.LogInformation("TerminalPane connect attempt sid={Sid} rowState={RowState} wsUrl={WsUrl}",
+                SessionId, RowState, wsUrl);
             await _module.InvokeVoidAsync("connect", SessionId, _host, wsUrl, _selfRef);
             Log.LogInformation("TerminalPane connect dispatched sid={Sid} wsUrl={WsUrl}", SessionId, wsUrl);
         }

--- a/src/CcDirector.Cockpit/Services/DirectorClient.cs
+++ b/src/CcDirector.Cockpit/Services/DirectorClient.cs
@@ -54,15 +54,13 @@ public sealed class ScreenshotsResponse
 }
 
 /// <summary>
-/// Drives a single session's write/act/read path. Issue #372: every PER-SESSION verb now goes to
-/// the local GATEWAY (this client's BaseAddress), which resolves the owning Director by session id
-/// and reverse-proxies to it (CcDirector.Gateway SessionWsProxyEndpoints). The Cockpit never dials
-/// a Director address directly, so a Director that advertises only a loopback endpoint is still
-/// fully drivable and there is one reachability/trust story (the Gateway), not two.
-///
-/// The few DIRECTOR-scoped paths that are not session-scoped (the screenshots folder, the
-/// Director's settings, and same-Director fanout) still take an explicit <c>directorBase</c> -
-/// they have no session id for the Gateway to resolve an owner from. Those are the next slice.
+/// Drives a single session's write/act/read path. Issue #372: EVERY call goes to the local
+/// GATEWAY (this client's BaseAddress) - session-scoped verbs are resolved to the owning Director
+/// by session id, the screenshots folder rides the selected session's id, Director settings ride
+/// the Director id (/directors/{id}/settings), and fanout uses the Gateway's own fleet-wide
+/// /fanout. The Cockpit never dials a Director address directly, so a Director that advertises
+/// only a loopback endpoint is still fully drivable and there is one reachability/trust story
+/// (the Gateway), not two.
 /// </summary>
 public sealed class DirectorClient
 {
@@ -74,12 +72,6 @@ public sealed class DirectorClient
         _http = http;
         _log = log;
     }
-
-    // Absolute URL builder for the DIRECTOR-scoped calls that still target a Director base directly
-    // (screenshots folder, settings, fanout). Session-scoped calls below use relative paths so they
-    // resolve against the Gateway BaseAddress instead.
-    private static Uri Url(string directorBase, string path) =>
-        new(new Uri(directorBase.TrimEnd('/') + "/"), path.TrimStart('/'));
 
     public async Task SendPromptAsync(string sid, string text, CancellationToken ct = default)
     {
@@ -206,27 +198,30 @@ public sealed class DirectorClient
     // ===== Screenshots gallery (folder lives on the Director's machine) =====
 
     /// <summary>
-    /// List the screenshots in the Director's screenshots folder, newest first
-    /// (<c>GET /screenshots</c>). The folder is per-machine, not per-session, so this still takes
-    /// the Director base directly (issue #372: no session id for the Gateway to resolve an owner
-    /// from - moving this onto the Gateway is the next slice). The image bytes themselves are
-    /// loaded by the browser SAME-ORIGIN via the Gateway's per-session proxy
-    /// (<c>CockpitShotUrls.Screenshot</c>, issue #317); this call returns just metadata + labels.
+    /// List the screenshots in the owning Director's screenshots folder, newest first. The folder
+    /// is per-machine on the Director, but the Cockpit always asks in the context of the selected
+    /// session, so the session id is the routing key: the Gateway forwards
+    /// <c>GET /sessions/{sid}/screenshots</c> to the Director's machine-wide <c>/screenshots</c>
+    /// (issue #372 slice 3). The image bytes themselves are loaded by the browser SAME-ORIGIN via
+    /// the Gateway's per-session proxy (<c>CockpitShotUrls.Screenshot</c>, issue #317); this call
+    /// returns just metadata + labels.
     /// <paramref name="count"/> caps the items (the folder can hold thousands); &lt;=0 fetches
     /// everything. Old Directors ignore the param and return all items with Total=0.
     /// </summary>
-    public async Task<ScreenshotsResponse> GetScreenshotsAsync(string directorBase, int count = 0, CancellationToken ct = default)
+    public async Task<ScreenshotsResponse> GetScreenshotsAsync(string sid, int count = 0, CancellationToken ct = default)
     {
-        var path = count > 0 ? $"screenshots?count={count}" : "screenshots";
-        var r = await _http.GetFromJsonAsync<ScreenshotsResponse>(Url(directorBase, path), ct);
+        var path = count > 0 ? $"sessions/{sid}/screenshots?count={count}" : $"sessions/{sid}/screenshots";
+        var r = await _http.GetFromJsonAsync<ScreenshotsResponse>(path, ct);
         return r ?? new ScreenshotsResponse();
     }
 
-    /// <summary>Delete one screenshot file from the Director's disk (<c>DELETE /screenshots/file</c>).</summary>
-    public async Task DeleteScreenshotAsync(string directorBase, string fileName, CancellationToken ct = default)
+    /// <summary>Delete one screenshot file from the owning Director's disk
+    /// (<c>DELETE /sessions/{sid}/screenshots/file</c>, forwarded to the Director's
+    /// <c>DELETE /screenshots/file</c>).</summary>
+    public async Task DeleteScreenshotAsync(string sid, string fileName, CancellationToken ct = default)
     {
-        _log.LogDebug("DeleteScreenshot file={File}", fileName);
-        var resp = await _http.DeleteAsync(Url(directorBase, $"screenshots/file?name={Uri.EscapeDataString(fileName)}"), ct);
+        _log.LogDebug("DeleteScreenshot sid={Sid} file={File}", sid, fileName);
+        var resp = await _http.DeleteAsync($"sessions/{sid}/screenshots/file?name={Uri.EscapeDataString(fileName)}", ct);
         resp.EnsureSuccessStatusCode();
     }
 
@@ -290,17 +285,19 @@ public sealed class DirectorClient
         return body.NewIssueUrl;
     }
 
-    /// <summary>Read a Director's raw settings JSON (<c>GET /settings</c>). Director-scoped (no
-    /// session id), so it still targets the Director base directly (issue #372: next slice).</summary>
-    public async Task<string> GetSettingsAsync(string directorBase, CancellationToken ct = default)
-        => await _http.GetStringAsync(Url(directorBase, "settings"), ct);
+    /// <summary>Read a Director's raw settings JSON. Routed by DIRECTOR id: the Gateway forwards
+    /// <c>GET /directors/{id}/settings</c> to that Director's <c>/settings</c> (issue #372
+    /// slice 3) - no Director address needed.</summary>
+    public async Task<string> GetSettingsAsync(string directorId, CancellationToken ct = default)
+        => await _http.GetStringAsync($"directors/{directorId}/settings", ct);
 
-    /// <summary>Write a Director's settings (<c>PUT /settings</c>) - the Director re-applies live.</summary>
-    public async Task PutSettingsAsync(string directorBase, string json, CancellationToken ct = default)
+    /// <summary>Write a Director's settings (<c>PUT /directors/{id}/settings</c>, forwarded to the
+    /// Director's <c>PUT /settings</c>) - the Director re-applies live.</summary>
+    public async Task PutSettingsAsync(string directorId, string json, CancellationToken ct = default)
     {
-        _log.LogDebug("PutSettings len={Len}", json.Length);
+        _log.LogDebug("PutSettings director={Director} len={Len}", directorId, json.Length);
         using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-        var resp = await _http.PutAsync(Url(directorBase, "settings"), content, ct);
+        var resp = await _http.PutAsync($"directors/{directorId}/settings", content, ct);
         resp.EnsureSuccessStatusCode();
     }
 
@@ -405,15 +402,16 @@ public sealed class DirectorClient
         => await _http.GetFromJsonAsync<GitSnapshot>($"sessions/{sid}/git", ct);
 
     /// <summary>
-    /// Broadcast a prompt to several sessions on ONE Director (<c>POST /fanout-local</c>). The
-    /// session ids must all belong to <paramref name="directorBase"/>; the Cockpit groups a
-    /// fleet-wide selection by Director and calls this once per Director. Director-scoped (issue
-    /// #372: next slice). <c>waitForIdle:false</c> returns as soon as the text is delivered.
+    /// Broadcast a prompt to several sessions anywhere on the fleet via the Gateway's own
+    /// <c>POST /fanout</c> (issue #372 slice 3): the Gateway resolves each session's owning
+    /// Director itself, so the Cockpit no longer groups the selection by Director or dials
+    /// <c>/fanout-local</c> on each one. <c>waitForIdle:false</c> returns as soon as the text is
+    /// delivered, so the UI does not block.
     /// </summary>
-    public async Task<FanoutResponse?> FanoutAsync(string directorBase, List<string> sessionIds, string text, CancellationToken ct = default)
+    public async Task<FanoutResponse?> FanoutAsync(List<string> sessionIds, string text, CancellationToken ct = default)
     {
         _log.LogDebug("Fanout count={Count} len={Len}", sessionIds.Count, text.Length);
-        var resp = await _http.PostAsJsonAsync(Url(directorBase, "fanout-local"),
+        var resp = await _http.PostAsJsonAsync("fanout",
             new { sessionIds, text, appendEnter = true, waitForIdle = false }, ct);
         resp.EnsureSuccessStatusCode();
         return await resp.Content.ReadFromJsonAsync<FanoutResponse>(cancellationToken: ct);

--- a/src/CcDirector.Gateway.Tests/SessionHttpProxyRoundTripTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionHttpProxyRoundTripTests.cs
@@ -105,6 +105,51 @@ public sealed class SessionHttpProxyRoundTripTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
+    // ----- Issue #372 slice 3: screenshots list/delete + director-scoped settings -----
+
+    [Fact]
+    public async Task Screenshot_list_forwards_to_the_directors_machine_wide_screenshots()
+    {
+        var resp = await _http.GetAsync("sessions/http-session-1/screenshots?count=5");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Equal("{\"items\":[]}", body);
+        // The sid-scoped Gateway path lands on the Director's machine-wide /screenshots,
+        // with the ?count query carried through.
+        Assert.Equal("GET /screenshots?count=5", _director.LastRequest);
+    }
+
+    [Fact]
+    public async Task Screenshot_delete_forwards_as_DELETE_to_the_directors_screenshots_file()
+    {
+        var resp = await _http.DeleteAsync("sessions/http-session-1/screenshots/file?name=a%20b.png");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("DELETE /screenshots/file?name=a b.png", _director.LastRequest);
+    }
+
+    [Fact]
+    public async Task Director_settings_round_trip_by_director_id()
+    {
+        var get = await _http.GetAsync($"directors/{_director.DirectorId}/settings");
+        Assert.Equal(HttpStatusCode.OK, get.StatusCode);
+        Assert.Equal("{\"voice\":{}}", await get.Content.ReadAsStringAsync());
+        Assert.Equal("GET /settings", _director.LastRequest);
+
+        var put = await _http.PutAsync($"directors/{_director.DirectorId}/settings",
+            new StringContent("{\"voice\":{\"rate\":2}}", System.Text.Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.OK, put.StatusCode);
+        Assert.Equal("PUT /settings {\"voice\":{\"rate\":2}}", _director.LastRequest);
+    }
+
+    [Fact]
+    public async Task Unknown_director_id_is_404_for_settings()
+    {
+        var resp = await _http.GetAsync("directors/no-such-director/settings");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
     private static int FreePort()
     {
         using var l = new TcpListener(IPAddress.Loopback, 0);
@@ -165,6 +210,30 @@ public sealed class SessionHttpProxyRoundTripTests : IAsyncLifetime
 
             _app.MapPost("/sessions/{sid}/history-picker", (string sid) =>
                 Results.Json(new { error = "not supported" }, statusCode: StatusCodes.Status409Conflict));
+
+            // Issue #372 slice 3 legs: machine-wide screenshots + Director settings.
+            _app.MapGet("/screenshots", (HttpContext ctx) =>
+            {
+                LastRequest = $"GET /screenshots{ctx.Request.QueryString.Value}";
+                return Results.Text("{\"items\":[]}", "application/json");
+            });
+            _app.MapDelete("/screenshots/file", (string name) =>
+            {
+                LastRequest = $"DELETE /screenshots/file?name={name}";
+                return Results.Json(new { deleted = true });
+            });
+            _app.MapGet("/settings", () =>
+            {
+                LastRequest = "GET /settings";
+                return Results.Text("{\"voice\":{}}", "application/json");
+            });
+            _app.MapPut("/settings", async (HttpContext ctx) =>
+            {
+                using var reader = new StreamReader(ctx.Request.Body);
+                var body = await reader.ReadToEndAsync();
+                LastRequest = $"PUT /settings {body}";
+                return Results.Json(new { applied = true });
+            });
 
             await _app.StartAsync();
         }

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -64,9 +64,19 @@ internal static class SessionWsProxyEndpoints
         // Screenshot bytes (issue #317): plain HTTP forward (no WS upgrade) to the owning
         // Director's machine-wide /screenshots/file . The ?name=... query carries through via
         // RewritePathTransformer; the response (image bytes + content type) streams back as-is.
-        app.MapGet("/sessions/{sid}/screenshots/file", async (string sid, HttpContext ctx) =>
+        // Issue #372 slice 3: Map (not MapGet) so DELETE /sessions/{sid}/screenshots/file also
+        // forwards - the Cockpit's gallery Del button no longer dials the Director directly.
+        app.Map("/sessions/{sid}/screenshots/file", async (string sid, HttpContext ctx) =>
         {
             await ProxyAsync(ctx, sid, "shot", "/screenshots/file", registry, client, proxy, owners);
+        });
+
+        // Screenshot LIST (issue #372 slice 3): the folder is machine-wide on the Director
+        // (/screenshots), but the Cockpit always asks in the context of a selected session, so the
+        // session id is the routing key. ?count=N carries through.
+        app.MapGet("/sessions/{sid}/screenshots", async (string sid, HttpContext ctx) =>
+        {
+            await ProxyAsync(ctx, sid, "shots", "/screenshots", registry, client, proxy, owners);
         });
 
         // Issue #372: generic per-session HTTP forward. ANY method on /sessions/{sid}/{**rest} that
@@ -84,6 +94,37 @@ internal static class SessionWsProxyEndpoints
             // cached owner before a fleet fan-out. The WS/screenshot legs are long-lived/low-frequency
             // and keep the plain resolve.
             await ProxyAsync(ctx, sid, "http", directorPath, registry, client, proxy, owners, fastPath: true);
+        });
+
+        // Issue #372 slice 3: DIRECTOR-scoped settings (GET reads, PUT writes-and-reapplies-live).
+        // The routing key is the Director id, not a session id, so resolution is a plain registry
+        // lookup - no ownership fan-out. 404 for an unknown Director id; a failed forward is 503
+        // exactly like the session legs. This retires the Cockpit settings page's last
+        // direct-to-Director call.
+        app.Map("/directors/{id}/settings", async (string id, HttpContext ctx) =>
+        {
+            FileLog.Write($"[SessionWsProxy] open leg=dirsettings director={id} method={ctx.Request.Method} client={ctx.Connection.RemoteIpAddress}");
+            var d = registry.Get(id);
+            if (d is null)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                await ctx.Response.WriteAsJsonAsync(new { error = "no such director" });
+                return;
+            }
+            var destination = ForwardDestination(d);
+            if (destination is null)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await ctx.Response.WriteAsJsonAsync(new { error = "director has no reachable endpoint" });
+                return;
+            }
+            var error = await proxy.ForwardAsync(ctx, destination, "/settings");
+            if (error != ForwarderError.None && !ctx.Response.HasStarted)
+            {
+                FileLog.Write($"[SessionWsProxy] leg=dirsettings director={id} -> 503 (forwarder error {error})");
+                ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await ctx.Response.WriteAsJsonAsync(new { error = $"director unreachable ({error})" });
+            }
         });
     }
 


### PR DESCRIPTION
Slice 3 of #372 (follow-up issue #374): the last three Cockpit calls that dialed a Director address directly - screenshots list/delete, Director settings, fanout - now ride the Gateway, and the stale `TailnetEndpoint` guards slice 2 left behind are removed. After this PR, `DirectorClient` has zero Director-address parameters and the Cockpit's only HTTP destination is the Gateway.

See #374 for full scope, acceptance criteria, and how-to-test.

Key points:
- Gateway: `GET /sessions/{sid}/screenshots` (list), screenshots-file route now also DELETE, `/directors/{id}/settings` GET/PUT by Director id (404 unknown / 503 unreachable). 4 new round-trip tests (44/44 proxy + route-precedence suites green).
- Cockpit: fanout is ONE Gateway `/fanout` call (per-Director grouping deleted); ~17 stale endpoint guards removed (they silently blocked loopback-only Directors); "no tailnet endpoint" dead-end pane and vestigial `DirectorBase` parameters gone.
- Verified live on the deployed fleet: settings + screenshots answer through the Gateway; `leg=shots`/`leg=dirsettings` forwards in the Gateway log.

Closes #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
