### PR TITLE
fix(#368): preserve inline-backtick content in ClaudeSummarizer CleanupForSpeech

### DIFF
--- a/docs/cencon/proof/issue-368/dotnet-build-output.txt
+++ b/docs/cencon/proof/issue-368/dotnet-build-output.txt
@@ -1,0 +1,35 @@
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  CcDirector.AgentBrain -> D:\ReposFred\cc-director\src\CcDirector.AgentBrain\bin\Debug\net10.0\CcDirector.AgentBrain.dll
+  CcDirector.Gateway.Contracts -> D:\ReposFred\cc-director\src\CcDirector.Gateway.Contracts\bin\Debug\net10.0\CcDirector.Gateway.Contracts.dll
+  CcDirector.Terminal.Core -> D:\ReposFred\cc-director\src\CcDirector.Terminal.Core\bin\Debug\net10.0\CcDirector.Terminal.Core.dll
+  CcClick -> D:\ReposFred\cc-director\src\CcClick\bin\Debug\net10.0-windows\CcClick.dll
+  CcDirector.Core -> D:\ReposFred\cc-director\src\CcDirector.Core\bin\Debug\net10.0\CcDirector.Core.dll
+  CcDirector.Setup.Engine -> D:\ReposFred\cc-director\tools\cc-director-setup-engine\bin\Debug\net10.0\CcDirector.Setup.Engine.dll
+  CcDirector.Terminal.Avalonia -> D:\ReposFred\cc-director\src\CcDirector.Terminal.Avalonia\bin\Debug\net10.0\CcDirector.Terminal.Avalonia.dll
+  CcDirector.Engine -> D:\ReposFred\cc-director\src\CcDirector.Engine\bin\Debug\net10.0\CcDirector.Engine.dll
+  CcDirector.HostedAgent -> D:\ReposFred\cc-director\src\CcDirector.HostedAgent\bin\Debug\net10.0\CcDirector.HostedAgent.dll
+  CcDirector.VoskStt -> D:\ReposFred\cc-director\src\CcDirector.VoskStt\bin\Debug\net10.0-windows\CcDirector.VoskStt.dll
+  CcDirector.ContentWriter -> D:\ReposFred\cc-director\src\CcDirector.ContentWriter\bin\Debug\net10.0-windows\CcDirector.ContentWriter.dll
+  CcDirector.CliExplorer -> D:\ReposFred\cc-director\src\CcDirector.CliExplorer\bin\Debug\net10.0-windows\CcDirector.CliExplorer.dll
+  CcDirector.Cockpit -> D:\ReposFred\cc-director\src\CcDirector.Cockpit\bin\Debug\net10.0\cc-director-cockpit.dll
+  CcDirector.Core.Tests -> D:\ReposFred\cc-director\src\CcDirector.Core.Tests\bin\Debug\net10.0\CcDirector.Core.Tests.dll
+  CcDirector.DocumentLibrary -> D:\ReposFred\cc-director\src\CcDirector.DocumentLibrary\bin\Debug\net10.0-windows\CcDirector.DocumentLibrary.dll
+  CcDirector.Terminal -> D:\ReposFred\cc-director\src\CcDirector.Terminal\bin\Debug\net10.0-windows\CcDirector.Terminal.dll
+  CcDirector.Engine.Tests -> D:\ReposFred\cc-director\src\CcDirector.Engine.Tests\bin\Debug\net10.0\CcDirector.Engine.Tests.dll
+  CcDirector.HostedAgent.Tests -> D:\ReposFred\cc-director\src\CcDirector.HostedAgent.Tests\bin\Debug\net10.0\CcDirector.HostedAgent.Tests.dll
+  CcDirector.Cockpit.Tests -> D:\ReposFred\cc-director\src\CcDirector.Cockpit.Tests\bin\Debug\net10.0\CcDirector.Cockpit.Tests.dll
+  CcDirector.AgentBrain.Panel -> D:\ReposFred\cc-director\src\CcDirector.AgentBrain.Panel\bin\Debug\net10.0\agent-brain-panel.dll
+  CcDirector.ControlApi -> D:\ReposFred\cc-director\src\CcDirector.ControlApi\bin\Debug\net10.0\CcDirector.ControlApi.dll
+  CcDirector.Launcher -> D:\ReposFred\cc-director\src\CcDirector.Launcher\bin\Debug\net10.0-windows\cc-launcher.dll
+  CcDirector.Gateway -> D:\ReposFred\cc-director\src\CcDirector.Gateway\bin\Debug\net10.0\CcDirector.Gateway.dll
+  CcDirector.Launcher.Tests -> D:\ReposFred\cc-director\src\CcDirector.Launcher.Tests\bin\Debug\net10.0-windows\CcDirector.Launcher.Tests.dll
+  CcDirector.Gateway.Tests -> D:\ReposFred\cc-director\src\CcDirector.Gateway.Tests\bin\Debug\net10.0\CcDirector.Gateway.Tests.dll
+  CcDirector.GatewayApp -> D:\ReposFred\cc-director\src\CcDirector.GatewayApp\bin\Debug\net10.0-windows\cc-director-gateway.dll
+  CcDirector.Avalonia -> D:\ReposFred\cc-director\src\CcDirector.Avalonia\bin\Debug\net10.0\cc-director.dll
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:27.32

--- a/docs/cencon/proof/issue-368/dotnet-test-output.txt
+++ b/docs/cencon/proof/issue-368/dotnet-test-output.txt
@@ -1,0 +1,20 @@
+Test run for D:\ReposFred\cc-director\src\CcDirector.Core.Tests\bin\Debug\net10.0\CcDirector.Core.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 10.0.9)
+[xUnit.net 00:00:00.11]   Discovering: CcDirector.Core.Tests
+[xUnit.net 00:00:00.28]   Discovered:  CcDirector.Core.Tests
+[xUnit.net 00:00:00.29]   Starting:    CcDirector.Core.Tests
+[xUnit.net 00:00:00.34]   Finished:    CcDirector.Core.Tests
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_BacktickIdentifier_IsPreserved [5 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_JapaneseInput_IsNotDropped [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_NonLatinInput_IsNotDropped [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_TripleBacktickCodeBlock_IsStripped [6 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_BacktickKeyValue_IsPreserved [< 1 ms]
+  Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions [< 1 ms]
+
+Test Run Successful.
+Total tests: 8
+     Passed: 8
+ Total time: 0.9650 Seconds

--- a/docs/cencon/proof/issue-368/qa-report.html
+++ b/docs/cencon/proof/issue-368/qa-report.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #368</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 900px; color: #222; }
+  h1 { border-bottom: 2px solid #5319e7; padding-bottom: 0.3rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: 0.5rem 0.7rem; text-align: left; vertical-align: top; }
+  th { background: #f3f0fa; }
+  .pass { color: #1a7f37; font-weight: bold; }
+  pre { background: #f6f8fa; padding: 0.8rem; overflow-x: auto; border: 1px solid #ddd; font-size: 0.85rem; }
+  .verdict { background: #e6f4ea; border: 2px solid #1a7f37; padding: 1rem; font-size: 1.1rem; font-weight: bold; }
+  .meta { color: #555; font-size: 0.9rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #368</h1>
+<p class="meta">
+  Issue: [Voice] Fix backtick content deletion in ClaudeSummarizer CleanupForSpeech<br>
+  PR: #381 (branch issue-368-backtick, head 5a31d95, base = origin/main 4bc2f82)<br>
+  QA Agent run: 2026-06-12, independent verification (developer artifacts NOT reused;
+  all tests and builds executed fresh by QA on its own checkout of the PR branch).
+</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-run evidence)</th><th>Verdict</th></tr>
+  <tr>
+    <td>1</td>
+    <td>CleanupForSpeech("Enable session `my-session` is done") contains "my-session"</td>
+    <td>Identifier preserved in output</td>
+    <td>Test ClaudeSummarizer_BacktickIdentifier_IsPreserved PASSED (Assert.Contains("my-session", result)) - run by QA, see test output below</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>CleanupForSpeech("Set `wingmanEnabled=False`") contains "wingmanEnabled=False"</td>
+    <td>Key=value preserved in output</td>
+    <td>Test ClaudeSummarizer_BacktickKeyValue_IsPreserved PASSED (Assert.Contains("wingmanEnabled=False", result))</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>Backtick markers removed (no backtick characters in output)</td>
+    <td>Output contains no backtick character</td>
+    <td>Both inline tests assert Assert.DoesNotContain backtick in result; both PASSED. Source regex replaces the markers with capture group $1 only.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>Triple-backtick code blocks still stripped entirely (existing behavior unaffected)</td>
+    <td>Code block content removed; surrounding prose kept</td>
+    <td>Test ClaudeSummarizer_TripleBacktickCodeBlock_IsStripped PASSED (asserts "var x = 1;" and "csharp" gone, "Here is the fix:" and "Done." kept). Source inspection confirms the code-block rule (```[\s\S]*?```) runs BEFORE the inline rule, so fenced content never reaches the keep-inner-text regex.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>5</td>
+    <td>dotnet build cc-director.sln succeeds with 0 errors</td>
+    <td>Build succeeded, 0 errors</td>
+    <td>QA build on PR branch: "Build succeeded. 0 Warning(s) 0 Error(s)"</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>6</td>
+    <td>dotnet test --filter ClaudeSummarizer passes (existing tests unaffected, new tests added)</td>
+    <td>All tests pass; 5 pre-existing #367 tests unaffected; required new tests present</td>
+    <td>QA test run: Failed: 0, Passed: 8, Skipped: 0, Total: 8. Both proof-target test names present and passing (see list below).</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>QA-run test output (detailed names)</h2>
+<pre>
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_BacktickIdentifier_IsPreserved [5 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_JapaneseInput_IsNotDropped [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_NonLatinInput_IsNotDropped [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_TripleBacktickCodeBlock_IsStripped [6 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_BacktickKeyValue_IsPreserved [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions [&lt; 1 ms]
+
+Passed!  - Failed: 0, Passed: 8, Skipped: 0, Total: 8, Duration: 13 ms - CcDirector.Core.Tests.dll (net10.0)
+</pre>
+
+<h2>QA-run build output (tail)</h2>
+<pre>
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+</pre>
+
+<h2>Fix inspection (the actual change, verified in source on the PR branch)</h2>
+<pre>
+// Remove code blocks
+text = Regex.Replace(text, @"```[\s\S]*?```", "");
+
+// Strip inline-code backtick markers but KEEP the inner text (issue #368):
+text = Regex.Replace(text, @"`([^`]+)`", "$1");     // was: replace with ""
+</pre>
+<p>Scope check: diff vs origin/main touches only ClaudeSummarizer.cs (regex + comment) and
+ClaudeSummarizerTests.cs (3 new tests) plus developer proof artifacts. Nothing out-of-scope
+(no VoiceTurnEndpoint, no Gateway, no Phone changes) - matches the issue's Out list.</p>
+
+<h2>Regression and method checks</h2>
+<ul>
+  <li>All 5 pre-existing #367 ClaudeSummarizer tests still pass (run by QA).</li>
+  <li>Full solution build clean (0 warnings, 0 errors).</li>
+  <li>CenCon: no architecture/security change (single regex in CcDirector.Core); no DT rule touched; no doc drift.</li>
+  <li>No fallback programming introduced; change is a targeted root-cause fix.</li>
+</ul>
+
+<div class="verdict">VERIFIED - all acceptance criteria met. QA verdict: PASS.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-368/report.html
+++ b/docs/cencon/proof/issue-368/report.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof - Issue #368: Backtick content deletion in ClaudeSummarizer CleanupForSpeech</title>
+<style>
+  body { font-family: 'Segoe UI', Arial, sans-serif; background: #1e1e1e; color: #cccccc; margin: 0; padding: 2rem; line-height: 1.5; }
+  h1, h2 { color: #ffffff; }
+  h1 { border-bottom: 2px solid #007acc; padding-bottom: .5rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #3c3c3c; padding: .5rem .75rem; text-align: left; vertical-align: top; }
+  th { background: #252526; color: #ffffff; }
+  code, pre { font-family: Consolas, monospace; background: #252526; color: #d7ba7d; }
+  code { padding: .1rem .3rem; border-radius: 3px; }
+  pre { padding: 1rem; overflow-x: auto; border: 1px solid #3c3c3c; border-radius: 4px; }
+  .pass { color: #4ec94e; font-weight: bold; }
+  .meta { color: #888888; font-size: .9rem; }
+  .verdict { background: #252526; border-left: 4px solid #4ec94e; padding: 1rem; margin: 1.5rem 0; }
+</style>
+</head>
+<body>
+<h1>Proof Report - Issue #368</h1>
+<p class="meta">
+  Issue: <a href="https://github.com/thefrederiksen/cc-director/issues/368" style="color:#3794ff">#368 [Voice] Fix backtick content deletion in ClaudeSummarizer CleanupForSpeech</a><br>
+  PR: <a href="https://github.com/thefrederiksen/cc-director/pull/381" style="color:#3794ff">#381</a> (branch <code>issue-368-backtick</code>)<br>
+  Date: 2026-06-12 | Agent: Developer Agent (CenCon Development Method)
+</p>
+
+<h2>What was implemented</h2>
+<p>
+<code>CleanupForSpeech</code> in <code>src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs</code>
+deleted inline-backtick spans <em>including their content</em>, so spoken voice confirmations lost
+the identifier they were confirming (session names, flag values). The inline-code regex now strips
+only the backtick markers and keeps the inner text:
+</p>
+<pre>- text = Regex.Replace(text, @"`[^`]+`", "");
++ text = Regex.Replace(text, @"`([^`]+)`", "$1");</pre>
+<p>
+Triple-backtick code blocks are still removed entirely (unspeakable content); that rule runs first
+in the method and is unchanged.
+</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>Criterion</th><th>Expected</th><th>Actual</th><th>Proof</th></tr>
+  <tr>
+    <td>CleanupForSpeech("Enable session `my-session` is done") contains "my-session"</td>
+    <td>Identifier preserved</td>
+    <td class="pass">PASS</td>
+    <td>Test <code>ClaudeSummarizer_BacktickIdentifier_IsPreserved</code> (dotnet-test-output.txt)</td>
+  </tr>
+  <tr>
+    <td>CleanupForSpeech("Set `wingmanEnabled=False`") contains "wingmanEnabled=False"</td>
+    <td>Key=value preserved</td>
+    <td class="pass">PASS</td>
+    <td>Test <code>ClaudeSummarizer_BacktickKeyValue_IsPreserved</code></td>
+  </tr>
+  <tr>
+    <td>No backtick characters in the output</td>
+    <td>Markers stripped</td>
+    <td class="pass">PASS</td>
+    <td><code>Assert.DoesNotContain("`", result)</code> in all three new tests</td>
+  </tr>
+  <tr>
+    <td>Triple-backtick code blocks still stripped entirely</td>
+    <td>Block content removed, surrounding prose kept</td>
+    <td class="pass">PASS</td>
+    <td>Test <code>ClaudeSummarizer_TripleBacktickCodeBlock_IsStripped</code></td>
+  </tr>
+  <tr>
+    <td>dotnet build cc-director.sln succeeds with 0 errors</td>
+    <td>Build succeeded, 0 errors</td>
+    <td class="pass">PASS (0 warnings, 0 errors)</td>
+    <td>dotnet-build-output.txt</td>
+  </tr>
+  <tr>
+    <td>dotnet test --filter ClaudeSummarizer passes, existing tests unaffected</td>
+    <td>All pass</td>
+    <td class="pass">PASS (8/8: 3 new + 5 existing #367 tests)</td>
+    <td>dotnet-test-output.txt</td>
+  </tr>
+</table>
+
+<h2>Test output (dotnet-test-output.txt excerpt)</h2>
+<pre>Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_BacktickIdentifier_IsPreserved [5 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_BacktickKeyValue_IsPreserved [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_TripleBacktickCodeBlock_IsStripped [6 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ClaudeSummarizer_NonLatinInput_IsNotDropped [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_JapaneseInput_IsNotDropped [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.CleanupForSpeech_NonLatinWithMarkdown_KeepsTextRemovesMarkdown [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions [&lt; 1 ms]
+Passed CcDirector.Core.Tests.Voice.ClaudeSummarizerTests.ProgressPrompt_AllowsNonLatinInput_NoRejectionInstructions [&lt; 1 ms]
+
+Test Run Successful.
+Total tests: 8
+     Passed: 8</pre>
+
+<h2>CenCon impact</h2>
+<p>No drift. Single regex change inside <code>CcDirector.Core</code> (container unchanged), no
+architecture or security posture change. Code review (review-code skill) passed: 0 blocking,
+0 warnings, 0 PII findings.</p>
+
+<h2>Verdict</h2>
+<div class="verdict">
+  <strong class="pass">I believe this is finished.</strong> Every acceptance criterion is met and
+  proven by unit tests committed to the PR branch; the full solution builds clean. The proof target
+  is library-level (pure static text helper), so dotnet test output is the proof artifact - no UI
+  surface or running Director involved.
+</div>
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/Voice/ClaudeSummarizerTests.cs
+++ b/src/CcDirector.Core.Tests/Voice/ClaudeSummarizerTests.cs
@@ -49,6 +49,42 @@ public sealed class ClaudeSummarizerTests
     }
 
     [Fact]
+    public void ClaudeSummarizer_BacktickIdentifier_IsPreserved()
+    {
+        // Issue #368: inline-backtick identifiers are the content of the answer
+        // (session names, flag values) - the markers go, the text stays.
+        var result = ClaudeSummarizer.CleanupForSpeech("Enable session `my-session` is done");
+
+        Assert.Contains("my-session", result);
+        Assert.DoesNotContain("`", result);
+    }
+
+    [Fact]
+    public void ClaudeSummarizer_BacktickKeyValue_IsPreserved()
+    {
+        var result = ClaudeSummarizer.CleanupForSpeech("Set `wingmanEnabled=False`");
+
+        Assert.Contains("wingmanEnabled=False", result);
+        Assert.DoesNotContain("`", result);
+    }
+
+    [Fact]
+    public void ClaudeSummarizer_TripleBacktickCodeBlock_IsStripped()
+    {
+        // Code blocks are not speakable - they are still removed entirely,
+        // including their content.
+        var input = "Here is the fix:\n```csharp\nvar x = 1;\n```\nDone.";
+
+        var result = ClaudeSummarizer.CleanupForSpeech(input);
+
+        Assert.DoesNotContain("var x = 1;", result);
+        Assert.DoesNotContain("csharp", result);
+        Assert.DoesNotContain("`", result);
+        Assert.Contains("Here is the fix:", result);
+        Assert.Contains("Done.", result);
+    }
+
+    [Fact]
     public void SummarizationPrompt_AllowsNonLatinInput_NoRejectionInstructions()
     {
         // The prompt must explicitly authorize any language/script...

--- a/src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs
+++ b/src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs
@@ -283,8 +283,11 @@ public class ClaudeSummarizer : IResponseSummarizer
         // Remove code blocks
         text = System.Text.RegularExpressions.Regex.Replace(text, @"```[\s\S]*?```", "");
 
-        // Remove inline code
-        text = System.Text.RegularExpressions.Regex.Replace(text, @"`[^`]+`", "");
+        // Strip inline-code backtick markers but KEEP the inner text (issue #368):
+        // identifiers like `sessionName` are the answer's content and must be
+        // spoken, not deleted. Code BLOCKS (``` fences) are removed entirely by
+        // the rule above, which runs first.
+        text = System.Text.RegularExpressions.Regex.Replace(text, @"`([^`]+)`", "$1");
 
         // Remove markdown links, keeping text
         text = System.Text.RegularExpressions.Regex.Replace(text, @"\[([^\]]+)\]\([^)]+\)", "$1");


### PR DESCRIPTION
Fixes #368.

## What

CleanupForSpeech in src/CcDirector.Core/Voice/Services/ClaudeSummarizer.cs deleted inline-backtick spans INCLUDING their content, so spoken voice confirmations lost the identifier they were confirming (e.g. "Enable session `my-session` is done" was spoken as "Enable session is done").

## Change

- Inline-code rule now strips only the backtick markers and keeps the inner text: regex `` `([^`]+)` `` replaced with `$1` instead of "".
- Triple-backtick code blocks are still removed entirely (unspeakable content); that rule runs first and is unchanged.

## Tests

New regression tests in src/CcDirector.Core.Tests/Voice/ClaudeSummarizerTests.cs:
- ClaudeSummarizer_BacktickIdentifier_IsPreserved
- ClaudeSummarizer_BacktickKeyValue_IsPreserved
- ClaudeSummarizer_TripleBacktickCodeBlock_IsStripped

All 8 ClaudeSummarizer tests pass (3 new + 5 existing #367 tests unaffected). Full solution builds with 0 warnings, 0 errors.

## CenCon impact

No drift - single regex in CcDirector.Core, no architecture or security change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)