### PR TITLE
fix(#366): voice-turn endpoint no longer speaks previous-turn content

### DIFF
--- a/docs/cencon/proof/issue-366/qa-report.html
+++ b/docs/cencon/proof/issue-366/qa-report.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #366 - Voice-turn stale transcript fix</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 960px; color: #1a1a1a; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #0b6e4f; padding-bottom: .4rem; }
+  h2 { color: #0b6e4f; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0f5f3; }
+  .pass { color: #0b6e4f; font-weight: bold; }
+  .fail { color: #b00020; font-weight: bold; }
+  code, pre { background: #f6f6f6; border: 1px solid #e0e0e0; border-radius: 4px; font-family: Consolas, monospace; }
+  code { padding: .1rem .3rem; }
+  pre { padding: .8rem; overflow-x: auto; font-size: .85rem; }
+  .verdict { background: #e6f4ee; border: 2px solid #0b6e4f; padding: 1rem; font-size: 1.1rem; margin-top: 2rem; }
+  .meta { color: #555; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>QA Proof Report - Issue #366</h1>
+<p class="meta">
+  Issue: [Voice] Fix stale transcript: voice-turn endpoint speaks previous-turn content<br>
+  PR: #379 (branch <code>issue-366-stale-transcript</code>, head <code>e607b9f</code>, fix commit <code>e781b11</code>)<br>
+  QA Agent: independent verification in an isolated git worktree (never touched the developer's binaries or shared tree)<br>
+  Date: 2026-06-12 | Verifier: QA Agent (CenCon Development Method)
+</p>
+
+<h2>Verification method</h2>
+<p>
+All verification was performed from a fresh isolated <code>git worktree</code> checkout of the PR branch.
+The acceptance criteria for this issue are build/test contracts (the proof target is the named regression
+test passing), so verification = independent build + independent test runs + code inspection + a vacuity
+check proving the new test fails on pre-fix code.
+</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-observed)</th><th>Verdict</th></tr>
+<tr>
+  <td>1</td>
+  <td>Two consecutive voice turns: second turn's spoken summary reflects the second turn's reply, not the first turn's</td>
+  <td>Regression test asserts turn 2 summary contains the turn-2 marker and NOT the turn-1 marker; turn 3 (no reply written during the turn - the exact defect window) contains neither prior marker</td>
+  <td><code>VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply</code> ran by QA: <strong>Passed [2 s]</strong>. Test inspected: 3 turns against one session with a real temp JSONL transcript via <code>TranscriptWritingBackend</code>; assertions match the criterion exactly. Vacuity check: with ONLY <code>VoiceTurnEndpoint.cs</code> reverted to pre-fix main (<code>cbea886</code>), the same test <strong>FAILS</strong> with <code>Assert.DoesNotContain() Failure: Sub-string found</code> (stale prior-turn content spoken) - so the test genuinely detects the defect</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td><code>ReadLastAssistantText</code> (or replacement) uses a post-send byte offset filter; no pre-turn assistant content can leak</td>
+  <td>JSONL byte length snapshotted immediately before <code>SendTextAsync</code>; only content at/after that offset read for the summary</td>
+  <td>Code inspected in diff <code>cbea886..e781b11</code>: <code>SnapshotTranscriptLength(session)</code> (uses <code>new FileInfo(jsonl).Length</code>) is called immediately before <code>await session.SendTextAsync(inputText)</code>; <code>ReadLastAssistantText</code> replaced by <code>ReadNewAssistantText(session, offsetBefore)</code> which calls new <code>StreamMessageParser.ParseFileFromOffset(jsonl, offsetBefore)</code> (seeks to the offset, <code>FileShare.ReadWrite</code>, falls back to start only when the offset exceeds the current file length, i.e. the file was replaced and all content is new). Scope respected: no changes to Gateway async pipeline, <code>ClaudeSummarizer.cs</code>, or <code>TtsService.cs</code></td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td><code>dotnet build cc-director.sln</code> succeeds with 0 errors</td>
+  <td>Build succeeded, 0 errors</td>
+  <td>QA ran the build in the isolated worktree: <strong>Build succeeded. 0 Warning(s), 0 Error(s)</strong> (31.3 s)</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>4</td>
+  <td><code>dotnet test --filter VoiceTurn</code> passes (existing tests unaffected, new regression test added)</td>
+  <td>All VoiceTurn-filtered tests green, including the new test</td>
+  <td>QA ran: Gateway.Tests VoiceTurn filter = <strong>9/9 Passed</strong> (8 pre-existing + 1 new); Core.Tests VoiceTurn filter = <strong>5/5 Passed</strong></td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Proof target</h2>
+<pre>Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply [2 s]
+     Passed: 1</pre>
+
+<h2>Vacuity check (test fails on pre-fix code)</h2>
+<pre># git checkout cbea886 -- src/CcDirector.ControlApi/VoiceTurnEndpoint.cs  (pre-fix endpoint only)
+[xUnit.net] Assert.DoesNotContain() Failure: Sub-string found
+Failed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply [2 s]
+Test Run Failed.  Failed: 1
+# file restored to PR head, solution rebuilt, test green again</pre>
+
+<h2>Regression sweep</h2>
+<table>
+<tr><th>Suite</th><th>Result</th><th>Notes</th></tr>
+<tr><td>CcDirector.Gateway.Tests (full, 588 tests)</td><td>587 passed / 1 failed</td>
+    <td>Sole failure: <code>DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider</code> ("expected at least 1 partial transcript, got 0"). <strong>Proven pre-existing:</strong> QA rebuilt and ran the same test on <code>origin/main</code> (<code>cbea886</code>) in the same environment - it fails identically there. Environmental (realtime transcription provider), unrelated to the VoiceTurn change; PR touches no dictation code.</td></tr>
+<tr><td>CcDirector.Core.Tests (full, 1857 tests)</td><td>1855 passed / 0 failed / 2 skipped</td><td>Covers the <code>StreamMessage.cs</code> change (new <code>ParseFileFromOffset</code>); zero failures.</td></tr>
+</table>
+
+<h2>Method checks</h2>
+<ul>
+  <li>Issue scope respected (In/Out list): only <code>VoiceTurnEndpoint.cs</code>, <code>StreamMessage.cs</code> (new public parser entry point required because <code>ParseLine</code> is internal to Core), and the test file changed in src/.</li>
+  <li>Enterprise logging present on both new methods (<code>FileLog.Write</code> entry + FAILED paths).</li>
+  <li>No security-sensitive surface touched; no CenCon doc update required (no architecture change - same containers, same data flow, read path narrowed).</li>
+  <li>No fallback-programming violation: the offset-beyond-EOF fallback reads from start because ALL content is then genuinely new (file replaced) - documented in code, not a problem-hiding fallback.</li>
+</ul>
+
+<div class="verdict">
+<strong>VERDICT: VERIFIED - all acceptance criteria met.</strong> 4/4 criteria PASS with independent QA-produced proof.
+The regression test is genuine (fails on pre-fix code), the build is clean, and the only full-suite failure is a
+proven pre-existing environmental dictation test failure also present on main.
+</div>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-366/regression-proof-prefix-code-fails.txt
+++ b/docs/cencon/proof/issue-366/regression-proof-prefix-code-fails.txt
@@ -1,0 +1,31 @@
+Regression proof for issue #366
+================================
+
+To prove the new test actually catches the defect, the two production files
+(src/CcDirector.ControlApi/VoiceTurnEndpoint.cs and
+src/CcDirector.Core/Claude/StreamMessage.cs) were temporarily reverted to
+origin/main (pre-fix code) while keeping the new test, then the test was run:
+
+  git checkout origin/main -- src/CcDirector.ControlApi/VoiceTurnEndpoint.cs src/CcDirector.Core/Claude/StreamMessage.cs
+  dotnet build src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
+  dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter VoiceTurn_TwoConsecutiveTurns --no-build
+
+Output (verbatim):
+
+[xUnit.net 00:00:03.12]     CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply [FAIL]
+  Failed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply [2 s]
+  Error Message:
+   Assert.DoesNotContain() Failure: Sub-string found
+         (pos 0)
+String: "ZEBRASECOND the second task is complete."
+Found:  "ZEBRASECOND"
+  Stack Trace:
+     at CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply() in src\CcDirector.Gateway.Tests\VoiceTurnEndpointTests.cs:line 353
+
+Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1, Duration: 2 s - CcDirector.Gateway.Tests.dll (net10.0)
+
+Interpretation: on pre-fix code, turn 3 (during which the agent wrote NOTHING
+to the transcript) spoke the SECOND turn's reply ("ZEBRASECOND the second task
+is complete.") - the exact stale-replay defect reported in #366. The fixed
+files were then restored (git checkout HEAD -- <files>) and the full VoiceTurn
+suite passes 14/14 (see test-output-*.txt).

--- a/docs/cencon/proof/issue-366/report.html
+++ b/docs/cencon/proof/issue-366/report.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof Report - Issue #366 - Voice-turn stale transcript fix</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1c2733; }
+  h1 { border-bottom: 3px solid #0b6e4f; padding-bottom: .4rem; }
+  h2 { color: #0b6e4f; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #c8d2dc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #eef3f7; }
+  code, pre { background: #f4f6f8; border-radius: 4px; }
+  code { padding: .1rem .3rem; }
+  pre { padding: .8rem; overflow-x: auto; border: 1px solid #dbe2e8; }
+  .pass { color: #0b6e4f; font-weight: 600; }
+  .fail { color: #b3261e; font-weight: 600; }
+  .meta { color: #5a6a78; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>Proof Report - Issue #366</h1>
+<p class="meta">
+  Issue: <a href="https://github.com/thefrederiksen/cc-director/issues/366">#366 [Voice] Fix stale transcript: voice-turn endpoint speaks previous-turn content</a><br>
+  PR: <a href="https://github.com/thefrederiksen/cc-director/pull/379">#379</a> (branch <code>issue-366-stale-transcript</code>)<br>
+  Date: 2026-06-12 - Developer Agent (CenCon Development Method)
+</p>
+
+<h2>What was implemented</h2>
+<p>
+The voice-turn endpoint (<code>POST /sessions/{sid}/voice-turn</code>) read the most recent
+assistant message of the WHOLE JSONL transcript after its turn poll loop. When the agent had
+not yet written its reply to the current utterance, the endpoint summarized and spoke the
+PREVIOUS turn's output - a systematic stale replay.
+</p>
+<ul>
+  <li><code>src/CcDirector.ControlApi/VoiceTurnEndpoint.cs</code> - <code>SnapshotTranscriptLength(session)</code>
+      captures the transcript byte length immediately before <code>session.SendTextAsync()</code>.
+      After the poll loop, <code>ReadNewAssistantText(session, offsetBefore)</code> reads only assistant
+      content appended at/after that offset. <code>ReadLastAssistantText</code> is gone.</li>
+  <li><code>src/CcDirector.Core/Claude/StreamMessage.cs</code> - new public
+      <code>StreamMessageParser.ParseFileFromOffset(jsonlPath, byteOffset)</code> (seeks to the snapshotted
+      line boundary, reads with <code>FileShare.ReadWrite</code>; an offset beyond EOF - transcript replaced -
+      reads from the start because then all content is new).</li>
+  <li><code>src/CcDirector.Gateway.Tests/VoiceTurnEndpointTests.cs</code> - regression test
+      <code>VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply</code> plus a
+      <code>TranscriptWritingBackend</code> stub that appends scripted assistant replies to a real temp
+      JSONL transcript per turn (and, when the script runs out, ends a turn with NO new content -
+      the exact defect window).</li>
+</ul>
+
+<h2>Acceptance criteria</h2>
+<table>
+  <tr><th>Criterion</th><th>Proof</th><th>Result</th></tr>
+  <tr>
+    <td>Two consecutive turns: the second turn's spoken summary reflects the second turn's reply, not the first turn's</td>
+    <td>Test turn 2: summary contains <code>ZEBRASECOND</code> and does NOT contain <code>ZEBRAFIRST</code>
+        (<code>test-output-voiceturn-gateway-tests.txt</code>)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Post-send byte-offset filter; no pre-turn assistant content can leak into the summary</td>
+    <td>Test turn 3: agent writes nothing during the turn; summary contains neither marker.
+        On PRE-FIX code this exact assertion fails with the stale turn-2 reply spoken
+        (<code>regression-proof-prefix-code-fails.txt</code>)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>dotnet build cc-director.sln</code> succeeds with 0 errors</td>
+    <td>Build output: <code>Build succeeded. 0 Warning(s) 0 Error(s)</code> (full solution, worktree at the PR head)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>dotnet test --filter VoiceTurn</code> passes; existing tests unaffected, new regression test added</td>
+    <td>14/14 pass: 9 in Gateway.Tests (8 existing + 1 new), 5 in Core.Tests
+        (<code>test-output-voiceturn-gateway-tests.txt</code>, <code>test-output-voiceturn-core-tests.txt</code>)</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Test output (fixed code)</h2>
+<pre>
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TextInput_EmitsTranscriptAndReplyStages [844 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_EmptyJsonBody_EmitsErrorStage [113 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_MissingTextAndAudio_EmitsErrorStage [103 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_WingmanUnavailable_ReplyStageAlwaysEmitted [715 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply [2 s]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_UnknownSession_Returns404Json [181 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_InvalidGuid_Returns400Json [179 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_AudioInput_NoKey_EmitsNoKeyError [109 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_SessionAlreadyExited_Returns410 [99 ms]
+Test Run Successful.  Total tests: 9  Passed: 9
+</pre>
+
+<h2>Regression proof (pre-fix code FAILS the new test)</h2>
+<pre>
+  Failed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply [2 s]
+   Assert.DoesNotContain() Failure: Sub-string found
+  String: "ZEBRASECOND the second task is complete."
+  Found:  "ZEBRASECOND"
+</pre>
+<p>
+On pre-fix code, turn 3 (agent wrote nothing during the turn) spoke the second turn's reply -
+the exact stale-replay defect from session e0a4ffbd. Procedure in
+<code>regression-proof-prefix-code-fails.txt</code>.
+</p>
+
+<h2>How QA can verify</h2>
+<ol>
+  <li>Check out PR #379 (branch <code>issue-366-stale-transcript</code>).</li>
+  <li><code>dotnet build cc-director.sln</code> - expect 0 errors.</li>
+  <li><code>dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter VoiceTurn</code> - expect 9/9 pass.</li>
+  <li><code>dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter VoiceTurn</code> - expect 5/5 pass.</li>
+  <li>Optional regression check: <code>git checkout origin/main -- src/CcDirector.ControlApi/VoiceTurnEndpoint.cs src/CcDirector.Core/Claude/StreamMessage.cs</code>,
+      rebuild the test project, re-run the named test - expect FAIL with the stale <code>ZEBRASECOND</code> leak;
+      then <code>git checkout HEAD -- &lt;files&gt;</code> to restore.</li>
+</ol>
+
+<h2>CenCon impact</h2>
+<p>No drift. Bug fix inside the existing <code>CcDirector.ControlApi</code> container plus a parsing helper
+in <code>CcDirector.Core</code> (Claude transcript reader). No architecture or security posture change;
+no blocking security rule touched.</p>
+
+<h2>Statement</h2>
+<p><strong>I believe this is finished.</strong> All four acceptance criteria are met with committed,
+reproducible proof, and the regression test demonstrably fails on the pre-fix code.</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-366/test-output-voiceturn-core-tests.txt
+++ b/docs/cencon/proof/issue-366/test-output-voiceturn-core-tests.txt
@@ -1,0 +1,9 @@
+  Passed CcDirector.Core.Tests.Voice.VoiceTurnLogTests.WriteInbound_WritesAudioAndTranscripts [31 ms]
+  Passed CcDirector.Core.Tests.Voice.VoiceTurnLogTests.WriteInbound_PurgesDirectoriesOlderThanRetention [3 ms]
+  Passed CcDirector.Core.Tests.Voice.VoiceTurnLogTests.AttachOutbound_DoesNotCrossSessions [14 ms]
+  Passed CcDirector.Core.Tests.Voice.VoiceTurnLogTests.AttachOutbound_AttachesToNewestPendingInboundForSession [31 ms]
+  Passed CcDirector.Core.Tests.Voice.VoiceTurnLogTests.AttachOutbound_NoPendingInbound_WritesStandalone [3 ms]
+Test Run Successful.
+Total tests: 5
+     Passed: 5
+ Total time: 0.6229 Seconds

--- a/docs/cencon/proof/issue-366/test-output-voiceturn-gateway-tests.txt
+++ b/docs/cencon/proof/issue-366/test-output-voiceturn-gateway-tests.txt
@@ -1,0 +1,13 @@
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TextInput_EmitsTranscriptAndReplyStages [844 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_EmptyJsonBody_EmitsErrorStage [113 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_MissingTextAndAudio_EmitsErrorStage [103 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_WingmanUnavailable_ReplyStageAlwaysEmitted [715 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply [2 s]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_UnknownSession_Returns404Json [181 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_InvalidGuid_Returns400Json [179 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_AudioInput_NoKey_EmitsNoKeyError [109 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnEndpointTests.VoiceTurn_SessionAlreadyExited_Returns410 [99 ms]
+Test Run Successful.
+Total tests: 9
+     Passed: 9
+ Total time: 5.1510 Seconds

--- a/src/CcDirector.ControlApi/VoiceTurnEndpoint.cs
+++ b/src/CcDirector.ControlApi/VoiceTurnEndpoint.cs
@@ -24,7 +24,9 @@ namespace CcDirector.ControlApi;
 ///   5. Call the ClaudeSummarizer to produce 2-3 sentences of plain spoken prose.
 ///   6. Synthesize via TtsService and return audio bytes in the reply event.
 ///   7. If summarizer or TTS unavailable, fall back to SpokenText from the last
-///      JSONL assistant message, synthesize that, and return it - never goes silent.
+///      JSONL assistant message of THIS turn (the transcript length is snapshotted
+///      before the text is posted, and only content appended after that offset is
+///      read - issue #366), synthesize that, and return it - never goes silent.
 ///
 /// Response: Server-Sent Events (text/event-stream). One data: JSON per stage, then
 /// a final {"stage":"reply","summary":"...","audioBase64":"..."}. On any terminal
@@ -184,7 +186,12 @@ internal static class VoiceTurnEndpoint
                 }
 
                 // --- step 3: post text to the session ---
-                FileLog.Write($"[VoiceTurnEndpoint] sid={guid}: sending text len={inputText.Length}");
+                // Snapshot the transcript length BEFORE sending so the reply read
+                // after the turn only sees assistant text appended for THIS turn.
+                // Without this, a turn whose reply has not been written yet would
+                // replay the PREVIOUS turn's output (issue #366).
+                var offsetBefore = SnapshotTranscriptLength(session);
+                FileLog.Write($"[VoiceTurnEndpoint] sid={guid}: sending text len={inputText.Length}, transcriptOffsetBefore={offsetBefore}");
                 try
                 {
                     await session.SendTextAsync(inputText);
@@ -222,7 +229,7 @@ internal static class VoiceTurnEndpoint
                 // --- step 5: summarize the reply ---
                 await EmitAsync(new { stage = "summarizing" });
 
-                var rawReply = ReadLastAssistantText(session);
+                var rawReply = ReadNewAssistantText(session, offsetBefore);
                 string summary;
                 try
                 {
@@ -358,25 +365,57 @@ internal static class VoiceTurnEndpoint
     }
 
     /// <summary>
-    /// Read the last assistant text block from the session's linked JSONL transcript.
-    /// Returns empty string when the session is unlinked or the file is not there yet.
+    /// Snapshot the byte length of the session's linked JSONL transcript.
+    /// Taken immediately before SendTextAsync so <see cref="ReadNewAssistantText"/>
+    /// can restrict the reply read to content appended during THIS turn (issue #366).
+    /// Returns 0 when the session is unlinked or the file does not exist yet
+    /// (then everything in the file is new).
     /// </summary>
-    private static string ReadLastAssistantText(Session session)
+    private static long SnapshotTranscriptLength(Session session)
     {
         try
         {
-            if (string.IsNullOrEmpty(session.ClaudeSessionId)) return "";
-            var jsonl = Core.Claude.ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
-            if (!File.Exists(jsonl)) return "";
-            var messages = Core.Claude.StreamMessageParser.ParseFile(jsonl);
+            var jsonl = GetTranscriptPath(session);
+            return jsonl is not null && File.Exists(jsonl) ? new FileInfo(jsonl).Length : 0L;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceTurnEndpoint] SnapshotTranscriptLength FAILED: {ex.Message}");
+            return 0L;
+        }
+    }
+
+    /// <summary>
+    /// Read the last assistant text block appended to the session's linked JSONL
+    /// transcript at or after <paramref name="offsetBefore"/> (the byte length
+    /// snapshotted before the turn's text was sent). Assistant content written
+    /// for PREVIOUS turns sits below the offset and is never returned, so a turn
+    /// whose reply has not been written yet yields "" instead of replaying the
+    /// previous turn's output (issue #366). Returns empty string when the session
+    /// is unlinked or the file is not there yet.
+    /// </summary>
+    private static string ReadNewAssistantText(Session session, long offsetBefore)
+    {
+        try
+        {
+            var jsonl = GetTranscriptPath(session);
+            if (jsonl is null || !File.Exists(jsonl)) return "";
+            var messages = Core.Claude.StreamMessageParser.ParseFileFromOffset(jsonl, offsetBefore);
             var summary = Core.Claude.SummaryBuilder.Build(messages);
             return summary.LastAssistantText ?? "";
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[VoiceTurnEndpoint] ReadLastAssistantText FAILED: {ex.Message}");
+            FileLog.Write($"[VoiceTurnEndpoint] ReadNewAssistantText FAILED: {ex.Message}");
             return "";
         }
+    }
+
+    /// <summary>Path of the session's linked JSONL transcript, or null when unlinked.</summary>
+    private static string? GetTranscriptPath(Session session)
+    {
+        if (string.IsNullOrEmpty(session.ClaudeSessionId)) return null;
+        return Core.Claude.ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Claude/StreamMessage.cs
+++ b/src/CcDirector.Core/Claude/StreamMessage.cs
@@ -163,6 +163,56 @@ public static class StreamMessageParser
         }
     }
 
+    /// <summary>
+    /// Parse messages starting from a specific BYTE offset in the JSONL file
+    /// (for reading only content appended after a snapshot, issue #366).
+    /// The offset must sit on a line boundary - callers snapshot the file
+    /// length between writes (Claude appends whole lines), so seeking there
+    /// lands at the start of the next appended line. Offsets beyond the
+    /// current end of file (e.g. the file was replaced and is now shorter)
+    /// fall back to reading from the start, because then ALL content is new.
+    /// Reads with FileShare.ReadWrite to allow reading while Claude is writing.
+    /// </summary>
+    public static List<StreamMessage> ParseFileFromOffset(string jsonlPath, long byteOffset)
+    {
+        FileLog.Write($"[StreamMessageParser] ParseFileFromOffset: {jsonlPath}, offset={byteOffset}");
+        var messages = new List<StreamMessage>();
+
+        if (!File.Exists(jsonlPath))
+        {
+            FileLog.Write("[StreamMessageParser] ParseFileFromOffset: file not found");
+            return messages;
+        }
+
+        try
+        {
+            using var fs = new FileStream(jsonlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            if (byteOffset > 0 && byteOffset <= fs.Length)
+                fs.Seek(byteOffset, SeekOrigin.Begin);
+            using var reader = new StreamReader(fs);
+
+            int lineNum = 0;
+            string? line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    var msg = ParseLine(line, lineNum);
+                    if (msg != null)
+                        messages.Add(msg);
+                }
+                lineNum++;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[StreamMessageParser] ParseFileFromOffset FAILED: {ex.Message}");
+        }
+
+        FileLog.Write($"[StreamMessageParser] ParseFileFromOffset: parsed {messages.Count} messages");
+        return messages;
+    }
+
     internal static StreamMessage? ParseLine(string line, int lineNum)
     {
         try

--- a/src/CcDirector.Gateway.Tests/VoiceTurnEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTurnEndpointTests.cs
@@ -279,7 +279,105 @@ public sealed class VoiceTurnEndpointTests : IAsyncLifetime
         Assert.NotNull(audioBase64);
     }
 
+    // ===== Test 6: consecutive turns must never replay a previous turn (issue #366) =====
+
+    /// <summary>
+    /// Regression test for issue #366: the endpoint snapshots the JSONL transcript
+    /// length before posting the turn's text and reads only assistant content
+    /// appended after that offset.
+    ///
+    /// Three turns against one session with a real (temp) JSONL transcript:
+    ///   Turn 1: the agent writes a reply containing FIRST marker -> spoken summary has it.
+    ///   Turn 2: the agent writes a reply containing SECOND marker -> spoken summary has
+    ///           the SECOND marker and never the first turn's content.
+    ///   Turn 3: the agent writes NOTHING during the turn (the exact #366 defect window:
+    ///           reply not yet in the transcript when the poll loop exits) -> the summary
+    ///           must not replay either previous turn's content.
+    /// Pre-#366 code read the last assistant message of the WHOLE file, so turn 3
+    /// would speak the second turn's reply again - this test fails on that code.
+    /// </summary>
+    [Fact]
+    public async Task VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply()
+    {
+        const string firstMarker = "ZEBRAFIRST";
+        const string secondMarker = "ZEBRASECOND";
+
+        // Unique fake repo path -> unique folder under ~/.claude/projects we fully own.
+        var repoPath = @"C:\test\voice-turn-366-" + Guid.NewGuid().ToString("N");
+        var claudeSessionId = Guid.NewGuid().ToString();
+        var jsonlPath = CcDirector.Core.Claude.ClaudeSessionReader.GetJsonlPath(claudeSessionId, repoPath);
+        var projectDir = Path.GetDirectoryName(jsonlPath)!;
+        Directory.CreateDirectory(projectDir);
+        File.WriteAllText(jsonlPath, "");
+
+        try
+        {
+            var backend = new TranscriptWritingBackend(jsonlPath, new[]
+            {
+                $"{firstMarker} the first task is complete.",
+                $"{secondMarker} the second task is complete.",
+                // Turn 3 has NO scripted reply: the agent has not written anything
+                // to the transcript when the turn poll loop exits.
+            });
+            var session = new Session(
+                Guid.NewGuid(),
+                repoPath: repoPath,
+                workingDirectory: repoPath,
+                claudeArgs: null,
+                backend: backend,
+                claudeSessionId: claudeSessionId,
+                activityState: ActivityState.Idle,
+                createdAt: DateTimeOffset.UtcNow,
+                customName: "voice-turn-366-test",
+                customColor: null);
+            session.MarkRunning();
+            backend.Session = session;
+            _sm.AdoptSession(session);
+            var sid = session.Id.ToString();
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+            // Turn 1: spoken summary reflects the first turn's reply.
+            var reply1 = await RunVoiceTurnAsync(sid, "do the first task", cts.Token);
+            Assert.Contains(firstMarker, reply1);
+
+            // Turn 2: spoken summary reflects THIS turn's reply, never the first turn's.
+            var reply2 = await RunVoiceTurnAsync(sid, "do the second task", cts.Token);
+            Assert.Contains(secondMarker, reply2);
+            Assert.DoesNotContain(firstMarker, reply2);
+
+            // Turn 3: nothing was written during the turn - no previous-turn content
+            // may leak into the spoken summary (the #366 stale replay).
+            var reply3 = await RunVoiceTurnAsync(sid, "and a third thing", cts.Token);
+            Assert.DoesNotContain(firstMarker, reply3);
+            Assert.DoesNotContain(secondMarker, reply3);
+        }
+        finally
+        {
+            try { Directory.Delete(projectDir, recursive: true); } catch { /* test cleanup */ }
+        }
+    }
+
     // ===== Helpers =============================================================
+
+    /// <summary>
+    /// POST one voice turn (JSON text path), stream the SSE events, and return the
+    /// final reply stage's summary. Asserts the reply stage exists.
+    /// </summary>
+    private async Task<string> RunVoiceTurnAsync(string sid, string text, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"sessions/{sid}/voice-turn")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(new { text }), Encoding.UTF8, "application/json"),
+        };
+        using var resp = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var events = await ReadSseStreamAsync(resp, ct);
+        var replyEvent = events.LastOrDefault(e => ReadStage(e) == "reply");
+        Assert.NotNull(replyEvent);
+        return ReadField(replyEvent!, "summary") ?? "";
+    }
 
     /// <summary>
     /// Create a minimal idle session backed by a stub backend. The QuickIdleBackend
@@ -474,6 +572,83 @@ public sealed class VoiceTurnEndpointTests : IAsyncLifetime
             // Fire-and-forget: after Session.SendTextAsync sets Working state (which happens
             // after we return), flip back to WaitingForInput to simulate an instant turn-end.
             // The 200ms delay ensures we run AFTER Session.SendTextAsync has set Working.
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(200);
+                Session?.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+            });
+            return Task.CompletedTask;
+        }
+
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Stub backend for issue #366: behaves like QuickIdleBackend (flips the session
+    /// back to WaitingForInput shortly after SendTextAsync), but also appends one
+    /// scripted assistant reply per turn to a real JSONL transcript BEFORE the flip -
+    /// like a real agent writing its response. When the scripted replies run out, a
+    /// turn ends with NO new assistant content, reproducing the exact #366 defect
+    /// window (the agent has not written its reply when the poll loop exits).
+    /// </summary>
+    private sealed class TranscriptWritingBackend : ISessionBackend
+    {
+        private readonly string _jsonlPath;
+        private readonly Queue<string> _pendingReplies;
+
+        public Session? Session { get; set; }
+
+        public TranscriptWritingBackend(string jsonlPath, IEnumerable<string> replies)
+        {
+            _jsonlPath = jsonlPath;
+            _pendingReplies = new Queue<string>(replies);
+        }
+
+        public int ProcessId => 1;
+        public string Status => "TranscriptWriting";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows,
+            Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+
+        public Task SendTextAsync(string text)
+        {
+            // Append this turn's user prompt + assistant reply (when scripted) in the
+            // Claude Code JSONL shape, synchronously, so the transcript content is in
+            // place before the WaitingForInput flip ends the turn.
+            if (_pendingReplies.Count > 0)
+            {
+                var reply = _pendingReplies.Dequeue();
+                var userLine = JsonSerializer.Serialize(new
+                {
+                    type = "user",
+                    message = new { role = "user", content = text },
+                });
+                var assistantLine = JsonSerializer.Serialize(new
+                {
+                    type = "assistant",
+                    message = new
+                    {
+                        role = "assistant",
+                        content = new object[] { new { type = "text", text = reply } },
+                    },
+                });
+                File.AppendAllText(_jsonlPath, userLine + "\n" + assistantLine + "\n");
+            }
+
+            // Same instant-turn-end simulation as QuickIdleBackend: the 200ms delay
+            // ensures we run AFTER Session.SendTextAsync has set Working.
             _ = Task.Run(async () =>
             {
                 await Task.Delay(200);


### PR DESCRIPTION
Closes #366

## Root cause
ReadLastAssistantText read the most recent assistant message of the WHOLE JSONL transcript after the turn poll loop. If the agent had not yet written its reply to the current utterance, the endpoint summarized and spoke the PREVIOUS turn's output - a systematic stale replay (4 consecutive turns affected in session e0a4ffbd).

## Fix
- VoiceTurnEndpoint snapshots the transcript byte length immediately before session.SendTextAsync() (SnapshotTranscriptLength) and, after the poll loop, reads only assistant content appended at/after that offset (ReadNewAssistantText). Pre-turn assistant content can no longer leak into the spoken summary.
- New public StreamMessageParser.ParseFileFromOffset(jsonlPath, byteOffset) in Core (ParseLine is internal and not visible to ControlApi; parsing belongs in Core).

## Test
VoiceTurn_TwoConsecutiveTurns_SecondTurnSpeaksCurrentReply: three turns on one session against a real temp JSONL transcript via a transcript-writing stub backend. Turn 2 speaks the second reply only; turn 3 (agent wrote nothing during the turn - the exact defect window) speaks no stale content. Verified the test FAILS against pre-fix code (turn 3 spoke the turn-2 reply) and passes with the fix.

dotnet build cc-director.sln: 0 errors, 0 warnings. dotnet test --filter VoiceTurn: 14/14 pass (9 Gateway.Tests + 5 Core.Tests).

Proof: docs/cencon/proof/issue-366/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)