### PR TITLE
fix(#367): non-Latin script refusal in ClaudeSummarizer

### DIFF
--- a/docs/cencon/proof/issue-367/dotnet-test-output.txt
+++ b/docs/cencon/proof/issue-367/dotnet-test-output.txt
@@ -1,0 +1,17 @@
+Test run for D:\ReposFred\cc-director\src\CcDirector.Core.Tests\bin\Debug\net10.0\CcDirector.Core.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 10.0.9)
+[xUnit.net 00:00:00.06]   Discovering: CcDirector.Core.Tests
+[xUnit.net 00:00:00.18]   Discovered:  CcDirector.Core.Tests
+[xUnit.net 00:00:00.18]   Starting:    CcDirector.Core.Tests
+[xUnit.net 00:00:00.22]   Finished:    CcDirector.Core.Tests
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_JapaneseInput_IsNotDropped [4 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_NonLatinInput_IsNotDropped [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions [6 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions [< 1 ms]
+
+Test Run Successful.
+Total tests: 5
+     Passed: 5
+ Total time: 0.5925 Seconds

--- a/docs/cencon/proof/issue-367/qa-report.html
+++ b/docs/cencon/proof/issue-367/qa-report.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Report - Issue #367 - Non-Latin script refusal in ClaudeSummarizer</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 960px; color: #1a1a2e; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #0f3460; padding-bottom: .4rem; }
+  h2 { color: #0f3460; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #c8c8d0; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #0f3460; color: #fff; }
+  .pass { background: #e6f4ea; color: #137333; font-weight: 700; }
+  .verdict { background: #137333; color: #fff; padding: 1rem 1.4rem; font-size: 1.2rem; font-weight: 700; border-radius: 6px; margin: 1.5rem 0; }
+  pre { background: #f4f4f8; border: 1px solid #d8d8e0; padding: .8rem; overflow-x: auto; font-size: .85rem; }
+  code { background: #f0f0f5; padding: .1rem .3rem; border-radius: 3px; }
+  .meta td:first-child { font-weight: 600; width: 220px; }
+</style>
+</head>
+<body>
+<h1>QA Verification Report - Issue #367</h1>
+<p><strong>[Voice] Fix non-Latin script refusal in ClaudeSummarizer</strong></p>
+
+<table class="meta">
+  <tr><td>Issue</td><td>#367 (thefrederiksen/cc-director)</td></tr>
+  <tr><td>PR</td><td>#380, branch <code>issue-367-non-latin</code>, HEAD <code>8b13870</code></td></tr>
+  <tr><td>QA performed</td><td>2026-06-12 (UTC), independent context - dev report not trusted, all checks re-run by QA</td></tr>
+  <tr><td>Method</td><td>Fresh pull of <code>main</code> + checkout of PR branch; code inspection of the fix and diff vs main; full solution build; test runs executed by QA. Verification surface is unit-test/code-level (the issue's Proof Target is passing <code>dotnet test</code> output), so no Director slot/launch was required.</td></tr>
+  <tr><td>Raw evidence</td><td><code>docs/cencon/proof/issue-367/qa-test-output.txt</code> (QA-captured build + test output)</td></tr>
+</table>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-observed)</th><th>Verdict</th></tr>
+  <tr>
+    <td>1</td>
+    <td>Korean test string (the flagged-turn sentence) passed through <code>CleanupForSpeech</code> is not reduced to an empty or near-empty string</td>
+    <td>Content survives pre-processing</td>
+    <td><code>ClaudeSummarizer_NonLatinInput_IsNotDropped</code> PASSED. The test asserts <code>Assert.Equal(korean, result)</code> - the full Korean sentence survives byte-for-byte, stronger than "not near-empty". Japanese variant (<code>CleanupForSpeech_JapaneseInput_IsNotDropped</code>) and markdown-wrapped Korean (<code>CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown</code>) also PASSED. QA inspected <code>CleanupForSpeech</code>: it operates only on markdown syntax characters (regex on backticks, brackets, asterisks, underscores, hashes, whitespace) - no code-point filtering exists.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>Summarizer prompt contains no instructions to reject, flag, or replace non-ASCII characters</td>
+    <td>No rejection language; faithful source-language summary mandated</td>
+    <td>QA read both prompts in <code>ClaudeSummarizer.cs</code>. <code>SummarizationPrompt</code> states the reply may be in ANY language or script, that non-Latin Unicode is valid content and never encoding corruption, and mandates summarizing faithfully in the same language, never refusing. <code>ProgressPrompt</code> has the equivalent clause. Two prompt tests (<code>SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions</code>, <code>ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions</code>) assert absence of reject/invalid/ASCII instructions - both PASSED.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td><code>dotnet build cc-director.sln</code> succeeds with 0 errors</td>
+    <td>Build succeeded, 0 errors</td>
+    <td>QA ran it on the PR branch: <strong>Build succeeded. 0 Warning(s), 0 Error(s)</strong>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td><code>dotnet test --filter ClaudeSummarizer</code> passes; existing tests unaffected, new test added</td>
+    <td>All filter tests pass; no regression</td>
+    <td>QA ran it: <strong>5/5 PASSED</strong> (new file <code>ClaudeSummarizerTests.cs</code>, including the proof target). Regression sweep: full Voice namespace <strong>86/86 PASSED</strong>, full solution builds clean.</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Root-cause review (code inspection)</h2>
+<p>The actual corruption source was not an explicit validation guard: <code>RunClaudeAsync</code> redirected the claude CLI's stdin/stdout/stderr without specifying encodings, so Windows applied the legacy console code page and mangled non-Latin scripts into "?" before the model saw them. The fix sets BOM-less UTF-8 on <code>StandardInputEncoding</code>, <code>StandardOutputEncoding</code>, and <code>StandardErrorEncoding</code>. Combined with the prompt mandate (criterion 2), this addresses both the data path and the model behavior. The issue's stated assumption (defect in pre-processing or prompt text in ClaudeSummarizer.cs) holds - no guard exists elsewhere in the pipeline for this defect class.</p>
+
+<h2>Scope and method checks</h2>
+<ul>
+  <li>PR diff vs main touches only <code>src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs</code>, the new test file, and proof artifacts. Out-of-scope files (<code>VoiceTurnEndpoint.cs</code>, <code>TtsService.cs</code>, Gateway) are untouched - confirmed from the PR file list and <code>git diff main...HEAD --stat</code>.</li>
+  <li>Visibility widening (<code>private</code> to <code>internal</code>) for <code>CleanupForSpeech</code> and the prompt constants is test-access only; <code>InternalsVisibleTo</code> already present. No public API change.</li>
+  <li>No CenCon blocking security rule touched; no architecture/security change requiring docs updates.</li>
+  <li>PR reported MERGEABLE against current main.</li>
+</ul>
+
+<h2>QA-captured evidence</h2>
+<pre>--- dotnet build cc-director.sln (tail) ---
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+--- dotnet test --filter ClaudeSummarizer (per-test) ---
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_JapaneseInput_IsNotDropped
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_NonLatinInput_IsNotDropped
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions
+
+--- Voice namespace regression ---
+Passed!  - Failed: 0, Passed: 86, Skipped: 0, Total: 86</pre>
+
+<div class="verdict">VERIFIED - all acceptance criteria met. 4/4 PASS. Issue #367 approved for merge.</div>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-367/qa-test-output.txt
+++ b/docs/cencon/proof/issue-367/qa-test-output.txt
@@ -1,0 +1,19 @@
+=== QA independent verification - issue #367 / PR #380 ===
+Date: 2026-06-12T22:23:10Z  Branch: issue-367-non-latin  HEAD: 8b13870
+
+--- dotnet build cc-director.sln (tail) ---
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:02.48
+
+--- dotnet test --filter ClaudeSummarizer (per-test) ---
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_JapaneseInput_IsNotDropped [6 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_NonLatinInput_IsNotDropped [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown [1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions [8 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions [< 1 ms]
+
+--- Voice namespace regression ---
+Passed!  - Failed:     0, Passed:    86, Skipped:     0, Total:    86, Duration: 171 ms - CcDirector.Core.Tests.dll (net10.0)

--- a/docs/cencon/proof/issue-367/report.html
+++ b/docs/cencon/proof/issue-367/report.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof - Issue #367: Non-Latin script refusal in ClaudeSummarizer</title>
+<style>
+  body { font-family: 'Segoe UI', Arial, sans-serif; background: #1e1e1e; color: #cccccc; margin: 0; padding: 2rem; line-height: 1.5; }
+  .wrap { max-width: 960px; margin: 0 auto; }
+  h1 { color: #ffffff; font-size: 1.5rem; border-bottom: 2px solid #007acc; padding-bottom: .5rem; }
+  h2 { color: #4fc1ff; font-size: 1.15rem; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #3c3c3c; padding: .5rem .75rem; text-align: left; vertical-align: top; }
+  th { background: #252526; color: #ffffff; }
+  .pass { color: #4ec9b0; font-weight: bold; }
+  pre { background: #0d0d0d; color: #d4d4d4; padding: 1rem; overflow-x: auto; border: 1px solid #3c3c3c; border-radius: 4px; font-size: .85rem; }
+  code { background: #252526; padding: .1rem .3rem; border-radius: 3px; font-size: .9em; }
+  .meta { color: #808080; font-size: .85rem; }
+  .verdict { background: #16331f; border: 1px solid #4ec9b0; border-radius: 4px; padding: 1rem; margin-top: 2rem; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Proof - Issue #367: [Voice] Fix non-Latin script refusal in ClaudeSummarizer</h1>
+<p class="meta">Developer Agent - 2026-06-12 - Branch <code>issue-367-non-latin</code> - PR #380 - Container: CcDirector.Core</p>
+
+<h2>What was implemented</h2>
+<p>Voice turns whose agent reply contained non-Latin script (Korean, Japanese, Arabic, ...) came back as a spoken refusal ("the text cannot be read") instead of a summary. Two defects in <code>src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs</code> were fixed:</p>
+<table>
+<tr><th>Defect</th><th>Fix</th></tr>
+<tr>
+  <td><strong>Console-code-page mojibake on the CLI pipes.</strong> <code>RunClaudeAsync</code> redirected the <code>claude</code> CLI's stdin/stdout/stderr without setting encodings. On Windows the redirected pipes default to the legacy console code page, which destroys non-Latin code points into <code>?</code> before the model ever sees them - the model then reports the text as unreadable corruption. This was the de-facto "pre-processing that flags non-ASCII code points as invalid" named by the issue.</td>
+  <td><code>StandardInputEncoding</code>, <code>StandardOutputEncoding</code>, and <code>StandardErrorEncoding</code> are now BOM-less UTF-8, so all scripts reach the model intact.</td>
+</tr>
+<tr>
+  <td><strong>Prompts never authorized non-Latin input</strong>, so the model had no instruction to summarize a non-English reply rather than refuse.</td>
+  <td><code>SummarizationPrompt</code> and <code>ProgressPrompt</code> now explicitly state: input may be in ANY language or script, non-Latin Unicode is valid content (never encoding corruption), summarize faithfully in the source language, and never refuse. Neither prompt contains any instruction to reject, flag, or replace non-ASCII characters.</td>
+</tr>
+</table>
+<p><code>CleanupForSpeech</code> and the prompt constants changed from <code>private</code> to <code>internal</code> so <code>CcDirector.Core.Tests</code> can prove the behavior (<code>InternalsVisibleTo</code> already declared in CcDirector.Core.csproj). Out-of-scope files (<code>VoiceTurnEndpoint.cs</code>, <code>TtsService.cs</code>, Gateway) untouched.</p>
+
+<h2>Acceptance criteria - proof for each</h2>
+<table>
+<tr><th>Criterion</th><th>Proof</th><th>Result</th></tr>
+<tr>
+  <td>Korean string ("&#50504;&#45397;&#54616;&#49464;&#50836;, ...") through <code>CleanupForSpeech</code> is not reduced to an empty or near-empty string</td>
+  <td>Test <code>ClaudeSummarizer_NonLatinInput_IsNotDropped</code> asserts the result is non-blank AND equals the full original Korean sentence. PASSED (see test output below).</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>The summarizer prompt does not contain instructions to reject, flag, or replace non-ASCII characters</td>
+  <td>Tests <code>SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions</code> and <code>ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions</code> assert the prompts contain the explicit language-allowance text and contain no "reject"/"invalid"/"ASCII" instructions. PASSED.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td><code>dotnet build cc-director.sln</code> succeeds with 0 errors</td>
+  <td>Full-solution build output: <code>Build succeeded. 0 Warning(s) 0 Error(s)</code> (Time Elapsed 00:00:16.17).</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td><code>dotnet test --filter ClaudeSummarizer</code> passes (existing tests unaffected, new test added)</td>
+  <td>5/5 passed (full log: <code>dotnet-test-output.txt</code> beside this report). Whole <code>CcDirector.Core.Tests.Voice</code> namespace also re-run: 86/86 passed - no existing test affected.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>dotnet test output (proof target)</h2>
+<pre>
+[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 10.0.9)
+[xUnit.net 00:00:00.06]   Discovering: CcDirector.Core.Tests
+[xUnit.net 00:00:00.18]   Discovered:  CcDirector.Core.Tests
+[xUnit.net 00:00:00.18]   Starting:    CcDirector.Core.Tests
+[xUnit.net 00:00:00.22]   Finished:    CcDirector.Core.Tests
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_JapaneseInput_IsNotDropped [4 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_NonLatinInput_IsNotDropped [&lt; 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown [&lt; 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions [6 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions [&lt; 1 ms]
+
+Test Run Successful.
+Total tests: 5
+     Passed: 5
+ Total time: 0.5925 Seconds
+</pre>
+
+<h2>CenCon impact</h2>
+<p>No drift. Internal fix inside the existing CcDirector.Core voice service; no container, interface, or security-posture change. <code>review-code</code> self-review: PASS (0 blocking, 0 warnings, PII scan clean, CenCon docs current, security profile within drift threshold).</p>
+
+<div class="verdict">
+<strong>Developer Agent verdict:</strong> All four acceptance criteria are met with committed, passing tests. I believe this is finished.
+</div>
+
+</div>
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/Voice/ClaudeSummarizerTests.cs
+++ b/src/CcDirector.Core.Tests/Voice/ClaudeSummarizerTests.cs
@@ -1,0 +1,76 @@
+using CcDirector.Core.Voice.Services;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Voice;
+
+/// <summary>
+/// Coverage for ClaudeSummarizer pre-processing and prompt content (issue #367):
+/// non-Latin scripts (Korean, Japanese, ...) are valid voice content and must
+/// survive CleanupForSpeech, and the summarizer prompts must instruct the model
+/// to summarize faithfully in the source language instead of refusing.
+/// </summary>
+public sealed class ClaudeSummarizerTests
+{
+    [Fact]
+    public void ClaudeSummarizer_NonLatinInput_IsNotDropped()
+    {
+        // Korean agent reply - the exact defect class from the flagged voice turn.
+        var korean = "안녕하세요, 도움이 필요하시면 말씀해 주세요.";
+
+        var result = ClaudeSummarizer.CleanupForSpeech(korean);
+
+        Assert.False(string.IsNullOrWhiteSpace(result));
+        // Not near-empty: the full Korean sentence survives, not a stripped husk.
+        Assert.Equal(korean, result);
+    }
+
+    [Fact]
+    public void CleanupForSpeech_JapaneseInput_IsNotDropped()
+    {
+        var japanese = "ビルドは成功しました。テストはすべて合格です。";
+
+        var result = ClaudeSummarizer.CleanupForSpeech(japanese);
+
+        Assert.False(string.IsNullOrWhiteSpace(result));
+        Assert.Equal(japanese, result);
+    }
+
+    [Fact]
+    public void CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown()
+    {
+        // Markdown stripping must remove only the markdown syntax, never the
+        // non-Latin content it wraps.
+        var korean = "완료되었습니다";
+        var input = $"**{korean}**";
+
+        var result = ClaudeSummarizer.CleanupForSpeech(input);
+
+        Assert.Equal(korean, result);
+    }
+
+    [Fact]
+    public void SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions()
+    {
+        // The prompt must explicitly authorize any language/script...
+        Assert.Contains("ANY language", ClaudeSummarizer.SummarizationPrompt);
+        Assert.Contains("never encoding corruption", ClaudeSummarizer.SummarizationPrompt);
+        Assert.Contains("never refuse", ClaudeSummarizer.SummarizationPrompt);
+
+        // ...and must not instruct the model to reject, flag, or replace
+        // non-ASCII characters as invalid.
+        Assert.DoesNotContain("reject", ClaudeSummarizer.SummarizationPrompt, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("invalid", ClaudeSummarizer.SummarizationPrompt, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ASCII", ClaudeSummarizer.SummarizationPrompt, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions()
+    {
+        Assert.Contains("any language", ClaudeSummarizer.ProgressPrompt);
+        Assert.Contains("never refuse", ClaudeSummarizer.ProgressPrompt);
+
+        Assert.DoesNotContain("reject", ClaudeSummarizer.ProgressPrompt, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("invalid", ClaudeSummarizer.ProgressPrompt, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ASCII", ClaudeSummarizer.ProgressPrompt, System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs
+++ b/src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs
@@ -18,9 +18,10 @@ public class ClaudeSummarizer : IResponseSummarizer
     private string? _unavailableReason;
 
     /// <summary>
-    /// The prompt template for summarization.
+    /// The prompt template for summarization. Internal so tests can assert the
+    /// prompt allows non-Latin input (issue #367).
     /// </summary>
-    private const string SummarizationPrompt = """
+    internal const string SummarizationPrompt = """
         You are turning a coding agent's written reply into words a person will
         hear out loud, probably while driving. Your job is FIDELITY, not brevity:
         the listener must hear the agent's actual answer, not a looser version of
@@ -35,21 +36,29 @@ public class ClaudeSummarizer : IResponseSummarizer
         - Speak for the ear: do not read code, commands, file paths, function
           names, or symbols out loud. When code matters, say in plain words what
           it does or would do.
+        - The reply may be in ANY language or script (Korean, Japanese, Arabic,
+          and so on). Non-Latin and other Unicode characters are valid content,
+          never encoding corruption. Summarize faithfully in the same language
+          the reply is written in; never refuse or say the text cannot be read.
         Output ONLY the spoken version, nothing else.
         """;
 
     /// <summary>
     /// The prompt template for periodic progress notes during a long turn. The
     /// input is a raw, noisy terminal tail; the job is to extract intent.
+    /// Internal so tests can assert the prompt allows non-Latin input (issue #367).
     /// </summary>
-    private const string ProgressPrompt = """
+    internal const string ProgressPrompt = """
         Below is the recent terminal output of a coding agent that is STILL working
         on a task. In one or two short, calm spoken sentences, tell a person who is
         listening while driving what the agent appears to be doing right now. Speak
         in plain concepts only: no code, commands, file paths, function names, or
-        symbols. Begin as if continuing to wait, for example "Still going" or
-        "Still working". If you genuinely cannot tell what it is doing, say only
-        that it is still working. Output ONLY the spoken update, nothing else.
+        symbols. The output may be in any language or script; non-Latin Unicode
+        characters are valid content, never encoding corruption - describe the work
+        in the same language, and never refuse. Begin as if continuing to wait, for
+        example "Still going" or "Still working". If you genuinely cannot tell what
+        it is doing, say only that it is still working. Output ONLY the spoken
+        update, nothing else.
         """;
 
     /// <inheritdoc />
@@ -172,6 +181,12 @@ public class ClaudeSummarizer : IResponseSummarizer
     /// </summary>
     private static async Task<string> RunClaudeAsync(string prompt, string input, CancellationToken cancellationToken)
     {
+        // UTF-8 on all redirected pipes (issue #367): without this, Windows
+        // defaults redirected stdin/stdout to the legacy console code page,
+        // which destroys non-Latin scripts (Korean, Japanese, ...) into "?"
+        // mojibake before the model ever sees them - the model then reports
+        // the text as unreadable corruption and the spoken summary is lost.
+        var utf8NoBom = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         var psi = new ProcessStartInfo
         {
             FileName = ClaudeExecutable,
@@ -179,6 +194,9 @@ public class ClaudeSummarizer : IResponseSummarizer
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            StandardInputEncoding = utf8NoBom,
+            StandardOutputEncoding = utf8NoBom,
+            StandardErrorEncoding = utf8NoBom,
             UseShellExecute = false,
             CreateNoWindow = true
         };
@@ -256,9 +274,11 @@ public class ClaudeSummarizer : IResponseSummarizer
 
     /// <summary>
     /// Clean up text for speech synthesis.
-    /// Removes markdown formatting, code blocks, etc.
+    /// Removes markdown formatting, code blocks, etc. Operates only on markdown
+    /// syntax characters - all scripts (Latin or not) pass through untouched.
+    /// Internal so tests can prove non-Latin input is not dropped (issue #367).
     /// </summary>
-    private static string CleanupForSpeech(string text)
+    internal static string CleanupForSpeech(string text)
     {
         // Remove code blocks
         text = System.Text.RegularExpressions.Regex.Replace(text, @"```[\s\S]*?```", "");


### PR DESCRIPTION
Fixes #367.

## What

The Haiku voice summarizer refused to summarize agent replies containing non-Latin scripts (Korean, Japanese, Arabic, ...), speaking a refusal message instead - the voice channel went silent for non-English sessions.

## Root causes (both in src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs)

1. **Console-code-page mojibake on the CLI pipes.** `RunClaudeAsync` redirected the `claude` CLI's stdin/stdout/stderr without setting encodings, so Windows used the legacy console code page and destroyed non-Latin code points into `?` before the model ever saw them. The model then (correctly, given its input) reported the text as unreadable corruption. This was the de-facto "pre-processing that flags non-ASCII as invalid" named in the issue. All three pipes now use BOM-less UTF-8.
2. **Prompts never authorized non-Latin input.** Both `SummarizationPrompt` and `ProgressPrompt` now explicitly state that any language/script is valid content, to summarize faithfully in the source language, and never to refuse or treat Unicode as encoding corruption. Neither prompt contains any instruction to reject, flag, or replace non-ASCII characters.

`CleanupForSpeech` and the prompt constants are now `internal` (was `private`) so the test project can prove non-Latin content survives pre-processing (`InternalsVisibleTo CcDirector.Core.Tests` already declared).

## Tests

New `src/CcDirector.Core.Tests/Voice/ClaudeSummarizerTests.cs`:
- `ClaudeSummarizer_NonLatinInput_IsNotDropped` - the proof-target test: Korean through `CleanupForSpeech`, full content survives
- Japanese input survives; markdown-wrapped Korean keeps text and loses only the markdown
- Both prompts assert language-allowance present and no reject/invalid/ASCII instructions

`dotnet build cc-director.sln`: Build succeeded, 0 errors, 0 warnings.
`dotnet test --filter ClaudeSummarizer`: 5/5 passed. Full Voice namespace: 86/86 passed.

## Acceptance criteria

- [x] Korean test string through `CleanupForSpeech` is not reduced to empty/near-empty
- [x] Summarizer prompt contains no instructions to reject/flag/replace non-ASCII characters
- [x] `dotnet build cc-director.sln` succeeds with 0 errors
- [x] `dotnet test --filter ClaudeSummarizer` passes (new test added, existing tests unaffected)

## CenCon impact

No drift - internal fix inside the existing CcDirector.Core voice service; no architecture or security posture change. Out-of-scope files (VoiceTurnEndpoint.cs, TtsService.cs, Gateway) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)