### PR TITLE
feat(#376): Gateway async voice-turn submit/poll endpoints + TurnJobStore

### DIFF
--- a/docs/cencon/proof/voice-turn-gateway/qa-report.html
+++ b/docs/cencon/proof/voice-turn-gateway/qa-report.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #376 - Gateway async voice-turn submit/poll</title>
+<style>
+  body { background: #0f1318; color: #d8dee6; font-family: "Segoe UI", Arial, sans-serif; margin: 0; padding: 32px; line-height: 1.5; }
+  h1 { color: #e8eef5; font-size: 22px; border-bottom: 2px solid #2a3340; padding-bottom: 10px; }
+  h2 { color: #c9d4e0; font-size: 17px; margin-top: 30px; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; }
+  th, td { border: 1px solid #2a3340; padding: 8px 12px; text-align: left; font-size: 14px; vertical-align: top; }
+  th { background: #1a212b; color: #aebbcb; }
+  code, pre { font-family: Consolas, monospace; background: #161c24; border-radius: 4px; }
+  code { padding: 1px 5px; font-size: 13px; }
+  pre { padding: 12px 14px; overflow-x: auto; font-size: 13px; border: 1px solid #232b36; }
+  .pass { color: #7ce38b; font-weight: bold; }
+  .fail { color: #ff8a8a; font-weight: bold; }
+  .verdict { background: #14241a; border: 1px solid #2f5c3a; border-radius: 6px; padding: 14px 18px; margin: 22px 0; font-size: 15px; }
+  .note { background: #20262e; border-left: 4px solid #c9a227; padding: 10px 14px; margin: 14px 0; font-size: 14px; }
+</style>
+</head>
+<body>
+
+<h1>QA Proof Report - Issue #376: [Gateway] Async voice-turn submit/poll endpoints + TurnJobStore</h1>
+
+<p>
+<strong>Date:</strong> 2026-06-12 &nbsp;|&nbsp;
+<strong>QA Agent:</strong> independent verification (fresh context, never saw the Developer's work) &nbsp;|&nbsp;
+<strong>PR:</strong> #382 (<code>issue-376-gateway-voice-turn</code>, head <code>724d4ac</code>, base = current <code>main</code> at <code>708c250</code>)
+</p>
+
+<div class="verdict">
+<span class="pass">VERIFIED - all acceptance criteria met.</span>
+All 11 named integration tests pass when run by QA. Solution builds clean (0 warnings, 0 errors).
+Full Gateway.Tests regression: 598/599 in the QA run; the single failure reproduces identically on
+clean <code>main</code> (verified independently by QA, not taken from the Developer's report).
+Code review against the issue's acceptance criteria found no defects.
+</div>
+
+<h2>1. Focused test run (run BY QA, not reused from the Developer)</h2>
+<p>Command: <code>dotnet test src\CcDirector.Gateway.Tests --filter GatewayVoiceTurnAsync</code></p>
+<table>
+<tr><th>Test</th><th>QA result</th></tr>
+<tr><td>Submit_InvalidGuid_Returns400</td><td class="pass">PASS</td></tr>
+<tr><td>Submit_UnknownSession_Returns404</td><td class="pass">PASS</td></tr>
+<tr><td>Submit_ValidIdleSession_Returns202WithTurnId</td><td class="pass">PASS</td></tr>
+<tr><td>Submit_TextBody_Returns202</td><td class="pass">PASS</td></tr>
+<tr><td>Submit_SessionAlreadyExited_Returns404OrGone</td><td class="pass">PASS</td></tr>
+<tr><td>Poll_UnknownTurnId_Returns404</td><td class="pass">PASS</td></tr>
+<tr><td>Poll_ValidTurnId_WhileProcessing_ReturnsInProgressStage</td><td class="pass">PASS</td></tr>
+<tr><td>Poll_ValidTurnId_AfterCompletion_ReturnsReplyStage</td><td class="pass">PASS</td></tr>
+<tr><td>Poll_MultiplePolls_SameResult</td><td class="pass">PASS</td></tr>
+<tr><td>Poll_ValidTurnId_AfterTTLExpiry_Returns404</td><td class="pass">PASS</td></tr>
+<tr><td>Poll_DirectorUnreachable_ReturnsErrorStage</td><td class="pass">PASS</td></tr>
+</table>
+<pre>Passed!  - Failed:     0, Passed:    11, Skipped:     0, Total:    11, Duration: 14 s - CcDirector.Gateway.Tests.dll (net10.0)</pre>
+
+<h2>2. Build gate</h2>
+<p><code>dotnet build cc-director.sln</code> on the PR branch:
+<span class="pass">Build succeeded. 0 Warning(s), 0 Error(s).</span></p>
+
+<h2>3. Full Gateway.Tests regression sweep (QA run)</h2>
+<pre>Failed!  - Failed:     1, Passed:   598, Skipped:     0, Total:   599, Duration: 2 m 19 s</pre>
+<p>The one failure:
+<code>DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider</code>
+(a real-network OpenAI Realtime test).</p>
+<div class="note">
+<strong>Pre-existing claim VERIFIED INDEPENDENTLY by QA:</strong> QA checked out clean
+<code>main</code> (<code>708c250</code>) and ran exactly this test there - it
+<span class="fail">FAILS</span> identically on main, so it is environmental and not introduced
+by this change. The Developer's second flaky test
+(<code>DirectorEventsAndFactsTests.Facts_Proxy_ReturnsToolInventoryAndLauncherFact</code>)
+<span class="pass">PASSED</span> in the QA full-suite run, consistent with the
+"environmental/flaky" characterization. Neither touches the files in this diff.
+</div>
+
+<h2>4. Code review vs the issue's acceptance criteria</h2>
+<table>
+<tr><th>Acceptance criterion</th><th>Where verified</th><th>Verdict</th></tr>
+<tr><td>POST submit with non-Guid sid -&gt; 400 <code>{"error":"invalid session id format"}</code></td>
+    <td><code>GatewayVoiceTurnEndpoint</code> Guid.TryParse gate (first check) + test Submit_InvalidGuid_Returns400</td>
+    <td class="pass">PASS</td></tr>
+<tr><td>POST submit unknown session -&gt; 404 <code>{"error":"session not found"}</code></td>
+    <td>Owner-cache miss + fleet fan-out miss path + test Submit_UnknownSession_Returns404</td>
+    <td class="pass">PASS</td></tr>
+<tr><td>POST submit valid idle session -&gt; 202 with UUID <code>turn_id</code> + ISO 8601 UTC <code>expires_at</code></td>
+    <td>202 path returns <code>{ turn_id, expires_at }</code> (DateTime.UtcNow + 10 min, serialized ISO 8601 Z) + test Submit_ValidIdleSession_Returns202WithTurnId (asserts UUID parse and ~10-min expiry)</td>
+    <td class="pass">PASS</td></tr>
+<tr><td>GET poll unknown turn id -&gt; 404 JSON</td>
+    <td>Store miss (or sid mismatch) -&gt; 404 + test Poll_UnknownTurnId_Returns404</td>
+    <td class="pass">PASS</td></tr>
+<tr><td>GET poll in-flight -&gt; 200 with in-progress stage</td>
+    <td>SlowIdleBackend pins the turn Working; test Poll_ValidTurnId_WhileProcessing_ReturnsInProgressStage asserts stage in the documented vocabulary</td>
+    <td class="pass">PASS</td></tr>
+<tr><td>GET poll after completion -&gt; <code>stage:"reply"</code>, non-null <code>summary</code> and <code>audioBase64</code> (empty string OK keyless)</td>
+    <td><code>TurnJob.SetReply</code> coerces both to non-null; test Poll_ValidTurnId_AfterCompletion_ReturnsReplyStage</td>
+    <td class="pass">PASS</td></tr>
+<tr><td>TTL expiry (job aged 11 min via test seam) -&gt; 404</td>
+    <td>Lazy expiry in <code>GatewayTurnJobStore.Get</code> (expired job removed on read) + opportunistic sweep on Create; test Poll_ValidTurnId_AfterTTLExpiry_Returns404 uses <code>OverrideCreatedAtForTest</code></td>
+    <td class="pass">PASS</td></tr>
+<tr><td>Director unreachable -&gt; submit 404/503; poll lands <code>{"stage":"error","message":"..."}</code></td>
+    <td>Unregistered Director -&gt; 404 (Submit_UnknownSession_Returns404); registered-but-dead endpoint -&gt; 202 then background task error stage with message (Poll_DirectorUnreachable_ReturnsErrorStage); no-dialable-endpoint -&gt; 503 in code</td>
+    <td class="pass">PASS</td></tr>
+<tr><td>Idempotent polls (repeat polls return the same cached result)</td>
+    <td>Poll reads a lock-serialized <code>Snapshot()</code>, no state mutation on read (except lazy expiry); test Poll_MultiplePolls_SameResult</td>
+    <td class="pass">PASS</td></tr>
+<tr><td><code>dotnet build cc-director.sln</code> 0 errors</td><td>Section 2</td><td class="pass">PASS</td></tr>
+<tr><td><code>dotnet test --filter GatewayVoiceTurnAsync</code> all green</td><td>Section 1 (11/11)</td><td class="pass">PASS</td></tr>
+<tr><td>HTML proof report committed at <code>docs/cencon/proof/voice-turn-gateway/report.html</code></td>
+    <td>Present on the PR branch (commit <code>724d4ac</code>); lists all 11 tests by name with PASS, the build line, the full-suite result, and a live curl submit-&gt;202-&gt;poll-&gt;reply trace - consistent with everything QA observed independently</td>
+    <td class="pass">PASS</td></tr>
+</table>
+
+<h2>5. Method / regression checks</h2>
+<ul>
+<li><strong>Thread safety:</strong> <code>TurnJob</code> serializes all writes and the snapshot read
+on one private lock; pollers always consume <code>Snapshot()</code>, never fields piecemeal. The
+store is a <code>ConcurrentDictionary</code>. No torn reads possible.</li>
+<li><strong>Background task always terminal:</strong> <code>RunTurnAsync</code> is a task entry
+point owning its try-catch (per CodingStyle: try-catch at entry points only); every exit path lands
+the job in <code>reply</code> or <code>error</code> - a poll can never hang forever.</li>
+<li><strong>No fallback programming:</strong> failures surface as explicit 4xx/5xx JSON or the
+job's error stage with the real message; nothing silently degrades.</li>
+<li><strong>Enterprise logging:</strong> FileLog entries on submit, accept, poll-miss, expiry,
+background start/terminal/failure - all tagged <code>[GatewayVoiceTurn]</code> /
+<code>[GatewayTurnJobStore]</code>.</li>
+<li><strong>Wiring:</strong> <code>GatewayHost.TurnJobs</code> singleton passed through
+<code>GatewayEndpoints.Map(..., turnJobs:)</code> as an optional parameter (old callers unaffected);
+specific literal routes win over the #372 catch-all session forwarder - proven live by the passing
+integration tests, which run with the full route table mapped.</li>
+<li><strong>Scope respected:</strong> no changes to the Director's SSE endpoint,
+<code>VoiceTurnEndpoint.cs</code>, or <code>ClaudeSummarizer.cs</code>; diff touches only the
+6 files declared in the issue.</li>
+<li><strong>Adjacent surfaces:</strong> full Gateway.Tests sweep shows no new failures
+(Section 3).</li>
+</ul>
+
+<h2>Verdict</h2>
+<p class="pass">VERIFIED - all acceptance criteria met. PASS. Authorized squash-merge of PR #382
+follows per the implementation-loop QA contract (DECIDED D5).</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/voice-turn-gateway/report.html
+++ b/docs/cencon/proof/voice-turn-gateway/report.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #376 - Gateway async voice-turn submit/poll + TurnJobStore - Developer Agent Proof</title>
+<style>
+  body { font-family: "Segoe UI", Arial, sans-serif; background: #14181d; color: #d8dee6; margin: 0; padding: 32px; line-height: 1.5; }
+  .wrap { max-width: 1000px; margin: 0 auto; }
+  h1 { color: #6fc3ff; font-size: 1.5em; border-bottom: 2px solid #2a3340; padding-bottom: 8px; }
+  h2 { color: #8fd0a0; font-size: 1.15em; margin-top: 32px; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  th, td { border: 1px solid #2a3340; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #1c232b; color: #9fb3c8; }
+  code, pre { font-family: Consolas, monospace; background: #1c232b; color: #c9e3a6; border-radius: 4px; }
+  code { padding: 1px 5px; }
+  pre { padding: 12px; overflow-x: auto; border: 1px solid #2a3340; }
+  .pass { color: #7ce38b; font-weight: bold; }
+  .fail { color: #ff8a8a; font-weight: bold; }
+  .note { background: #20262e; border-left: 4px solid #c9a227; padding: 10px 14px; margin: 14px 0; }
+  a { color: #6fc3ff; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Issue #376 - [Gateway] Add async voice-turn submit/poll endpoints and TurnJobStore</h1>
+
+<p><strong>Role:</strong> Developer Agent (CenCon Development Method) &nbsp;|&nbsp;
+<strong>Branch:</strong> <code>issue-376-gateway-voice-turn</code> &nbsp;|&nbsp;
+<strong>Date:</strong> 2026-06-12 &nbsp;|&nbsp;
+<strong>Live rig:</strong> isolated slot-8 Director (own worktree build <code>cc-director8.exe</code>,
+PID 79476, Control API 127.0.0.1:7884, launched via the per-slot scheduled task
+<code>cc-director8-launch</code> per <code>scripts/agent-session-isolation.ps1</code>) discovered
+ONLY by an isolated NEW-code Gateway (dev console host, 127.0.0.1:17878, isolated
+<code>CC_DIRECTOR_ROOT</code> + copied instance file, <code>CC_TURNBRIEFS=0</code>,
+<code>CC_GATEWAY_NO_TAILSCALE=1</code>) - the user's production fleet, serve table, and
+key vault were never touched. Everything was torn down afterwards (slot 8 freed,
+proof root deleted, test session killed).</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li><code>src/CcDirector.Gateway/Voice/GatewayTurnJobStore.cs</code> - in-memory
+      <code>TurnJob</code> store keyed by UUID <code>turn_id</code>; 10-minute TTL checked lazily
+      on read (plus an opportunistic sweep on create); thread-safe
+      (<code>ConcurrentDictionary</code> + per-job lock with snapshot reads). TurnJob fields:
+      TurnId, SessionId, Stage, Transcript, Summary, AudioBase64, ErrorMessage, CreatedAt, ExpiresAt.</li>
+  <li><code>src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs</code> -
+      <code>POST /sessions/{sid}/voice-turn/submit</code> (400 invalid guid, 404 unknown session,
+      410 exited session, 202 <code>{ turn_id, expires_at }</code>) and
+      <code>GET /sessions/{sid}/voice-turn/{turnId}</code> (404 unknown/expired, 200
+      <code>{ stage, transcript, summary, audioBase64, message }</code>). Submit buffers the body
+      (multipart audio/text or raw JSON), resolves the owning Director
+      (<code>SessionOwnerCache</code> fast path, else live fleet fan-out), and fires an unawaited
+      background task that drives the Director's existing SSE
+      <code>POST /sessions/{sid}/voice-turn</code>, mirroring every stage event
+      (submitted/transcribing/transcript/waiting/thinking/summarizing/reply/error) into the job.
+      The task ALWAYS lands the job terminal (reply or error) - a poll can never hang.</li>
+  <li>Wiring: <code>GatewayEndpoints.Map()</code> gained a <code>turnJobs</code> parameter;
+      <code>GatewayHost</code> registers <code>GatewayTurnJobStore</code> as the
+      <code>TurnJobs</code> singleton and passes it through.</li>
+  <li><code>src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs</code> - 11 integration
+      tests: real <code>ControlApiHost</code> + real <code>GatewayHost</code> on ephemeral ports,
+      isolated <code>_instancesDir</code> (the <code>WingmanAskForwardingTests</code> pattern),
+      stub <code>QuickIdleBackend</code>/<code>SlowIdleBackend</code> sessions (the
+      <code>VoiceTurnEndpointTests</code> pattern) - no live Claude/OpenAI calls.</li>
+</ul>
+
+<h2>Integration tests (dotnet test --filter GatewayVoiceTurnAsync)</h2>
+<table>
+  <tr><th>Test</th><th>Result</th></tr>
+  <tr><td>Submit_InvalidGuid_Returns400</td><td class="pass">PASS</td></tr>
+  <tr><td>Submit_UnknownSession_Returns404</td><td class="pass">PASS</td></tr>
+  <tr><td>Submit_ValidIdleSession_Returns202WithTurnId</td><td class="pass">PASS</td></tr>
+  <tr><td>Submit_TextBody_Returns202</td><td class="pass">PASS</td></tr>
+  <tr><td>Submit_SessionAlreadyExited_Returns404OrGone</td><td class="pass">PASS</td></tr>
+  <tr><td>Poll_UnknownTurnId_Returns404</td><td class="pass">PASS</td></tr>
+  <tr><td>Poll_ValidTurnId_WhileProcessing_ReturnsInProgressStage</td><td class="pass">PASS</td></tr>
+  <tr><td>Poll_ValidTurnId_AfterCompletion_ReturnsReplyStage</td><td class="pass">PASS</td></tr>
+  <tr><td>Poll_MultiplePolls_SameResult</td><td class="pass">PASS</td></tr>
+  <tr><td>Poll_ValidTurnId_AfterTTLExpiry_Returns404</td><td class="pass">PASS</td></tr>
+  <tr><td>Poll_DirectorUnreachable_ReturnsErrorStage</td><td class="pass">PASS</td></tr>
+</table>
+<pre>Passed!  - Failed:     0, Passed:    11, Skipped:     0, Total:    11, Duration: 14 s - CcDirector.Gateway.Tests.dll (net10.0)</pre>
+
+<p><code>dotnet build cc-director.sln</code>: <span class="pass">Build succeeded. 0 Warning(s), 0 Error(s).</span></p>
+
+<h2>Full Gateway.Tests regression run</h2>
+<pre>Failed!  - Failed:     2, Passed:   597, Skipped:     0, Total:   599, Duration: 2 m 32 s</pre>
+<div class="note">
+<strong>The 2 failures are PRE-EXISTING / environmental, not introduced by this change
+(verified, stated honestly):</strong>
+<ul>
+  <li><code>DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider</code> -
+      a real-network OpenAI Realtime test. It fails <em>identically</em> on a clean
+      <code>origin/main</code> worktree (commit <code>708c250</code>, verified by running exactly
+      this test there: "expected at least 1 partial transcript, got 0"). Live-API behavior,
+      untouched by this diff.</li>
+  <li><code>DirectorEventsAndFactsTests.Facts_Proxy_ReturnsToolInventoryAndLauncherFact</code> -
+      timing-sensitive under load (a slot build was running concurrently during the suite run);
+      it <span class="pass">PASSES</span> when re-run in isolation on this branch.</li>
+</ul>
+This branch's diff touches only the five voice-turn files
+(<code>git diff main...HEAD --stat</code>: GatewayTurnJobStore.cs, GatewayVoiceTurnEndpoint.cs,
+GatewayEndpoints.cs, GatewayHost.cs, GatewayVoiceTurnAsyncTests.cs) - neither failing test's
+surface is in the diff.
+</div>
+
+<h2>Live curl trace: submit -&gt; poll -&gt; reply (real slot-8 Director + real Gateway)</h2>
+<p>A real ClaudeCode session (<code>3a50e27b-7822-4a3f-b7b8-1bf4a7558f8b</code>) was created on the
+slot-8 Director; the Gateway (127.0.0.1:17878, running THIS branch's code) drove the full turn.
+The Director resolved the production OpenAI key, so the reply carries REAL TTS audio.</p>
+
+<pre>$ curl -i -X POST "http://127.0.0.1:17878/sessions/3a50e27b-7822-4a3f-b7b8-1bf4a7558f8b/voice-turn/submit" \
+       -H "Content-Type: application/json" \
+       -d '{"text":"What is 2 plus 2? Reply with one short sentence only."}'
+HTTP/1.1 202 Accepted
+Content-Type: application/json; charset=utf-8
+
+{"turn_id":"53302715-9b53-4dca-a548-205d4090c6b0","expires_at":"2026-06-12T23:08:01.2506005Z"}
+
+$ # poll loop, 2s interval
+[18:58:14] poll 1: stage=thinking
+[18:58:17] poll 2: stage=thinking
+[18:58:19] poll 3: stage=thinking
+[18:58:21] poll 4: stage=thinking
+[18:58:23] poll 5: stage=thinking
+[18:58:26] poll 6: {"turn_id": "53302715-9b53-4dca-a548-205d4090c6b0", "stage": "reply",
+                    "transcript": null, "summary": "4.",
+                    "audioBase64": "//PkxABnNDoIAVjIAD7k4lXEFAGZBqQZAFxFNGXw... (12800 chars)",
+                    "message": null, "expires_at": "2026-06-12T23:08:01.2506005Z"}</pre>
+
+<p>Negative paths and idempotent re-poll, same rig:</p>
+<pre>$ curl -X POST .../sessions/not-a-guid/voice-turn/submit -d '{"text":"..."}'
+{"error":"invalid session id format"}            HTTP 400
+
+$ curl -X POST .../sessions/&lt;random-uuid&gt;/voice-turn/submit -d '{"text":"..."}'
+{"error":"session not found"}                    HTTP 404
+
+$ curl .../sessions/3a50e27b-.../voice-turn/&lt;random-uuid&gt;
+{"error":"turn not found or expired"}            HTTP 404
+
+$ curl .../sessions/3a50e27b-.../voice-turn/53302715-9b53-4dca-a548-205d4090c6b0   # second poll
+{"turn_id": "53302715-...", "stage": "reply", "transcript": null, "summary": "4.",
+ "audioBase64": "//PkxABnNDoIAVjIAD7k4lXE...", "message": null, ...}               HTTP 200 (identical)</pre>
+
+<h2>Acceptance criteria -&gt; proof</h2>
+<table>
+  <tr><th>Criterion</th><th>Proof</th></tr>
+  <tr><td>POST submit with unknown guid -&gt; 404 <code>{"error":"session not found"}</code></td>
+      <td>Test Submit_UnknownSession_Returns404 + live curl (404 above)</td></tr>
+  <tr><td>POST submit with non-guid -&gt; 400 <code>{"error":"invalid session id format"}</code></td>
+      <td>Test Submit_InvalidGuid_Returns400 + live curl (400 above)</td></tr>
+  <tr><td>POST submit valid idle session -&gt; 202 with UUID <code>turn_id</code> + ISO-8601 UTC <code>expires_at</code></td>
+      <td>Test Submit_ValidIdleSession_Returns202WithTurnId + live curl (202 above)</td></tr>
+  <tr><td>GET poll unknown turn id -&gt; 404 JSON</td>
+      <td>Test Poll_UnknownTurnId_Returns404 + live curl (404 above)</td></tr>
+  <tr><td>GET poll in-flight -&gt; 200 with in-progress stage</td>
+      <td>Test Poll_ValidTurnId_WhileProcessing_ReturnsInProgressStage + live polls 1-5 (stage=thinking)</td></tr>
+  <tr><td>GET poll after completion -&gt; <code>stage:"reply"</code>, non-null summary + audioBase64</td>
+      <td>Test Poll_ValidTurnId_AfterCompletion_ReturnsReplyStage (keyless: audioBase64="" but present) + live poll 6 (real audio, 12800 chars)</td></tr>
+  <tr><td>After simulated TTL expiry -&gt; 404</td>
+      <td>Test Poll_ValidTurnId_AfterTTLExpiry_Returns404 (injects 11-minutes-old CreatedAt via the documented test seam)</td></tr>
+  <tr><td>Director unreachable -&gt; submit 404/503; job polls land at <code>stage:"error"</code> with message</td>
+      <td>Tests Submit_UnknownSession_Returns404 (unregistered) + Poll_DirectorUnreachable_ReturnsErrorStage (registered-but-dead endpoint: 202 then error stage with message)</td></tr>
+  <tr><td><code>dotnet build cc-director.sln</code> 0 errors</td><td>Build output above</td></tr>
+  <tr><td><code>dotnet test --filter GatewayVoiceTurnAsync</code> all green</td><td>11/11 PASS above</td></tr>
+  <tr><td>HTML proof report committed</td><td>This file (committed to the PR branch)</td></tr>
+</table>
+
+<h2>CenCon impact</h2>
+<p>No architecture drift beyond what is already documented: this change IS Phase 2 of
+<code>docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md</code> (the Gateway owns the async
+voice-turn interface; the Director's SSE endpoint stays the worker, unchanged). No security-posture
+change: the new routes inherit the host-wide token middleware exactly like every other Gateway
+route; the dedicated bearer-token gate on these two routes is issue #369 (explicitly out of scope
+here and dependent on this issue). Affected containers: <code>CcDirector.Gateway</code>,
+<code>CcDirector.Gateway.Tests</code> - matching the issue's Affected Containers section.</p>
+
+<h2>Verdict</h2>
+<p class="pass">All acceptance criteria are met, the build is clean, the new tests are green,
+the live submit -&gt; poll -&gt; reply round-trip was proven against a real Director + Gateway,
+and the two unrelated suite failures are accounted for honestly. I believe this is finished.</p>
+
+</div>
+</body>
+</html>

--- a/src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs
@@ -1,0 +1,417 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Integration tests for the Gateway's async voice-turn submit/poll surface (issue #376):
+///   POST /sessions/{sid}/voice-turn/submit  -> 202 { turn_id, expires_at }
+///   GET  /sessions/{sid}/voice-turn/{turnId} -> 200 { stage, ... } | 404
+///
+/// Real ControlApiHost (the Director) + real GatewayHost on ephemeral loopback ports with an
+/// isolated discovery directory (the WingmanAskForwardingTests pattern). Sessions are adopted
+/// straight into the Director's SessionManager with stub backends (the VoiceTurnEndpointTests
+/// pattern) so no live Claude/OpenAI calls are needed:
+///   - QuickIdleBackend flips the session back to WaitingForInput ~200ms after SendTextAsync,
+///     so the Director's SSE turn completes fast (reply-stage tests).
+///   - SlowIdleBackend holds the session Working for several seconds, pinning the job in an
+///     in-progress stage long enough to poll it deterministically.
+/// </summary>
+public sealed class GatewayVoiceTurnAsyncTests : IAsyncLifetime
+{
+    private static readonly TimeSpan ReplyDeadline = TimeSpan.FromSeconds(120);
+
+    private ControlApiHost _director = null!;
+    private SessionManager _sm = null!;
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string? _originalEnv;
+
+    // Isolated discovery dir: the test Director and Gateway find each other here, and a real
+    // Director running on the dev machine can never leak into (or see) these test hosts.
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        // Remove OPENAI_API_KEY so TTS/transcription take the no-key path deterministically.
+        _originalEnv = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        Environment.SetEnvironmentVariable("OPENAI_API_KEY", null);
+
+        _sm = new SessionManager(new AgentOptions { OpenAiKey = null });
+        _director = new ControlApiHost(_sm, "1.0.0-test", () => Task.CompletedTask, useEphemeralPort: true,
+            instancesDirectory: _instancesDir);
+        await _director.StartAsync();
+
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token", authEnabled: false,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+        _http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+
+        // Wait for FSW discovery of the in-process Director.
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_gateway.Registry.ListDirectors().Any(d => d.DirectorId == _director.DirectorId)) break;
+            await Task.Delay(100);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        await _director.StopAsync();
+        _sm.Dispose();
+        Environment.SetEnvironmentVariable("OPENAI_API_KEY", _originalEnv);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* test cleanup, ignore */ }
+    }
+
+    // ===== Submit validation =====
+
+    [Fact]
+    public async Task Submit_InvalidGuid_Returns400()
+    {
+        var resp = await _http.PostAsJsonAsync("sessions/not-a-guid/voice-turn/submit", new { text = "hello" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("invalid session id", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Submit_UnknownSession_Returns404()
+    {
+        var bogus = Guid.NewGuid().ToString();
+        var resp = await _http.PostAsJsonAsync($"sessions/{bogus}/voice-turn/submit", new { text = "hello" });
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("session not found", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Submit_ValidIdleSession_Returns202WithTurnId()
+    {
+        var sid = AdoptQuickIdleSession();
+
+        using var form = new MultipartFormDataContent { { new StringContent("What is 2 + 2?"), "text" } };
+        var resp = await _http.PostAsync($"sessions/{sid}/voice-turn/submit", form);
+
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var turnId = doc.RootElement.GetProperty("turn_id").GetString();
+        Assert.NotNull(turnId);
+        Assert.True(Guid.TryParse(turnId, out _), $"turn_id is not a UUID: {turnId}");
+        var expiresAt = doc.RootElement.GetProperty("expires_at").GetDateTime();
+        Assert.True(expiresAt > DateTime.UtcNow.AddMinutes(8), $"expires_at not ~10 minutes out: {expiresAt:O}");
+    }
+
+    [Fact]
+    public async Task Submit_TextBody_Returns202()
+    {
+        var sid = AdoptQuickIdleSession();
+
+        using var content = new StringContent("""{"text":"What is 2 + 2?"}""", Encoding.UTF8, "application/json");
+        var resp = await _http.PostAsync($"sessions/{sid}/voice-turn/submit", content);
+
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.True(Guid.TryParse(doc.RootElement.GetProperty("turn_id").GetString(), out _));
+    }
+
+    [Fact]
+    public async Task Submit_SessionAlreadyExited_Returns404OrGone()
+    {
+        var session = MakeExitedSession();
+        _sm.AdoptSession(session);
+        var sid = session.Id.ToString();
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/voice-turn/submit", new { text = "hello" });
+
+        // 410 when the Director still reports the exited session row; 404 when it hides it.
+        Assert.True(resp.StatusCode is HttpStatusCode.Gone or HttpStatusCode.NotFound,
+            $"expected 410 or 404, got {(int)resp.StatusCode}");
+    }
+
+    // ===== Poll =====
+
+    [Fact]
+    public async Task Poll_UnknownTurnId_Returns404()
+    {
+        var sid = Guid.NewGuid().ToString();
+        var resp = await _http.GetAsync($"sessions/{sid}/voice-turn/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Poll_ValidTurnId_WhileProcessing_ReturnsInProgressStage()
+    {
+        // SlowIdleBackend keeps the session Working for ~6s, so the job is reliably
+        // still in flight when we poll one second after the 202.
+        var sid = AdoptSlowIdleSession();
+        var turnId = await SubmitTextTurnAsync(sid, "take your time");
+
+        await Task.Delay(1000);
+        var (status, doc) = await PollAsync(sid, turnId);
+
+        Assert.Equal(HttpStatusCode.OK, status);
+        using (doc)
+        {
+            var stage = doc.RootElement.GetProperty("stage").GetString();
+            Assert.Contains(stage, new[] { "submitted", "transcribing", "transcript", "waiting", "thinking", "summarizing" });
+        }
+    }
+
+    [Fact]
+    public async Task Poll_ValidTurnId_AfterCompletion_ReturnsReplyStage()
+    {
+        var sid = AdoptQuickIdleSession();
+        var turnId = await SubmitTextTurnAsync(sid, "What is 2 + 2?");
+
+        using var doc = await PollUntilTerminalAsync(sid, turnId);
+        var root = doc.RootElement;
+
+        Assert.Equal("reply", root.GetProperty("stage").GetString());
+        // Both fields must be PRESENT and non-null after completion; audioBase64 is the empty
+        // string in this keyless environment, which is the documented contract.
+        Assert.NotNull(root.GetProperty("summary").GetString());
+        Assert.NotNull(root.GetProperty("audioBase64").GetString());
+    }
+
+    [Fact]
+    public async Task Poll_MultiplePolls_SameResult()
+    {
+        var sid = AdoptQuickIdleSession();
+        var turnId = await SubmitTextTurnAsync(sid, "What is 2 + 2?");
+
+        using var first = await PollUntilTerminalAsync(sid, turnId);
+        Assert.Equal("reply", first.RootElement.GetProperty("stage").GetString());
+
+        var (status, second) = await PollAsync(sid, turnId);
+        Assert.Equal(HttpStatusCode.OK, status);
+        using (second)
+        {
+            Assert.Equal("reply", second.RootElement.GetProperty("stage").GetString());
+            Assert.Equal(first.RootElement.GetProperty("summary").GetString(),
+                second.RootElement.GetProperty("summary").GetString());
+            Assert.Equal(first.RootElement.GetProperty("audioBase64").GetString(),
+                second.RootElement.GetProperty("audioBase64").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task Poll_ValidTurnId_AfterTTLExpiry_Returns404()
+    {
+        var sid = AdoptQuickIdleSession();
+        var turnId = await SubmitTextTurnAsync(sid, "What is 2 + 2?");
+        Assert.NotNull(turnId);
+
+        // Inject an 11-minutes-old creation time (the documented test seam) so the lazy
+        // expiry check on the next read treats the job as past its 10-minute TTL.
+        var job = _gateway.TurnJobs.Get(turnId);
+        Assert.NotNull(job);
+        job.OverrideCreatedAtForTest(DateTime.UtcNow.AddMinutes(-11), Voice.GatewayTurnJobStore.Ttl);
+
+        var (status, doc) = await PollAsync(sid, turnId);
+        doc.Dispose();
+        Assert.Equal(HttpStatusCode.NotFound, status);
+    }
+
+    [Fact]
+    public async Task Poll_DirectorUnreachable_ReturnsErrorStage()
+    {
+        // A Director that registered but is no longer listening: its endpoint dials a port
+        // nothing answers on. The owner cache knows the session, so submit still answers 202
+        // (the async contract) and the background task lands the job in the error stage.
+        var deadPort = AllocateFreePort();
+        var fakeDirectorId = Guid.NewGuid().ToString();
+        var register = await _http.PostAsJsonAsync("directors/register", new DirectorRegistrationRequest
+        {
+            DirectorId = fakeDirectorId,
+            TailnetEndpoint = $"http://127.0.0.1:{deadPort}",
+            MachineName = "test-dead-machine",
+        });
+        Assert.Equal(HttpStatusCode.Created, register.StatusCode);
+
+        var sid = Guid.NewGuid().ToString();
+        _gateway.SessionOwners.Remember(sid, fakeDirectorId);
+
+        var turnId = await SubmitTextTurnAsync(sid, "anyone home?");
+
+        using var doc = await PollUntilTerminalAsync(sid, turnId, TimeSpan.FromSeconds(30));
+        Assert.Equal("error", doc.RootElement.GetProperty("stage").GetString());
+        var message = doc.RootElement.GetProperty("message").GetString();
+        Assert.False(string.IsNullOrEmpty(message), "error stage must carry a message");
+    }
+
+    // ===== Helpers =============================================================
+
+    /// <summary>POST a JSON text turn to the Gateway submit route; asserts 202 and returns turn_id.</summary>
+    private async Task<string> SubmitTextTurnAsync(string sid, string text)
+    {
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/voice-turn/submit", new { text });
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var turnId = doc.RootElement.GetProperty("turn_id").GetString();
+        Assert.NotNull(turnId);
+        return turnId;
+    }
+
+    private async Task<(HttpStatusCode status, JsonDocument doc)> PollAsync(string sid, string turnId)
+    {
+        var resp = await _http.GetAsync($"sessions/{sid}/voice-turn/{turnId}");
+        var body = await resp.Content.ReadAsStringAsync();
+        return (resp.StatusCode, JsonDocument.Parse(body));
+    }
+
+    /// <summary>Poll until the job reaches a terminal stage (reply or error); asserts the deadline.</summary>
+    private async Task<JsonDocument> PollUntilTerminalAsync(string sid, string turnId, TimeSpan? deadline = null)
+    {
+        var until = DateTime.UtcNow + (deadline ?? ReplyDeadline);
+        while (true)
+        {
+            var (status, doc) = await PollAsync(sid, turnId);
+            Assert.Equal(HttpStatusCode.OK, status);
+            var stage = doc.RootElement.GetProperty("stage").GetString();
+            if (stage is "reply" or "error") return doc;
+            doc.Dispose();
+            Assert.True(DateTime.UtcNow < until, $"turn {turnId} not terminal before deadline (last stage: {stage})");
+            await Task.Delay(500);
+        }
+    }
+
+    private string AdoptQuickIdleSession()
+    {
+        var session = MakeStubSession(new QuickIdleBackend());
+        _sm.AdoptSession(session);
+        return session.Id.ToString();
+    }
+
+    private string AdoptSlowIdleSession()
+    {
+        var session = MakeStubSession(new SlowIdleBackend(TimeSpan.FromSeconds(6)));
+        _sm.AdoptSession(session);
+        return session.Id.ToString();
+    }
+
+    private static Session MakeStubSession(SessionDrivingBackend backend)
+    {
+        var session = new Session(
+            Guid.NewGuid(),
+            repoPath: @"C:\test\gateway-voice-turn-test",
+            workingDirectory: @"C:\test\gateway-voice-turn-test",
+            claudeArgs: null,
+            backend: backend,
+            claudeSessionId: null,
+            activityState: ActivityState.Idle,
+            createdAt: DateTimeOffset.UtcNow,
+            customName: "gateway-voice-turn-test",
+            customColor: null);
+        session.MarkRunning();
+        backend.Session = session;
+        return session;
+    }
+
+    private static Session MakeExitedSession()
+    {
+        var session = new Session(
+            Guid.NewGuid(),
+            repoPath: @"C:\test\gateway-voice-turn-exited",
+            workingDirectory: @"C:\test\gateway-voice-turn-exited",
+            claudeArgs: null,
+            backend: new QuickIdleBackend(),
+            claudeSessionId: null,
+            activityState: ActivityState.Exited,
+            createdAt: DateTimeOffset.UtcNow,
+            customName: "gateway-voice-turn-exited",
+            customColor: null);
+        // MarkFailed sets Status = Failed, which the submit gate treats the same as Exited.
+        session.MarkFailed();
+        return session;
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    /// <summary>
+    /// Base for stub backends that drive the session back to WaitingForInput some time after
+    /// SendTextAsync, simulating a turn-end without any real process. Session is set as a
+    /// property after construction (circular dependency).
+    /// </summary>
+    private abstract class SessionDrivingBackend : ISessionBackend
+    {
+        public Session? Session { get; set; }
+
+        protected abstract TimeSpan TurnDuration { get; }
+
+        public int ProcessId => 1;
+        public string Status => "Stub";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows,
+            Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+
+        public Task SendTextAsync(string text)
+        {
+            // Fire-and-forget: after Session.SendTextAsync sets Working state (which happens
+            // after we return), flip back to WaitingForInput to simulate the turn-end. The
+            // delay must run AFTER Session.SendTextAsync has set Working (>= 200ms).
+            var duration = TurnDuration;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(duration);
+                Session?.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+            });
+            return Task.CompletedTask;
+        }
+
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    /// <summary>Instant turn-end (~200ms): the reply-stage tests complete fast.</summary>
+    private sealed class QuickIdleBackend : SessionDrivingBackend
+    {
+        protected override TimeSpan TurnDuration => TimeSpan.FromMilliseconds(200);
+    }
+
+    /// <summary>Holds the session Working for a fixed window so in-flight polls are deterministic.</summary>
+    private sealed class SlowIdleBackend : SessionDrivingBackend
+    {
+        private readonly TimeSpan _duration;
+        public SlowIdleBackend(TimeSpan duration) => _duration = duration;
+        protected override TimeSpan TurnDuration => _duration;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -36,14 +36,24 @@ internal static class GatewayEndpoints
     /// doorbell event vocabulary (session-created/session-exited/prompt-detected) so the
     /// events are observable at GET /directors/{id}/events. Null (old callers, tests that
     /// don't care) records nothing and the events route serves empty lists.</param>
+    /// <param name="turnJobs">Issue #376: the async voice-turn job store (singleton owned by
+    /// <see cref="GatewayHost"/>). When present, the submit/poll routes are mapped via
+    /// <see cref="GatewayVoiceTurnEndpoint"/>; null (old callers) maps nothing.</param>
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client, string version, string token, bool authEnabled = false, Func<bool>? requestShutdown = null,
         Action<string, string, string>? onSessionState = null, Func<string, string?>? assessedStateFor = null,
         Func<string, (string BriefingState, string? RailLine)>? briefStampFor = null,
         Func<string, (string? RailLine, string? Headline)>? interruptedBriefFor = null,
         Func<string, List<TurnBriefDto>>? briefHistoryFor = null,
         SessionOwnerCache? owners = null,
-        Gateway.Events.DirectorEventLog? directorEvents = null)
+        Gateway.Events.DirectorEventLog? directorEvents = null,
+        Voice.GatewayTurnJobStore? turnJobs = null)
     {
+        // Issue #376: async voice-turn submit/poll (the phone's reconnect-resilient voice
+        // interface). Mapped first for readability; route precedence (literal segments win
+        // over the catch-all session forwarder) does the actual dispatch.
+        if (turnJobs is not null)
+            GatewayVoiceTurnEndpoint.Map(app, turnJobs, registry, client, owners, token);
+
         // Graceful exit for the self-update helper: answer first (so the caller gets its 200),
         // then hand off to the host's shutdown handler shortly after. 501 when the hosting
         // process wired no handler - this endpoint never half-stops the host on its own.

--- a/src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs
@@ -1,0 +1,355 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Voice;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Async voice-turn submit/poll surface (issue #376; docs/architecture/gateway/
+/// VOICE_TURN_ARCHITECTURE.md). The phone submits ONE request and is then free to drop signal:
+///
+///   POST /sessions/{sid}/voice-turn/submit  -> 202 { turn_id, expires_at }
+///        creates a <see cref="TurnJob"/>, resolves the owning Director, and fires a
+///        background task that drives the Director's existing SSE endpoint
+///        (POST /sessions/{sid}/voice-turn), mirroring each stage event into the job.
+///
+///   GET  /sessions/{sid}/voice-turn/{turnId} -> 200 { stage, transcript, summary,
+///        audioBase64, message } from the job cache (no Director call); 404 when the
+///        turn id is unknown or past its 10-minute TTL.
+///
+/// The Director's SSE endpoint stays the worker (transcription, send-to-session, summarize,
+/// TTS); this layer only owns the async interface and the result cache. Owner resolution
+/// mirrors <see cref="SessionWsProxyEndpoints"/>: the <see cref="SessionOwnerCache"/> fast
+/// path first, then a live fleet fan-out.
+/// </summary>
+internal static class GatewayVoiceTurnEndpoint
+{
+    /// <summary>Ceiling for one full Director-side turn (transcribe + Claude + summarize + TTS).
+    /// Comfortably above the Director's own internal timeouts (60s ready-wait + 120s turn).</summary>
+    private static readonly TimeSpan DirectorTurnTimeout = TimeSpan.FromMinutes(5);
+
+    public static void Map(IEndpointRouteBuilder app, GatewayTurnJobStore store, DirectorRegistry registry,
+        DirectorEndpointClient client, SessionOwnerCache? owners, string token)
+    {
+        app.MapPost("/sessions/{sid}/voice-turn/submit", async (string sid, HttpContext ctx) =>
+        {
+            FileLog.Write($"[GatewayVoiceTurn] POST /sessions/{sid}/voice-turn/submit from {ctx.Connection.RemoteIpAddress}");
+
+            if (!Guid.TryParse(sid, out _))
+                return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
+
+            // Capture the input NOW: the request body is gone once the 202 is written, and the
+            // background task must be able to (re)build it for the Director.
+            VoiceTurnInput input;
+            try
+            {
+                input = await VoiceTurnInput.ReadAsync(ctx);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[GatewayVoiceTurn] submit sid={sid}: unreadable body: {ex.Message}");
+                return Results.Json(new { error = "unreadable request body: " + ex.Message },
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            // Resolve the owning Director. Fast path: the cached owner (kept fresh by the fleet
+            // aggregator and the WS proxy) - a dictionary lookup, no fleet fan-out, and it still
+            // resolves when the Director has just gone dark (the background task then surfaces
+            // the failure as the job's error stage, which is exactly the async contract).
+            string? endpoint = null;
+            if (owners?.OwnerOf(sid) is { } cachedOwnerId && registry.Get(cachedOwnerId) is { } cachedDir)
+                endpoint = DialEndpoint(cachedDir);
+
+            if (endpoint is null)
+            {
+                var (director, session) = await LocateOwningDirectorAsync(registry, client, sid);
+                if (director is null || session is null)
+                {
+                    FileLog.Write($"[GatewayVoiceTurn] submit sid={sid}: no owning director -> 404");
+                    return Results.Json(new { error = "session not found" }, statusCode: StatusCodes.Status404NotFound);
+                }
+                if (IsExited(session))
+                {
+                    FileLog.Write($"[GatewayVoiceTurn] submit sid={sid}: session exited -> 410");
+                    return Results.Json(new { error = "session has exited" }, statusCode: StatusCodes.Status410Gone);
+                }
+                owners?.Remember(sid, director.DirectorId);
+                endpoint = DialEndpoint(director);
+                if (endpoint is null)
+                {
+                    FileLog.Write($"[GatewayVoiceTurn] submit sid={sid}: owner {director.DirectorId} has no dialable endpoint -> 503");
+                    return Results.Json(new { error = "owning director has no reachable endpoint" },
+                        statusCode: StatusCodes.Status503ServiceUnavailable);
+                }
+            }
+
+            var job = store.Create(sid);
+
+            // Fire-and-forget by design: the 202 is the whole point - the caller never waits on
+            // the Director. The task is its own entry point, so it owns its try-catch and ALWAYS
+            // lands the job in a terminal stage (reply or error); a poll can never hang forever.
+            _ = Task.Run(() => RunTurnAsync(job, endpoint, sid, input, token));
+
+            FileLog.Write($"[GatewayVoiceTurn] submit sid={sid}: accepted turnId={job.TurnId}, director={endpoint}");
+            return Results.Json(new { turn_id = job.TurnId, expires_at = job.ExpiresAt },
+                statusCode: StatusCodes.Status202Accepted);
+        });
+
+        app.MapGet("/sessions/{sid}/voice-turn/{turnId}", (string sid, string turnId) =>
+        {
+            var job = store.Get(turnId);
+            if (job is null || !string.Equals(job.SessionId, sid, StringComparison.OrdinalIgnoreCase))
+            {
+                FileLog.Write($"[GatewayVoiceTurn] poll sid={sid} turnId={turnId}: unknown or expired -> 404");
+                return Results.Json(new { error = "turn not found or expired" }, statusCode: StatusCodes.Status404NotFound);
+            }
+
+            var s = job.Snapshot();
+            return Results.Json(new
+            {
+                turn_id = job.TurnId,
+                stage = s.Stage,
+                transcript = s.Transcript,
+                summary = s.Summary,
+                audioBase64 = s.AudioBase64,
+                message = s.ErrorMessage,
+                expires_at = job.ExpiresAt,
+            });
+        });
+    }
+
+    /// <summary>
+    /// Background driver for one turn: POST the captured input to the owning Director's SSE
+    /// voice-turn endpoint, mirror every stage event into <paramref name="job"/>, and ALWAYS
+    /// leave the job terminal (reply or error). This is a top-level task entry point, so the
+    /// try-catch boundary lives here.
+    /// </summary>
+    private static async Task RunTurnAsync(TurnJob job, string directorEndpoint, string sid,
+        VoiceTurnInput input, string token)
+    {
+        FileLog.Write($"[GatewayVoiceTurn] RunTurnAsync: turnId={job.TurnId}, sid={sid}, director={directorEndpoint}");
+        try
+        {
+            using var http = new HttpClient { Timeout = DirectorTurnTimeout };
+            if (!string.IsNullOrEmpty(token))
+                http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{directorEndpoint}/sessions/{sid}/voice-turn")
+            {
+                Content = input.BuildContent(),
+            };
+            using var resp = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadAsStringAsync();
+                FileLog.Write($"[GatewayVoiceTurn] RunTurnAsync turnId={job.TurnId}: director answered {(int)resp.StatusCode}");
+                job.SetError($"director returned {(int)resp.StatusCode}: {Truncate(body)}");
+                return;
+            }
+
+            await using var stream = await resp.Content.ReadAsStreamAsync();
+            using var reader = new StreamReader(stream);
+
+            var terminal = false;
+            while (await reader.ReadLineAsync() is { } line)
+            {
+                var trimmed = line.Trim();
+                if (!trimmed.StartsWith("data:", StringComparison.Ordinal)) continue;
+                var json = trimmed["data:".Length..].Trim();
+                if (string.IsNullOrWhiteSpace(json)) continue;
+
+                if (ApplyEvent(job, json)) { terminal = true; break; }
+            }
+
+            if (!terminal)
+            {
+                FileLog.Write($"[GatewayVoiceTurn] RunTurnAsync turnId={job.TurnId}: SSE stream ended without reply/error");
+                job.SetError("director stream ended without a reply");
+            }
+            else
+            {
+                FileLog.Write($"[GatewayVoiceTurn] RunTurnAsync turnId={job.TurnId}: terminal stage={job.Snapshot().Stage}");
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayVoiceTurn] RunTurnAsync turnId={job.TurnId} FAILED: {ex.Message}");
+            job.SetError("director unreachable: " + ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Apply one Director SSE event payload to the job. Returns true when the event is terminal
+    /// (reply or error). An unparseable payload is skipped - the stream's terminal event (or its
+    /// EOF guard) still lands the job in a terminal stage.
+    /// </summary>
+    private static bool ApplyEvent(TurnJob job, string json)
+    {
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            FileLog.Write($"[GatewayVoiceTurn] ApplyEvent turnId={job.TurnId}: unparseable SSE payload skipped: {ex.Message}");
+            return false;
+        }
+
+        using (doc)
+        {
+            var stage = ReadString(doc, "stage");
+            if (string.IsNullOrEmpty(stage)) return false;
+
+            switch (stage)
+            {
+                case "transcript":
+                    job.SetTranscript(ReadString(doc, "text"));
+                    return false;
+                case "reply":
+                    job.SetReply(ReadString(doc, "summary"), ReadString(doc, "audioBase64"));
+                    return true;
+                case "error":
+                    job.SetError(ReadString(doc, "message") ?? "director reported an error");
+                    return true;
+                default:
+                    // submitted/transcribing/waiting/thinking/summarizing - plain progress.
+                    job.SetStage(stage);
+                    return false;
+            }
+        }
+    }
+
+    private static string? ReadString(JsonDocument doc, string field)
+        => doc.RootElement.TryGetProperty(field, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    /// <summary>
+    /// Find the one Director that owns this session id, with its session row (so the submit can
+    /// gate on an exited session). Fans out in parallel - mirrors GatewayEndpoints.LocateSessionAsync.
+    /// </summary>
+    private static async Task<(DirectorDto? director, SessionDto? session)> LocateOwningDirectorAsync(
+        DirectorRegistry registry, DirectorEndpointClient client, string sid)
+    {
+        var lookups = registry.ListDirectors().Select(async d =>
+        {
+            var ep = (d.ControlEndpoint ?? "").TrimEnd('/');
+            var s = await client.GetSessionAsync(ep, sid);
+            return (director: d, session: s);
+        }).ToList();
+
+        var results = await Task.WhenAll(lookups);
+        foreach (var (director, session) in results)
+            if (session is not null) return (director, session);
+        return (null, null);
+    }
+
+    private static bool IsExited(SessionDto session)
+        => string.Equals(session.Status, "Exited", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(session.Status, "Failed", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(session.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The base URL the Gateway dials to reach the Director's Control API: the
+    /// ControlEndpoint (loopback for FSW-discovered, tailnet for HTTP-registered), else the
+    /// TailnetEndpoint. Null when neither is usable.</summary>
+    private static string? DialEndpoint(DirectorDto d)
+    {
+        var endpoint = !string.IsNullOrWhiteSpace(d.ControlEndpoint) ? d.ControlEndpoint : d.TailnetEndpoint;
+        return string.IsNullOrWhiteSpace(endpoint) ? null : endpoint.TrimEnd('/');
+    }
+
+    private static string Truncate(string s)
+        => s.Length <= 300 ? s : s[..300] + "...";
+
+    /// <summary>
+    /// The captured submit body, buffered so the background task can rebuild it after the 202
+    /// has been written. Two shapes, matching the Director endpoint's own contract:
+    /// multipart/form-data (optional text field + optional audio file) or a raw JSON body
+    /// (forwarded verbatim - the Director validates it).
+    /// </summary>
+    private sealed class VoiceTurnInput
+    {
+        private readonly string? _text;
+        private readonly byte[]? _audioBytes;
+        private readonly string? _audioFileName;
+        private readonly string? _audioContentType;
+        private readonly string? _rawJson;
+
+        private VoiceTurnInput(string? text, byte[]? audioBytes, string? audioFileName,
+            string? audioContentType, string? rawJson)
+        {
+            _text = text;
+            _audioBytes = audioBytes;
+            _audioFileName = audioFileName;
+            _audioContentType = audioContentType;
+            _rawJson = rawJson;
+        }
+
+        public static async Task<VoiceTurnInput> ReadAsync(HttpContext ctx)
+        {
+            if (ctx.Request.HasFormContentType)
+            {
+                var form = await ctx.Request.ReadFormAsync(ctx.RequestAborted);
+                var text = form["text"].ToString();
+                var file = form.Files.GetFile("audio") ?? form.Files.FirstOrDefault();
+
+                byte[]? audioBytes = null;
+                string? fileName = null;
+                string? contentType = null;
+                if (file is not null && file.Length > 0)
+                {
+                    using var ms = new MemoryStream();
+                    await file.CopyToAsync(ms, ctx.RequestAborted);
+                    audioBytes = ms.ToArray();
+                    fileName = string.IsNullOrEmpty(file.FileName) ? "audio.webm" : file.FileName;
+                    contentType = string.IsNullOrEmpty(file.ContentType) ? "application/octet-stream" : file.ContentType;
+                }
+
+                return new VoiceTurnInput(
+                    string.IsNullOrWhiteSpace(text) ? null : text,
+                    audioBytes, fileName, contentType, rawJson: null);
+            }
+
+            // JSON path: buffer the raw body and forward it verbatim - the Director's own
+            // validation (text required) is the single source of truth for the JSON shape.
+            using var reader = new StreamReader(ctx.Request.Body, Encoding.UTF8);
+            var raw = await reader.ReadToEndAsync(ctx.RequestAborted);
+            return new VoiceTurnInput(text: null, audioBytes: null, audioFileName: null,
+                audioContentType: null, rawJson: raw);
+        }
+
+        /// <summary>Rebuild the HttpContent for the Director call. Safe to call once per turn.</summary>
+        public HttpContent BuildContent()
+        {
+            if (_rawJson is not null)
+                return new StringContent(_rawJson, Encoding.UTF8, "application/json");
+
+            var form = new MultipartFormDataContent();
+            if (_text is not null)
+                form.Add(new StringContent(_text), "text");
+            if (_audioBytes is not null)
+            {
+                var audio = new ByteArrayContent(_audioBytes);
+                audio.Headers.ContentType = new MediaTypeHeaderValue(_audioContentType ?? "application/octet-stream");
+                form.Add(audio, "audio", _audioFileName ?? "audio.webm");
+            }
+            if (_text is null && _audioBytes is null)
+            {
+                // Empty form: forward a placeholder field so the multipart body is valid; the
+                // Director answers with its structured "text or audio required" error event,
+                // which the background task mirrors into the job (the async error contract).
+                form.Add(new StringContent(""), "text");
+            }
+            return form;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -46,6 +46,14 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     public Events.DirectorEventLog DirectorEvents { get; } = new();
 
+    /// <summary>
+    /// Issue #376: the async voice-turn job cache (10-minute TTL). The submit endpoint creates
+    /// jobs here, a background task mirrors the owning Director's SSE stage events into them,
+    /// and the poll endpoint reads them - in-memory by design (a Gateway restart drops in-flight
+    /// turns and the phone re-submits).
+    /// </summary>
+    public Voice.GatewayTurnJobStore TurnJobs { get; } = new();
+
     /// <summary>When this host was constructed - the Cockpit Settings page reads it for uptime.</summary>
     public DateTime StartedAtUtc { get; } = DateTime.UtcNow;
 
@@ -382,7 +390,9 @@ public sealed class GatewayHost : IAsyncDisposable
             // proxy can return 503 (owner offline) rather than 404 for a session whose Director went dark.
             owners: SessionOwners,
             // Issue #330: doorbell event-vocabulary pings land in the per-director event ring.
-            directorEvents: DirectorEvents);
+            directorEvents: DirectorEvents,
+            // Issue #376: async voice-turn submit/poll rides the host-owned job store.
+            turnJobs: TurnJobs);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and

--- a/src/CcDirector.Gateway/Voice/GatewayTurnJobStore.cs
+++ b/src/CcDirector.Gateway/Voice/GatewayTurnJobStore.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Voice;
+
+/// <summary>
+/// One async voice turn tracked by the Gateway (issue #376). The submit endpoint creates a job,
+/// a background task drives the Director's SSE voice-turn endpoint and mirrors each stage event
+/// into the job, and the poll endpoint reads it - so a phone that loses signal mid-turn collects
+/// the cached result on reconnect instead of restarting the turn.
+///
+/// Stage vocabulary (mirrors the Director's SSE events, see
+/// docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md): submitted, transcribing, transcript,
+/// waiting, thinking, summarizing, reply (terminal), error (terminal).
+///
+/// Thread safety: the background task writes and any number of poll requests read concurrently,
+/// so every mutation and the snapshot read are serialized on one private lock. Readers always
+/// consume <see cref="Snapshot"/> - never the fields piecemeal - so a poll can never observe a
+/// half-applied reply event.
+/// </summary>
+public sealed class TurnJob
+{
+    private readonly object _lock = new();
+    private string _stage = "submitted";
+    private string? _transcript;
+    private string? _summary;
+    private string? _audioBase64;
+    private string? _errorMessage;
+
+    /// <summary>UUID identifying this turn; the poll route key.</summary>
+    public string TurnId { get; }
+
+    /// <summary>The session this turn targets; polls for a different session 404.</summary>
+    public string SessionId { get; }
+
+    /// <summary>When the job was created (UTC).</summary>
+    public DateTime CreatedAt { get; private set; }
+
+    /// <summary>When the job expires (UTC); reads after this point behave as not-found.</summary>
+    public DateTime ExpiresAt { get; private set; }
+
+    public TurnJob(string turnId, string sessionId, DateTime createdAtUtc, TimeSpan ttl)
+    {
+        if (string.IsNullOrEmpty(turnId))
+            throw new ArgumentException("turnId is required", nameof(turnId));
+        if (string.IsNullOrEmpty(sessionId))
+            throw new ArgumentException("sessionId is required", nameof(sessionId));
+
+        TurnId = turnId;
+        SessionId = sessionId;
+        CreatedAt = createdAtUtc;
+        ExpiresAt = createdAtUtc + ttl;
+    }
+
+    /// <summary>Record an in-progress stage event (transcribing/waiting/thinking/summarizing).</summary>
+    public void SetStage(string stage)
+    {
+        if (string.IsNullOrEmpty(stage)) return;
+        lock (_lock) { _stage = stage; }
+    }
+
+    /// <summary>Record the transcript event: the audio was transcribed to <paramref name="transcript"/>.</summary>
+    public void SetTranscript(string? transcript)
+    {
+        lock (_lock)
+        {
+            _stage = "transcript";
+            _transcript = transcript ?? "";
+        }
+    }
+
+    /// <summary>Record the terminal reply event. Fields are coerced to non-null so a completed
+    /// poll always carries both (audioBase64 may be empty when no TTS key is configured).</summary>
+    public void SetReply(string? summary, string? audioBase64)
+    {
+        lock (_lock)
+        {
+            _stage = "reply";
+            _summary = summary ?? "";
+            _audioBase64 = audioBase64 ?? "";
+        }
+    }
+
+    /// <summary>Record the terminal error outcome (Director error event, unreachable Director,
+    /// non-2xx answer, or a stream that ended without a reply).</summary>
+    public void SetError(string message)
+    {
+        lock (_lock)
+        {
+            _stage = "error";
+            _errorMessage = string.IsNullOrEmpty(message) ? "unknown error" : message;
+        }
+    }
+
+    /// <summary>Consistent point-in-time read of the job for the poll endpoint.</summary>
+    public TurnJobSnapshot Snapshot()
+    {
+        lock (_lock)
+        {
+            return new TurnJobSnapshot(_stage, _transcript, _summary, _audioBase64, _errorMessage);
+        }
+    }
+
+    /// <summary>
+    /// TEST SEAM: rewrite the creation time (and the derived expiry) so a test can simulate a
+    /// job created in the past without waiting out the real TTL.
+    /// </summary>
+    internal void OverrideCreatedAtForTest(DateTime createdAtUtc, TimeSpan ttl)
+    {
+        lock (_lock)
+        {
+            CreatedAt = createdAtUtc;
+            ExpiresAt = createdAtUtc + ttl;
+        }
+    }
+}
+
+/// <summary>Point-in-time view of a <see cref="TurnJob"/> (one lock acquisition per poll).</summary>
+public readonly record struct TurnJobSnapshot(
+    string Stage, string? Transcript, string? Summary, string? AudioBase64, string? ErrorMessage);
+
+/// <summary>
+/// In-memory store of async voice-turn jobs keyed by UUID turn_id (issue #376). 10-minute TTL;
+/// expiry is checked lazily on every read and swept opportunistically on create, so no timer
+/// thread is needed. In-memory by design - a Gateway restart drops in-flight turns, and the
+/// phone simply re-submits (the same contract as the rest of the Gateway's in-memory state).
+/// </summary>
+public sealed class GatewayTurnJobStore
+{
+    /// <summary>How long a completed (or in-flight) turn result stays pollable.</summary>
+    public static readonly TimeSpan Ttl = TimeSpan.FromMinutes(10);
+
+    private readonly ConcurrentDictionary<string, TurnJob> _jobs = new(StringComparer.Ordinal);
+
+    /// <summary>Create and register a new job for <paramref name="sessionId"/> (stage=submitted).</summary>
+    public TurnJob Create(string sessionId)
+    {
+        SweepExpired();
+        var job = new TurnJob(Guid.NewGuid().ToString(), sessionId, DateTime.UtcNow, Ttl);
+        _jobs[job.TurnId] = job;
+        FileLog.Write($"[GatewayTurnJobStore] Create: turnId={job.TurnId}, sid={sessionId}, expiresAt={job.ExpiresAt:O}");
+        return job;
+    }
+
+    /// <summary>
+    /// The job for <paramref name="turnId"/>, or null when unknown or expired. An expired job is
+    /// removed on this read (lazy expiry) so the caller's 404 is also the cleanup.
+    /// </summary>
+    public TurnJob? Get(string turnId)
+    {
+        if (string.IsNullOrEmpty(turnId)) return null;
+        if (!_jobs.TryGetValue(turnId, out var job)) return null;
+        if (job.ExpiresAt <= DateTime.UtcNow)
+        {
+            _jobs.TryRemove(turnId, out _);
+            FileLog.Write($"[GatewayTurnJobStore] Get: turnId={turnId} expired (created {job.CreatedAt:O}); removed");
+            return null;
+        }
+        return job;
+    }
+
+    /// <summary>Drop every expired job. Called on each create so the dictionary stays bounded
+    /// by the number of turns submitted within one TTL window.</summary>
+    private void SweepExpired()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var kvp in _jobs)
+        {
+            if (kvp.Value.ExpiresAt <= now)
+                _jobs.TryRemove(kvp.Key, out _);
+        }
+    }
+}


### PR DESCRIPTION
Implements #376: the Gateway's async voice-turn submit/poll layer over the Director's existing SSE endpoint, per [docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md](docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md) Phase 2.

## Changes
- **`src/CcDirector.Gateway/Voice/GatewayTurnJobStore.cs`** - in-memory TurnJob cache keyed by UUID `turn_id`, 10-minute TTL (lazy expiry on read + sweep on create), thread-safe (ConcurrentDictionary + per-job lock with snapshot reads).
- **`src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs`**
  - `POST /sessions/{sid}/voice-turn/submit` - 400 invalid guid, 404 unknown session, 410 exited session, else 202 `{ turn_id, expires_at }`. Buffers the body (multipart audio/text or raw JSON), resolves the owning Director (SessionOwnerCache fast path, else live fleet fan-out), and fires an unawaited background task that drives the Director's SSE `POST /sessions/{sid}/voice-turn`, mirroring every stage event into the job. The task always lands the job terminal (reply or error) - a poll can never hang.
  - `GET /sessions/{sid}/voice-turn/{turnId}` - 404 unknown/expired, 200 `{ stage, transcript, summary, audioBase64, message }`.
- **Wiring** - `GatewayEndpoints.Map()` gained a `turnJobs` param; `GatewayHost` owns the `TurnJobs` singleton.
- **`src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs`** - 11 integration tests (real ControlApiHost + GatewayHost on ephemeral ports, isolated instances dir, stub backends - no live Claude/OpenAI).

## How to Test
```
dotnet build cc-director.sln
dotnet test src\CcDirector.Gateway.Tests --filter GatewayVoiceTurnAsync
```

## Expected Result
Build clean, 11/11 tests green. Live: submit a JSON text turn through the Gateway, poll the turn id, watch stages thinking -> reply with summary + audioBase64.

## Proof
[docs/cencon/proof/voice-turn-gateway/report.html](docs/cencon/proof/voice-turn-gateway/report.html) - all 11 tests PASS + a live curl trace (submit -> 202 -> thinking polls -> reply with real TTS audio) against an isolated slot-8 Director + isolated NEW-code Gateway (torn down afterwards).

Full Gateway.Tests run: 597/599 passed; the 2 failures are pre-existing/environmental (Dictation realtime live-API test fails identically on clean main `708c250`; Facts_Proxy is timing-flaky under load and passes in isolation) - detailed in the proof report.

## Before/After
- Before: the phone holds a 60-120s SSE connection to the Director for a whole voice turn; a signal drop loses the turn.
- After: the phone submits once to the Gateway, gets a `turn_id`, and polls at its convenience; the result is cached 10 minutes, so reconnects cost nothing.

Out of scope (per issue): bearer-token auth on these routes (#369), phone URL swap, Director async endpoint removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
