### PR TITLE
feat(#378): phone voice turns submit/poll on the Gateway, not the Director

### DIFF
--- a/docs/cencon/proof/issue-378/qa-report.html
+++ b/docs/cencon/proof/issue-378/qa-report.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Report - Issue #378: Phone voice-turn URLs swap to Gateway</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 980px; color: #1a1a1a; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #2b6cb0; padding-bottom: .4rem; }
+  h2 { color: #2b6cb0; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cbd5e0; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #edf2f7; }
+  .pass { color: #276749; font-weight: bold; }
+  .carve { color: #975a16; font-weight: bold; }
+  code, pre { background: #f7fafc; border: 1px solid #e2e8f0; border-radius: 4px; font-family: Consolas, monospace; font-size: .9em; }
+  code { padding: 0 .25em; }
+  pre { padding: .7rem; overflow-x: auto; }
+  .verdict { background: #f0fff4; border: 2px solid #276749; border-radius: 6px; padding: 1rem 1.4rem; margin: 1.5rem 0; }
+  .warn { background: #fffaf0; border: 2px solid #975a16; border-radius: 6px; padding: 1rem 1.4rem; margin: 1.5rem 0; }
+</style>
+</head>
+<body>
+
+<h1>QA Report - Issue #378</h1>
+<p><strong>Issue:</strong> [Voice] Phone app: swap voice-turn URLs from Director to Gateway<br>
+<strong>PR:</strong> #383 (branch <code>issue-378-phone-gateway-urls</code>, head commit <code>91133a7</code>)<br>
+<strong>QA Agent run:</strong> 2026-06-12, independent verification on the QA machine (fresh checkout of the PR branch; builds and tests run by QA, not reused from the Developer)</p>
+
+<div class="verdict">
+<strong>VERDICT: PASS</strong> - every criterion verifiable on this machine is independently green.
+The on-device live e2e (criteria requiring a physical Android phone and a deployed post-#376 Gateway)
+is <strong>CARVED OUT as PENDING HARDWARE</strong> - see the loud carve-out section below. The merged
+code is safe to ship: this PR touches ONLY phone-app code plus proof; the Director's existing SSE
+voice-turn endpoint is untouched, so phones running old builds keep working unchanged.
+</div>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-verified)</th><th>Result</th></tr>
+<tr>
+  <td>1</td>
+  <td>Phone submits to <code>&lt;gateway-url&gt;/sessions/{sid}/voice-turn/submit</code></td>
+  <td>Submit goes to the Gateway URL, never a Director address; Director log shows the request arriving from the Gateway</td>
+  <td>CODE: <code>VoiceConversation.SpeakTurnAsync</code> agent path calls <code>SubmitVoiceTurnAsync(_gatewayBaseUrl, ...)</code> (VoiceConversation.cs:105-106); <code>_gatewayBaseUrl</code> comes from the page's <code>gateway_url</code> setting (TalkPage.xaml.cs:501-502 passes <code>ServerEntry.Text</code>; VoiceSessionView.xaml.cs:378-379 passes <code>_gatewayUrlProvider()</code> wired by FifoPage.xaml.cs:95-96). An empty gateway URL throws a clear error (VoiceConversation.cs:98-100) - no fallback to a Director address. LIVE log check: pending hardware.</td>
+  <td><span class="pass">PASS (code)</span> / <span class="carve">live: pending hardware</span></td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>Phone polls <code>&lt;gateway-url&gt;/sessions/{sid}/voice-turn/{turnId}</code></td>
+  <td>Poll loop hits the Gateway every ~1.5s until a terminal stage</td>
+  <td>CODE: poll loop calls <code>PollVoiceTurnAsync(_gatewayBaseUrl, session.SessionId, submit.TurnId)</code> at a 1500 ms cadence until stage <code>reply</code>/<code>error</code> (VoiceConversation.cs:113-149). The ONLY callers of Submit/Poll are this Gateway-URL path - zero <code>TailnetEndpoint</code> usage on the agent voice-turn path (verified by repo-wide grep). LIVE log check: pending hardware.</td>
+  <td><span class="pass">PASS (code)</span> / <span class="carve">live: pending hardware</span></td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>Complete voice turn end-to-end on the test device (mic -&gt; spoken summary)</td>
+  <td>Live run on a physical Android phone</td>
+  <td><code>adb devices</code> on this machine returns an EMPTY list (no device attached); the production Gateway also runs a pre-#376 build. The live run was NOT performed and is NOT claimed.</td>
+  <td><span class="carve">CARVED OUT - pending hardware</span></td>
+</tr>
+<tr>
+  <td>4</td>
+  <td><code>dotnet build</code> (MAUI Android) succeeds with 0 errors</td>
+  <td>0 errors</td>
+  <td>QA ran <code>dotnet build phone\CcDirectorClient\CcDirectorClient.csproj -f net10.0-android</code> on the PR branch: <strong>Build succeeded, 0 Error(s)</strong> (92 pre-existing NU1608 AndroidX version-constraint warnings, unrelated to this change).</td>
+  <td><span class="pass">PASS</span></td>
+</tr>
+<tr>
+  <td>5</td>
+  <td>Deployed and tested on the physical device via <code>scripts/deploy-phone.ps1</code></td>
+  <td>APK deployed to the phone</td>
+  <td>No device attached (<code>adb devices</code> empty) - cannot deploy honestly.</td>
+  <td><span class="carve">CARVED OUT - pending hardware</span></td>
+</tr>
+</table>
+
+<h2>Wire-contract verification (both sides, run by QA)</h2>
+<table>
+<tr><th>Check</th><th>Command</th><th>Result</th></tr>
+<tr>
+  <td>Phone-side parsers pin the Gateway shapes</td>
+  <td><code>dotnet test phone\CcDirectorClient.Tests\...csproj --filter VoiceTurnResultTests</code></td>
+  <td><span class="pass">11/11 passed</span> (7 methods, 11 cases). Pins the snake_case submit body (<code>turn_id</code>/<code>expires_at</code>), missing-turn-id throw, unparseable expiry tolerance, reply stage carrying <code>summary</code>+<code>audioBase64</code>, error stage carrying <code>message</code>, all five progress stages, and missing-stage -&gt; "unknown".</td>
+</tr>
+<tr>
+  <td>Gateway-side endpoint contract (#376)</td>
+  <td><code>dotnet test src\CcDirector.Gateway.Tests\...csproj --filter GatewayVoiceTurnAsyncTests</code></td>
+  <td><span class="pass">11/11 passed</span>.</td>
+</tr>
+<tr>
+  <td>Shapes actually match (source-level cross-check)</td>
+  <td>Read of <code>GatewayVoiceTurnEndpoint.cs</code> vs <code>VoiceTurnResults.cs</code></td>
+  <td><span class="pass">MATCH</span>. Gateway 202: <code>{ turn_id, expires_at }</code> (GatewayVoiceTurnEndpoint.cs:101) = exactly what <code>ParseSubmit</code> reads. Gateway poll 200: <code>{ turn_id, stage, transcript, summary, audioBase64, message, expires_at }</code> (lines 115-124) = exactly what <code>ParsePoll</code> reads. The phone's multipart field name <code>"audio"</code> is what the Gateway's <code>VoiceTurnInput.ReadAsync</code> looks for (<code>form.Files.GetFile("audio")</code>, line 303).</td>
+</tr>
+</table>
+
+<h2>Regression / safety sweep</h2>
+<table>
+<tr><th>Check</th><th>Result</th></tr>
+<tr><td>Full solution build on the PR branch: <code>dotnet build cc-director.sln</code></td><td><span class="pass">Build succeeded, 0 Warning(s), 0 Error(s)</span></td></tr>
+<tr><td>PR diff scope (git diff main...PR --stat)</td><td><span class="pass">Phone code + tests + proof only</span> - no <code>src/</code> files touched. The Director's SSE endpoint <code>POST /sessions/{sid}/voice-turn</code> (src/CcDirector.ControlApi/VoiceTurnEndpoint.cs) is UNCHANGED, so phones on old builds keep working - verified in code, not just claimed.</td></tr>
+<tr><td>No leftover <code>TailnetEndpoint</code> on the agent voice-turn path</td><td><span class="pass">Confirmed by grep.</span> Remaining <code>TailnetEndpoint</code> uses are the intentionally Director-direct paths: wingman ask, transcribe-to-textbox dictation, FIFO deliver, briefing/recap/TTS utilities, terminal mirror - all explicitly out of scope per the issue.</td></tr>
+<tr><td>No fallback programming</td><td><span class="pass">PASS</span> - missing gateway URL throws with a clear setup instruction (VoiceConversation.cs:98-100); malformed 202 throws (VoiceTurnResults.ParseSubmit) instead of polling an empty id.</td></tr>
+<tr><td>CenCon method / DT rules</td><td><span class="pass">No violation found.</span> No new endpoints, no auth change, architecture doc (VOICE_TURN_ARCHITECTURE.md Phase 3) referenced by the change.</td></tr>
+</table>
+
+<div class="warn">
+<h2 style="margin-top:0">LOUD CARVE-OUT: on-device e2e is PENDING HARDWARE</h2>
+<p>Acceptance criteria 1 (live Director-log proof), 2 (live Gateway-log proof), 3 (full voice turn on
+the phone) and 5 (deploy via <code>scripts/deploy-phone.ps1</code>) require a physical Android device
+and a deployed post-#376 Gateway. QA honestly verified that <strong>no device is attached</strong>
+(<code>adb devices</code> -&gt; empty list) and the production Gateway still runs a pre-#376 build.
+These steps were NOT performed and are NOT claimed.</p>
+<p><strong>Follow-up required when hardware is available:</strong> follow the Developer's QA runbook in
+<code>docs/cencon/proof/issue-378/report.html</code>: (1) deploy a post-#376 Gateway build,
+(2) <code>scripts\deploy-phone.ps1 -Phone &lt;ip:port&gt;</code>, (3) record a voice turn on a
+wingman-enabled session and confirm the Gateway log line
+<code>[GatewayVoiceTurn] POST /sessions/{sid}/voice-turn/submit from &lt;phone-ip&gt;</code> plus repeated
+phone polls, the Director seeing the turn arrive from the GATEWAY address, and the spoken summary
+playing on the phone. This note is also posted on the issue.</p>
+<p><strong>Why PASS anyway:</strong> everything verifiable on this machine is independently green, the
+wire contract is pinned by tests on BOTH sides and cross-checked in source, and shipping the merge
+cannot break any running phone: the phone APK only changes when explicitly deployed, and the old
+Director SSE path is untouched.</p>
+</div>
+
+<h2>Evidence log (commands run by QA on the PR branch)</h2>
+<pre>
+git checkout issue-378-phone-gateway-urls   # head 91133a7, up to date with origin
+adb devices                                  # -> "List of devices attached" (EMPTY - no device)
+dotnet build phone\CcDirectorClient\CcDirectorClient.csproj -f net10.0-android
+                                             # -> Build succeeded. 92 Warning(s) (pre-existing NU1608), 0 Error(s)
+dotnet test phone\CcDirectorClient.Tests --filter VoiceTurnResultTests
+                                             # -> Passed! Failed: 0, Passed: 11, Total: 11
+dotnet test src\CcDirector.Gateway.Tests --filter GatewayVoiceTurnAsyncTests
+                                             # -> Passed! Failed: 0, Passed: 11, Total: 11
+dotnet build cc-director.sln                 # -> Build succeeded. 0 Warning(s), 0 Error(s)
+</pre>
+
+<p><strong>VERIFIED - all acceptance criteria met that are verifiable on this machine; on-device
+criteria explicitly carved out as pending hardware and tracked on the issue.</strong></p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-378/report.html
+++ b/docs/cencon/proof/issue-378/report.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof - Issue #378: Phone voice-turn URLs swap from Director to Gateway</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; background: #0f1420; color: #dde3ee; margin: 0; padding: 32px; }
+  h1 { color: #5fd08a; font-size: 22px; }
+  h2 { color: #8ab4f8; font-size: 17px; margin-top: 28px; border-bottom: 1px solid #2a3349; padding-bottom: 4px; }
+  .meta { color: #8a93a8; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; font-size: 13.5px; }
+  th, td { border: 1px solid #2a3349; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #1a2235; color: #aebadd; }
+  .pass { color: #5fd08a; font-weight: 600; }
+  .pend { color: #e8b339; font-weight: 600; }
+  pre { background: #131a2b; border: 1px solid #2a3349; padding: 12px; overflow-x: auto; font-size: 12px; color: #c7d0e3; }
+  code { background: #1a2235; padding: 1px 5px; border-radius: 3px; font-size: 12.5px; }
+  .note { background: #2a2410; border: 1px solid #5c4d1a; padding: 12px; border-radius: 4px; margin: 12px 0; }
+</style>
+</head>
+<body>
+
+<h1>Proof - Issue #378: [Voice] Phone app: swap voice-turn URLs from Director to Gateway</h1>
+<p class="meta">Developer Agent | 2026-06-12 | Branch <code>issue-378-phone-gateway-urls</code> | PR #383 | Depends on #376 (merged, commit ead9299)</p>
+
+<h2>What was implemented</h2>
+<p>
+The phone walkie-talkie agent turn now submits and polls voice turns on the <strong>Gateway</strong>
+(<code>POST /sessions/{sid}/voice-turn/submit</code> + <code>GET /sessions/{sid}/voice-turn/{turnId}</code>,
+added by #376) instead of addressing the owning Director directly. The Gateway base URL comes from
+the phone's own settings (the <code>gateway_url</code> preference used by every page for the roster),
+so the DoR question in the issue resolves to: <strong>no session-DTO change needed</strong>.
+</p>
+<p>
+Porting note (recorded for QA honesty): the <code>SubmitVoiceTurnAsync</code>/<code>PollVoiceTurnAsync</code>
+methods the issue names existed only on the unmerged branch
+<code>issue-347-voice-dictation-recording-indicator</code> (commit <code>044e1c3</code> - the build the
+deployed phone currently runs). Main never had them. This change ports that submit/poll design into
+main's evolved phone code and points it at the Gateway, per
+<code>docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md</code> Phase 3.
+</p>
+
+<h2>Files changed</h2>
+<table>
+<tr><th>File</th><th>Change</th></tr>
+<tr><td>phone/CcDirectorClient/Voice/VoiceTurnResults.cs (new)</td><td>Dependency-free parsers for the Gateway wire shapes. Submit response is snake_case (<code>turn_id</code>/<code>expires_at</code>) - a casual case-insensitive deserialize would miss it; pinned by tests.</td></tr>
+<tr><td>phone/CcDirectorClient/Voice/DirectorVoiceClient.cs</td><td><code>SubmitVoiceTurnAsync</code> (multipart audio POST) + <code>PollVoiceTurnAsync</code>, both taking the GATEWAY base URL; bearer token attached as on every other call.</td></tr>
+<tr><td>phone/CcDirectorClient/Voice/VoiceConversation.cs</td><td><code>SpeakTurnAsync</code> agent path = submit once + poll every 1.5s; reply audio arrives base64 in the poll result and plays directly (no separate /tts call). Wingman path stays Director-direct. Dead wait/follow/summarize helpers removed (server-side pipeline owns them now). Ctor takes the Gateway base URL.</td></tr>
+<tr><td>phone/CcDirectorClient/TalkPage.xaml.cs</td><td><code>RunVoiceTurnAsync</code> constructs the conversation with the Gateway URL (the page's server setting).</td></tr>
+<tr><td>phone/CcDirectorClient/Controls/VoiceSessionView.xaml.cs</td><td><code>Configure()</code> gains an optional <code>gatewayUrlProvider</code>; the walkie-talkie path passes it through.</td></tr>
+<tr><td>phone/CcDirectorClient/FifoPage.xaml.cs</td><td>Passes the Gateway URL provider in its <code>Configure</code> call.</td></tr>
+<tr><td>phone/CcDirectorClient.Tests/* </td><td>Links VoiceTurnResults.cs; adds VoiceTurnResultTests (11 tests).</td></tr>
+</table>
+
+<h2>Acceptance criteria - status</h2>
+<table>
+<tr><th>Criterion</th><th>Status</th><th>Evidence</th></tr>
+<tr>
+  <td>Phone submits to <code>&lt;gateway-url&gt;/sessions/{sid}/voice-turn/submit</code></td>
+  <td class="pass">CODE + TESTS</td>
+  <td><code>DirectorVoiceClient.SubmitVoiceTurnAsync</code> builds exactly this URL from the Gateway base; live Director-log confirmation is the on-device step below.</td>
+</tr>
+<tr>
+  <td>Phone polls <code>&lt;gateway-url&gt;/sessions/{sid}/voice-turn/{turnId}</code></td>
+  <td class="pass">CODE + TESTS</td>
+  <td><code>DirectorVoiceClient.PollVoiceTurnAsync</code> + the 1.5s loop in <code>VoiceConversation.SpeakTurnAsync</code>; Gateway contract pinned by <code>VoiceTurnResultTests</code> (phone side) and <code>GatewayVoiceTurnAsyncTests</code> (server side, 11/11 green on this branch).</td>
+</tr>
+<tr>
+  <td>Complete voice turn end-to-end on the test device</td>
+  <td class="pend">PENDING HARDWARE</td>
+  <td>No Android device attached/reachable from this machine (see adb output below). Not faked.</td>
+</tr>
+<tr>
+  <td><code>dotnet build</code> (MAUI Android) 0 errors</td>
+  <td class="pass">PASS</td>
+  <td>Build output below: <code>0 Error(s)</code>; no new CS warnings (remaining warnings are pre-existing NU1608 package-constraint notes).</td>
+</tr>
+<tr>
+  <td>Deployed + tested on physical device via scripts/deploy-phone.ps1</td>
+  <td class="pend">PENDING HARDWARE</td>
+  <td>QA runbook below.</td>
+</tr>
+</table>
+
+<h2>Build proof (Android target)</h2>
+<pre>
+&gt; dotnet build phone\CcDirectorClient\CcDirectorClient.csproj -f net10.0-android
+    92 Warning(s)   (all pre-existing NU1608 AndroidX package-constraint warnings; zero CS warnings)
+    0 Error(s)
+Time Elapsed 00:01:25.20
+</pre>
+
+<h2>Unit test proof</h2>
+<pre>
+&gt; dotnet test phone\CcDirectorClient.Tests --filter FullyQualifiedName~VoiceTurnResultTests
+Passed!  - Failed: 0, Passed: 11, Skipped: 0, Total: 11
+
+&gt; dotnet test phone\CcDirectorClient.Tests      (full suite)
+Failed!  - Failed: 5, Passed: 104, Skipped: 0, Total: 109
+  (the 5 failures are all ConductorStateTests and fail IDENTICALLY on a clean
+   worktree of main @ ead9299 - pre-existing, unrelated to this change)
+
+&gt; dotnet test src\CcDirector.Gateway.Tests --filter FullyQualifiedName~GatewayVoiceTurnAsync
+Passed!  - Failed: 0, Passed: 11, Skipped: 0, Total: 11   (server-side contract green on this branch)
+</pre>
+
+<h2>Why on-device e2e is pending (verified, not assumed)</h2>
+<pre>
+&gt; adb devices
+List of devices attached
+                                  (empty - no USB or WiFi adb device reachable)
+
+&gt; GET http://localhost:7878/sessions/{random-guid}/voice-turn/{random-guid}   (production Gateway on this machine)
+HTTP 404  {"error":"session not found across any director"}
+</pre>
+<div class="note">
+That 404 body comes from the generic <code>/sessions/{sid}/**</code> catch-all forwarder, NOT from
+<code>GatewayVoiceTurnEndpoint</code> (which answers <code>{"error":"turn not found or expired"}</code>).
+The running production Gateway therefore predates today's #376 merge and does not yet map the
+voice-turn routes. <strong>QA must deploy a post-#376 Gateway build before the live test.</strong>
+</div>
+
+<h2>QA runbook to finish verification</h2>
+<ol>
+  <li>Deploy a Gateway build at or after commit <code>ead9299</code> (post-#376) to the Gateway host; verify its own log maps the voice-turn routes (probe: <code>GET /sessions/&lt;any-guid&gt;/voice-turn/&lt;any-guid&gt;</code> must answer <code>{"error":"turn not found or expired"}</code>).</li>
+  <li>Deploy this branch's app to the test phone: <code>scripts\deploy-phone.ps1 -Phone &lt;ip:port&gt;</code> (wireless debugging on, same tailnet).</li>
+  <li>Open a wingman-enabled session, Voice tab, record a question, submit.</li>
+  <li>Confirm: Gateway log shows <code>[GatewayVoiceTurn] POST /sessions/{sid}/voice-turn/submit from &lt;phone-ip&gt;</code> and repeated phone polls; the owning Director's log shows the SSE voice-turn request arriving from the GATEWAY's address, not the phone's; the spoken summary plays back on the phone.</li>
+</ol>
+
+<h2>CenCon impact</h2>
+<p>
+No architecture drift beyond what <code>VOICE_TURN_ARCHITECTURE.md</code> already documents as the target
+state (Phase 3 of its implementation plan - this change IS that phase). No security-posture change:
+the phone uses the same bearer-token mechanism against the same Gateway it already talks to for the
+roster; per-call tokens unchanged. (#369 adds the Gateway-side token enforcement separately.)
+</p>
+
+<h2>Verdict</h2>
+<p>
+Code change complete, Android build clean, both sides of the wire contract pinned by green tests.
+<strong>I believe this is finished</strong> at the level achievable on this machine; the on-device
+end-to-end run is pending hardware (no test device attached) plus a post-#376 Gateway deploy, and is
+handed to QA with the runbook above. Nothing was faked.
+</p>
+
+</body>
+</html>

--- a/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
+++ b/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\CcDirectorClient\Voice\FleetParser.cs" Link="Voice\FleetParser.cs" />
     <Compile Include="..\CcDirectorClient\Voice\SessionFilter.cs" Link="Voice\SessionFilter.cs" />
     <Compile Include="..\CcDirectorClient\Voice\ChatTurnResult.cs" Link="Voice\ChatTurnResult.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\VoiceTurnResults.cs" Link="Voice\VoiceTurnResults.cs" />
     <Compile Include="..\CcDirectorClient\Voice\ConductorState.cs" Link="Voice\ConductorState.cs" />
     <Compile Include="..\CcDirectorClient\Voice\RawTerminalPage.cs" Link="Voice\RawTerminalPage.cs" />
     <Compile Include="..\CcDirectorClient\Voice\TurnBrief.cs" Link="Voice\TurnBrief.cs" />

--- a/phone/CcDirectorClient.Tests/VoiceTurnResultTests.cs
+++ b/phone/CcDirectorClient.Tests/VoiceTurnResultTests.cs
@@ -1,0 +1,101 @@
+using CcDirectorClient.Voice;
+using Xunit;
+
+namespace CcDirectorClient.Tests;
+
+/// <summary>
+/// Wire-shape tests for the Gateway's async voice-turn responses (issue #378).
+/// The submit response is snake_case (turn_id / expires_at - the Gateway's contract,
+/// see GatewayVoiceTurnEndpoint), NOT camelCase like the Director's other routes, so
+/// these tests pin the mapping that a casual case-insensitive deserialize would miss.
+/// </summary>
+public class VoiceTurnResultTests
+{
+    // ===== ParseSubmit =====================================================
+
+    [Fact]
+    public void ParseSubmit_SnakeCaseGatewayBody_MapsTurnIdAndExpiry()
+    {
+        var json = "{\"turn_id\":\"3f6e2d1c-9a8b-4c7d-b5e4-aa11bb22cc33\",\"expires_at\":\"2026-06-12T23:30:00Z\"}";
+
+        var result = VoiceTurnResults.ParseSubmit(json);
+
+        Assert.Equal("3f6e2d1c-9a8b-4c7d-b5e4-aa11bb22cc33", result.TurnId);
+        Assert.Equal(new DateTimeOffset(2026, 6, 12, 23, 30, 0, TimeSpan.Zero), result.ExpiresAt);
+    }
+
+    [Fact]
+    public void ParseSubmit_MissingTurnId_Throws()
+    {
+        var json = "{\"expires_at\":\"2026-06-12T23:30:00Z\"}";
+
+        Assert.Throws<InvalidOperationException>(() => VoiceTurnResults.ParseSubmit(json));
+    }
+
+    [Fact]
+    public void ParseSubmit_UnparseableExpiry_StillReturnsTurnId()
+    {
+        var json = "{\"turn_id\":\"abc\",\"expires_at\":\"not-a-date\"}";
+
+        var result = VoiceTurnResults.ParseSubmit(json);
+
+        Assert.Equal("abc", result.TurnId);
+        Assert.Null(result.ExpiresAt);
+    }
+
+    // ===== ParsePoll =======================================================
+
+    [Fact]
+    public void ParsePoll_ReplyStage_CarriesSummaryAndAudio()
+    {
+        var json = "{\"turn_id\":\"abc\",\"stage\":\"reply\",\"transcript\":\"what is left\"," +
+                   "\"summary\":\"All done. Two tests remain red.\",\"audioBase64\":\"AAEC\"," +
+                   "\"message\":null,\"expires_at\":\"2026-06-12T23:30:00Z\"}";
+
+        var result = VoiceTurnResults.ParsePoll(json);
+
+        Assert.Equal("reply", result.Stage);
+        Assert.Equal("what is left", result.Transcript);
+        Assert.Equal("All done. Two tests remain red.", result.Summary);
+        Assert.Equal("AAEC", result.AudioBase64);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void ParsePoll_ErrorStage_CarriesMessage()
+    {
+        var json = "{\"turn_id\":\"abc\",\"stage\":\"error\",\"transcript\":null,\"summary\":null," +
+                   "\"audioBase64\":null,\"message\":\"director unreachable: timeout\"}";
+
+        var result = VoiceTurnResults.ParsePoll(json);
+
+        Assert.Equal("error", result.Stage);
+        Assert.Equal("director unreachable: timeout", result.Error);
+        Assert.Null(result.Summary);
+    }
+
+    [Theory]
+    [InlineData("submitted")]
+    [InlineData("transcribing")]
+    [InlineData("waiting")]
+    [InlineData("thinking")]
+    [InlineData("summarizing")]
+    public void ParsePoll_ProgressStages_PassThrough(string stage)
+    {
+        var json = $"{{\"turn_id\":\"abc\",\"stage\":\"{stage}\"}}";
+
+        var result = VoiceTurnResults.ParsePoll(json);
+
+        Assert.Equal(stage, result.Stage);
+    }
+
+    [Fact]
+    public void ParsePoll_MissingStage_MapsToUnknown()
+    {
+        var json = "{\"turn_id\":\"abc\"}";
+
+        var result = VoiceTurnResults.ParsePoll(json);
+
+        Assert.Equal("unknown", result.Stage);
+    }
+}

--- a/phone/CcDirectorClient/Controls/VoiceSessionView.xaml.cs
+++ b/phone/CcDirectorClient/Controls/VoiceSessionView.xaml.cs
@@ -38,6 +38,9 @@ public partial class VoiceSessionView : ContentView
     // The gateway token is read fresh from Preferences on every operation that needs
     // it, so the control does not need to be re-configured when the user changes it.
     private Func<string> _tokenProvider = () => "";
+    // The Gateway base URL, read fresh the same way. Required by the walkie-talkie
+    // agent turn, which submits/polls voice turns on the Gateway (issue #378).
+    private Func<string> _gatewayUrlProvider = () => "";
 
     // The most recent spoken clip for the current session (briefing or wingman answer),
     // kept so Replay can re-play it (issue #148). Cleared whenever the session changes
@@ -117,19 +120,21 @@ public partial class VoiceSessionView : ContentView
 
     /// <summary>
     /// Hand the control the services it needs (recorder, TTS, voice foreground service,
-    /// a way to read the current gateway token, and optional audio cues). The MAUI XAML
-    /// loader builds the control with a parameterless constructor, so the host calls this
+    /// a way to read the current gateway token, optional audio cues, and a way to read
+    /// the Gateway base URL for the walkie-talkie agent turn). The MAUI XAML loader
+    /// builds the control with a parameterless constructor, so the host calls this
     /// once after instantiation; everything else flows through it.
     /// </summary>
     public void Configure(IUtteranceRecorder recorder, IReplySpeaker tts,
                           IVoiceForeground foreground, Func<string> tokenProvider,
-                          IAudioCue? audioCue = null)
+                          IAudioCue? audioCue = null, Func<string>? gatewayUrlProvider = null)
     {
         _recorder = recorder;
         _tts = tts;
         _foreground = foreground;
         _tokenProvider = tokenProvider ?? (() => "");
         _audioCue = audioCue;
+        _gatewayUrlProvider = gatewayUrlProvider ?? (() => "");
     }
 
     /// <summary>
@@ -370,11 +375,13 @@ public partial class VoiceSessionView : ContentView
         SetBusy(true);
         _turnCts?.Cancel();
         _turnCts = new CancellationTokenSource();
-        var convo = new VoiceConversation(new DirectorVoiceClient(_tokenProvider()), _tts);
+        var convo = new VoiceConversation(
+            new DirectorVoiceClient(_tokenProvider()), _tts, _gatewayUrlProvider());
         try
         {
-            // Walkie-talkie mode (single-session host): run the full wait-send-follow-
-            // summarize-speak loop so the agent's reply is read back aloud as plain prose.
+            // Walkie-talkie mode (single-session host): submit the turn to the Gateway's
+            // async voice-turn pipeline and poll until the reply audio is back (issue
+            // #378), so the agent's reply is read back aloud as plain prose.
             // FIFO mode (queue host): deliver and move on without waiting for the reply.
             if (WalkieTalkieMode && !_recordingForWingman)
             {

--- a/phone/CcDirectorClient/FifoPage.xaml.cs
+++ b/phone/CcDirectorClient/FifoPage.xaml.cs
@@ -92,7 +92,8 @@ public partial class FifoPage : ContentPage
         TokenEntry.Text = Preferences.Get(PrefToken, "");
 
         // Configure the shared voice control to run in queue mode.
-        Voice.Configure(_recorder, _tts, _foreground, () => TokenEntry.Text ?? "", _audioCue);
+        Voice.Configure(_recorder, _tts, _foreground, () => TokenEntry.Text ?? "", _audioCue,
+            gatewayUrlProvider: () => (ServerEntry.Text ?? "").Trim());
         Voice.ShowSkip = true;
         Voice.ExitButtonText = "< Exit FIFO";
         Voice.ReadyActionsLine = "Ask Agent, Skip, or Hold";

--- a/phone/CcDirectorClient/TalkPage.xaml.cs
+++ b/phone/CcDirectorClient/TalkPage.xaml.cs
@@ -482,11 +482,12 @@ public partial class TalkPage : ContentPage
         VoiceStatusLabel.Text = "Tap Record and talk to the agent.";
     }
 
-    // Transcribe the clip, wait until the session is ready, send the question, follow the
-    // turn to completion, summarize via the wingman into plain spoken prose, then speak the
-    // summary and show the raw reply on screen. The foreground service stays up for the whole
-    // turn so capture + playback survive a screen-off.
-    // Status line cycles: Transcribing -> Sending -> Thinking -> Summarizing -> Speaking.
+    // Submit the clip to the GATEWAY's async voice-turn pipeline (issue #378): the Gateway
+    // drives the owning Director server-side (transcribe, wait for the session, run the
+    // turn, summarize, TTS) and the phone polls for the result, so the round-trip survives
+    // a brief signal drop. The foreground service stays up for the whole turn so capture +
+    // playback survive a screen-off.
+    // Status line cycles: Transcribing -> Waiting -> Thinking -> Summarizing -> Speaking.
     private async Task RunVoiceTurnAsync(SessionInfo session, UtteranceAudio audio)
     {
         var gate = OfflineGuard.Check(DeviceOnline, "send your voice message");
@@ -495,7 +496,10 @@ public partial class TalkPage : ContentPage
         _voiceTurnBusy = true;
         VoiceRecordButton.IsEnabled = false;
 
-        var convo = new VoiceConversation(new DirectorVoiceClient(TokenEntry.Text ?? ""), _tts);
+        // The voice turn submits/polls on the GATEWAY (its address is the page's server
+        // setting - the same one the roster comes from), never on a Director directly.
+        var convo = new VoiceConversation(
+            new DirectorVoiceClient(TokenEntry.Text ?? ""), _tts, (ServerEntry.Text ?? "").Trim());
         _voiceTurnCts?.Cancel();
         _voiceTurnCts = new CancellationTokenSource();
         var cts = _voiceTurnCts;

--- a/phone/CcDirectorClient/Voice/DirectorVoiceClient.cs
+++ b/phone/CcDirectorClient/Voice/DirectorVoiceClient.cs
@@ -21,9 +21,13 @@ public sealed record TranscribeResult(string Text);
 public sealed record BufferSlice(string Text, long NewCursor);
 
 /// <summary>
-/// Drives the per-session voice round-trip directly against the owning Director's
-/// Control API (the same endpoints the web voice page uses), using the Director's
-/// Tailnet base URL taken from the roster. Three concerns, kept apart:
+/// Drives the per-session voice round-trip. The full walkie-talkie agent turn goes
+/// through the GATEWAY's async submit/poll surface (<see cref="SubmitVoiceTurnAsync"/> /
+/// <see cref="PollVoiceTurnAsync"/>, issue #378) so the phone only ever needs the
+/// Gateway URL for it; the remaining read-only and utility calls still address the
+/// owning Director's Control API directly (the same endpoints the web voice page
+/// uses), using the Director's Tailnet base URL taken from the roster.
+/// Director-side concerns, kept apart:
 ///
 ///   1. <see cref="TranscribeUtteranceAsync"/> - upload the recorded audio and
 ///      get the transcript back (POST /voice/utterance -> PUT chunk -> POST complete).
@@ -172,6 +176,65 @@ public sealed class DirectorVoiceClient
             throw new InvalidOperationException("tts returned empty audio");
         ClientLog.Write($"[DirectorVoiceClient] SynthesizeSpeech OK: bytes={bytes.Length}");
         return bytes;
+    }
+
+    // ===== ASYNC VOICE TURN (Gateway submit + poll, issue #378) =============
+
+    /// <summary>
+    /// Submit a recorded utterance to the GATEWAY's async voice-turn pipeline
+    /// (POST {gatewayBase}/sessions/{sid}/voice-turn/submit, issue #376). The Gateway
+    /// resolves the owning Director, drives the turn server-side (transcribe, send to
+    /// the session, summarize, TTS), and caches the result for 10 minutes - so the
+    /// phone is freed immediately and can poll again after a signal drop. Pass the
+    /// Gateway base URL, never a Director's address: the Gateway is the stable entry
+    /// point and its address does not change when a session moves between Directors.
+    /// Throws on HTTP failure or a malformed 202 so the caller surfaces the real error.
+    /// </summary>
+    public async Task<VoiceTurnSubmitResult> SubmitVoiceTurnAsync(
+        string gatewayBase, string sessionId, byte[] audio, string mime, CancellationToken ct = default)
+    {
+        var b = gatewayBase.TrimEnd('/');
+        ClientLog.Write($"[DirectorVoiceClient] SubmitVoiceTurn: base={b}, sid={sessionId}, bytes={audio.Length}, mime={mime}");
+        using var http = NewClient();
+        using var form = new MultipartFormDataContent();
+        var audioContent = new ByteArrayContent(audio);
+        audioContent.Headers.ContentType = new MediaTypeHeaderValue(mime);
+        var ext = mime switch
+        {
+            "audio/mp4" => "m4a",
+            "audio/webm" => "webm",
+            "audio/ogg" => "ogg",
+            "audio/wav" => "wav",
+            _ => "bin",
+        };
+        form.Add(audioContent, "audio", $"audio.{ext}");
+        var resp = await http.PostAsync($"{b}/sessions/{sessionId}/voice-turn/submit", form, ct);
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"voice-turn/submit failed: {(int)resp.StatusCode} {body}");
+        var r = VoiceTurnResults.ParseSubmit(body);
+        ClientLog.Write($"[DirectorVoiceClient] SubmitVoiceTurn OK: turnId={r.TurnId}");
+        return r;
+    }
+
+    /// <summary>
+    /// Poll the GATEWAY for the result of a previously submitted voice turn
+    /// (GET {gatewayBase}/sessions/{sid}/voice-turn/{turnId}). Answered from the
+    /// Gateway's job cache - no Director call. Call every ~1.5 seconds until
+    /// <see cref="VoiceTurnPollResult.Stage"/> is "reply" or "error". Throws on HTTP
+    /// failure (including the 404 for an unknown/expired turn id) so the caller
+    /// surfaces the real reason.
+    /// </summary>
+    public async Task<VoiceTurnPollResult> PollVoiceTurnAsync(
+        string gatewayBase, string sessionId, string turnId, CancellationToken ct = default)
+    {
+        var b = gatewayBase.TrimEnd('/');
+        using var http = NewClient();
+        var resp = await http.GetAsync($"{b}/sessions/{sessionId}/voice-turn/{turnId}", ct);
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"voice-turn poll failed: {(int)resp.StatusCode} {body}");
+        return VoiceTurnResults.ParsePoll(body);
     }
 
     // ===== 2. CHAT (send + follow) =========================================

--- a/phone/CcDirectorClient/Voice/VoiceConversation.cs
+++ b/phone/CcDirectorClient/Voice/VoiceConversation.cs
@@ -1,25 +1,18 @@
 namespace CcDirectorClient.Voice;
 
 /// <summary>
-/// Runs one full voice turn against a single session: take the recorded audio,
-/// transcribe it, send it to the session, follow the agent's turn to completion,
-/// and speak the reply with the Director's OpenAI TTS voice (fetched from /tts
-/// and played on the device, identical to the web). Built on the injected clients and
-/// device interfaces so the page that hosts it stays thin and so the round-trip
-/// can be exercised with fakes.
-///
-/// Polling cadence: after the initial send returns "timeout" (the turn is still
-/// running), the conversation polls every <see cref="PollSeconds"/> and asks for
-/// a spoken progress note roughly every <see cref="ProgressEverySeconds"/> so a
-/// driver hears that work is still happening without paying a Haiku call on each
-/// cheap poll.
+/// Runs one full voice turn against a single session. The agent turn goes through
+/// the GATEWAY's async voice-turn pipeline (issue #378): the audio is submitted once
+/// to the Gateway, which drives the owning Director server-side (transcribe, wait for
+/// the session, run the turn, summarize, TTS) and caches the result, and the phone
+/// polls every <see cref="VoiceTurnPollMs"/> ms until the reply (with its synthesized
+/// audio) is ready. Built on the injected clients and device interfaces so the page
+/// that hosts it stays thin and so the round-trip can be exercised with fakes.
 /// </summary>
 public sealed class VoiceConversation
 {
-    private const int PollSeconds = 3;
-    private const int ProgressEverySeconds = 120;
-    private const int InitialTurnTimeoutMs = 45_000;
-    private const int ReadyPollSeconds = 4;
+    /// <summary>Cadence of the Gateway voice-turn poll loop (~1.5s; cheap cache reads).</summary>
+    private const int VoiceTurnPollMs = 1_500;
 
     // FIFO delivery: we deliberately do NOT wait for the agent's turn - the point of FIFO
     // is to deposit the answer and move on. The /chat call sends the text to the PTY before
@@ -29,11 +22,19 @@ public sealed class VoiceConversation
 
     private readonly DirectorVoiceClient _client;
     private readonly IReplySpeaker _tts;
+    private readonly string _gatewayBaseUrl;
 
-    public VoiceConversation(DirectorVoiceClient client, IReplySpeaker tts)
+    /// <summary>
+    /// <paramref name="gatewayBaseUrl"/> is the Gateway's base URL (the same address
+    /// the roster comes from) - required by <see cref="SpeakTurnAsync"/>'s agent path,
+    /// which submits/polls the voice turn on the Gateway (issue #378). Hosts that only
+    /// use the Director-direct members (FIFO deliver, briefing, one-off lines) may omit it.
+    /// </summary>
+    public VoiceConversation(DirectorVoiceClient client, IReplySpeaker tts, string gatewayBaseUrl = "")
     {
         _client = client;
         _tts = tts;
+        _gatewayBaseUrl = (gatewayBaseUrl ?? "").TrimEnd('/');
     }
 
     /// <summary>Status callback so the UI can show what is happening at each step.</summary>
@@ -55,108 +56,117 @@ public sealed class VoiceConversation
 
     /// <summary>
     /// Send a recorded utterance to <paramref name="session"/> and speak the reply.
-    /// <paramref name="onUpdate"/> fires on the main concerns (transcript, thinking,
-    /// progress, reply). Returns the final reply text. Throws on transcription or
-    /// send failure so the caller can surface the real error.
+    /// The agent path runs on the GATEWAY's async voice-turn pipeline (issue #378):
+    /// submit the audio once to the Gateway, which transcribes, waits for the session,
+    /// runs the agent turn, summarizes, and synthesizes the reply audio entirely
+    /// server-side; the phone polls ~every 1.5s and plays the returned audio directly,
+    /// so a brief signal drop just means the next poll arrives a little late.
+    /// The wingman path stays Director-direct (read-only, answers immediately).
+    /// <paramref name="onUpdate"/> fires as processing advances (transcribing,
+    /// transcript, waiting, thinking, summarizing, reply, speaking). Returns the final
+    /// spoken summary text. Throws on submit/poll failure or a terminal error stage so
+    /// the caller can surface the real error.
     /// </summary>
     public async Task<string> SpeakTurnAsync(
         SessionInfo session, UtteranceAudio audio,
         Action<TurnUpdate>? onUpdate = null, CancellationToken ct = default, bool forceWingman = false)
     {
         ClientLog.Write($"[VoiceConversation] SpeakTurn: session={session.DisplayName}, forceWingman={forceWingman}");
-        onUpdate?.Invoke(new TurnUpdate("transcribing", "Transcribing..."));
-
-        var t = await _client.TranscribeUtteranceAsync(
-            session.TailnetEndpoint, session.SessionId, audio.Bytes, audio.Mime, ct);
-        if (string.IsNullOrWhiteSpace(t.Text))
-            throw new InvalidOperationException("nothing was transcribed from the recording");
-        var transcript = t.Text;
-        onUpdate?.Invoke(new TurnUpdate("transcript", transcript));
 
         // Route to the wingman when the user tapped Ask Wingman. The wingman is
-        // read-only and answers immediately from the session - no waiting for the
-        // agent's turn, no /chat - and reads content verbatim instead of summarizing.
+        // read-only and answers immediately from the session - no agent turn - so it
+        // keeps the Director-direct transcribe-then-ask path.
         if (forceWingman)
         {
+            onUpdate?.Invoke(new TurnUpdate("transcribing", "Transcribing..."));
+            var t = await _client.TranscribeUtteranceAsync(
+                session.TailnetEndpoint, session.SessionId, audio.Bytes, audio.Mime, ct);
+            if (string.IsNullOrWhiteSpace(t.Text))
+                throw new InvalidOperationException("nothing was transcribed from the recording");
+            onUpdate?.Invoke(new TurnUpdate("transcript", t.Text));
+
             ClientLog.Write($"[VoiceConversation] SpeakTurn: routing to wingman for session={session.DisplayName}");
             onUpdate?.Invoke(new TurnUpdate("wingman", "Asking the wingman..."));
-            var answer = await _client.AskWingmanAsync(session.TailnetEndpoint, session.SessionId, transcript, ct);
+            var answer = await _client.AskWingmanAsync(session.TailnetEndpoint, session.SessionId, t.Text, ct);
             if (string.IsNullOrWhiteSpace(answer))
                 answer = "The wingman had nothing to report.";
             onUpdate?.Invoke(new TurnUpdate("answer", answer));
-            await SpeakAsync(session.TailnetEndpoint,answer, ct);
+            await SpeakAsync(session.TailnetEndpoint, answer, ct);
             return answer;
         }
 
-        // Only deliver the question to a session that has FINISHED its current
-        // turn. If it is still working, the prompt would interleave with the
-        // in-progress turn and the reply we read back would be that turn's
-        // output, not an answer to the question. So wait for a stopping point
-        // first - the same discipline as single-session voice.
-        await WaitUntilReadyAsync(session, onUpdate, ct);
+        if (string.IsNullOrWhiteSpace(_gatewayBaseUrl))
+            throw new InvalidOperationException(
+                "gateway URL is not configured - set the Gateway address in settings to run a voice turn");
 
-        onUpdate?.Invoke(new TurnUpdate("thinking", "Thinking..."));
-        var result = await _client.SendChatAsync(
-            session.TailnetEndpoint, session.SessionId, transcript, InitialTurnTimeoutMs, ct);
+        // Submit once: the Gateway queues the turn and answers 202 with a turn id
+        // immediately, so the phone is free while the Director does the work.
+        onUpdate?.Invoke(new TurnUpdate("transcribing", "Sending to the gateway..."));
+        var submit = await _client.SubmitVoiceTurnAsync(
+            _gatewayBaseUrl, session.SessionId, audio.Bytes, audio.Mime, ct);
+        ClientLog.Write($"[VoiceConversation] SpeakTurn: submitted turnId={submit.TurnId}");
 
-        result = await FollowTurnAsync(session, result, onUpdate, ct);
-
-        if (!string.Equals(result.Status, "ok", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException($"agent turn ended with status '{result.Status}': {result.Error}");
-
-        var rawReply = result.SpokenText();
-
-        // "reply" updates the on-screen reply label only - it does NOT advance the
-        // status indicator. The status must follow the actual processing order:
-        // Thinking -> Summarizing -> Speaking. See AC1.
-        onUpdate?.Invoke(new TurnUpdate("reply", rawReply));
-
-        // Step 5: summarize the raw reply into 2-3 spoken sentences of plain prose.
-        // The wingman translates terminal output (markdown, code, file paths) into
-        // something that can be read aloud naturally. Falls back to the raw reply text
-        // on any failure so the user always hears something rather than silence.
-        onUpdate?.Invoke(new TurnUpdate("summarizing", "Summarizing..."));
-        var spokenSummary = await SummarizeForVoiceAsync(session, rawReply, ct);
-
-        // "speaking" fires after summarization completes and before TTS begins,
-        // so the status label reads "Speaking..." only while audio is actually playing.
-        onUpdate?.Invoke(new TurnUpdate("speaking", "Speaking..."));
-        await SpeakAsync(session.TailnetEndpoint, spokenSummary, ct);
-        return rawReply;
-    }
-
-    /// <summary>
-    /// Ask the wingman to turn the raw agent reply into 2-3 sentences of plain spoken prose
-    /// safe to read aloud while driving (no markdown, no code, question preserved at the end
-    /// when the agent is asking the user something). Falls back to the raw <paramref name="rawReply"/>
-    /// text if the wingman is unavailable, times out, or returns empty, so the user always
-    /// hears something rather than silence.
-    /// </summary>
-    private async Task<string> SummarizeForVoiceAsync(
-        SessionInfo session, string rawReply, CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(rawReply)) return rawReply;
-        ClientLog.Write($"[VoiceConversation] SummarizeForVoice: session={session.DisplayName}, rawChars={rawReply.Length}");
-        try
+        // Poll the Gateway's job cache until the turn lands in a terminal stage.
+        // Stage vocabulary: submitted, transcribing, transcript, waiting, thinking,
+        // summarizing, reply (terminal), error (terminal).
+        var lastStage = "";
+        while (true)
         {
-            var prompt =
-                "Summarize the following agent reply in 2-3 spoken sentences of plain prose " +
-                "for a user who is driving. No markdown. No code. No bullet points. " +
-                "If the agent is asking the user a question, end with that question clearly. " +
-                $"Reply: {rawReply}";
-            var summary = await _client.AskWingmanAsync(session.TailnetEndpoint, session.SessionId, prompt, ct);
-            if (!string.IsNullOrWhiteSpace(summary))
+            ct.ThrowIfCancellationRequested();
+            await Task.Delay(TimeSpan.FromMilliseconds(VoiceTurnPollMs), ct);
+
+            var poll = await _client.PollVoiceTurnAsync(
+                _gatewayBaseUrl, session.SessionId, submit.TurnId, ct);
+
+            if (!string.Equals(poll.Stage, lastStage, StringComparison.Ordinal))
             {
-                ClientLog.Write($"[VoiceConversation] SummarizeForVoice OK: summaryChars={summary.Length}");
-                return summary;
+                lastStage = poll.Stage;
+                switch (poll.Stage)
+                {
+                    case "transcribing":
+                        onUpdate?.Invoke(new TurnUpdate("transcribing", "Transcribing..."));
+                        break;
+                    case "transcript":
+                        if (!string.IsNullOrWhiteSpace(poll.Transcript))
+                            onUpdate?.Invoke(new TurnUpdate("transcript", poll.Transcript));
+                        break;
+                    case "waiting":
+                        onUpdate?.Invoke(new TurnUpdate("waiting", "Waiting for the session to be ready..."));
+                        break;
+                    case "thinking":
+                        onUpdate?.Invoke(new TurnUpdate("thinking", "Thinking..."));
+                        break;
+                    case "summarizing":
+                        onUpdate?.Invoke(new TurnUpdate("summarizing", "Summarizing..."));
+                        break;
+                }
             }
-            ClientLog.Write("[VoiceConversation] SummarizeForVoice: wingman returned empty, using raw reply");
+
+            if (string.Equals(poll.Stage, "error", StringComparison.Ordinal))
+                throw new InvalidOperationException($"gateway voice turn failed: {poll.Error ?? "unknown error"}");
+
+            if (!string.Equals(poll.Stage, "reply", StringComparison.Ordinal))
+                continue;
+
+            var summary = poll.Summary ?? "";
+            onUpdate?.Invoke(new TurnUpdate("reply", summary));
+
+            // "speaking" fires before playback begins so the status label reads
+            // "Speaking..." only while audio is actually playing. The Gateway returns
+            // the reply audio with the result; audioBase64 is empty (never null) when
+            // the Director has no TTS key, in which case the on-screen summary is the
+            // whole reply.
+            onUpdate?.Invoke(new TurnUpdate("speaking", "Speaking..."));
+            if (!string.IsNullOrWhiteSpace(poll.AudioBase64))
+            {
+                var mp3 = Convert.FromBase64String(poll.AudioBase64);
+                if (mp3.Length > 0)
+                    await _tts.PlayAsync(mp3, ct);
+            }
+
+            ClientLog.Write($"[VoiceConversation] SpeakTurn done: turnId={submit.TurnId}, summaryChars={summary.Length}");
+            return summary;
         }
-        catch (Exception ex)
-        {
-            ClientLog.Write($"[VoiceConversation] SummarizeForVoice FAILED (fallback): {ex.Message}");
-        }
-        return rawReply;
     }
 
     /// <summary>
@@ -319,66 +329,6 @@ public sealed class VoiceConversation
             await SpeakAsync(session.TailnetEndpoint,answer, ct);
         }
         return answer;
-    }
-
-    /// <summary>
-    /// Block until the session has finished its current turn (is at a stopping
-    /// point: Idle / WaitingForInput / WaitingForPerm, which the server reports as
-    /// poll status "ok"). If it is still working, announce it once and poll until
-    /// it finishes. Throws if the session has exited. Honors cancellation so the
-    /// user can leave instead of waiting on a long turn.
-    /// </summary>
-    private async Task WaitUntilReadyAsync(SessionInfo session, Action<TurnUpdate>? onUpdate, CancellationToken ct)
-    {
-        var poll = await _client.PollChatAsync(session.TailnetEndpoint, session.SessionId, wantProgress: false, ct);
-        if (poll.IsGone)
-            throw new InvalidOperationException("that session has exited");
-        if (!poll.IsWorking)
-            return; // already finished its turn - safe to ask now
-
-        ClientLog.Write($"[VoiceConversation] WaitUntilReady: session={session.DisplayName} is working; holding the question");
-        onUpdate?.Invoke(new TurnUpdate("waiting", "That session is still working. I will ask when it finishes."));
-        await SpeakAsync(session.TailnetEndpoint,"That session is still working. I'll ask when it finishes.", ct);
-
-        while (!ct.IsCancellationRequested)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(ReadyPollSeconds), ct);
-            poll = await _client.PollChatAsync(session.TailnetEndpoint, session.SessionId, wantProgress: false, ct);
-            if (poll.IsGone)
-                throw new InvalidOperationException("that session has exited");
-            if (!poll.IsWorking)
-            {
-                ClientLog.Write($"[VoiceConversation] WaitUntilReady: session={session.DisplayName} now ready");
-                return;
-            }
-        }
-        ct.ThrowIfCancellationRequested();
-    }
-
-    private async Task<ChatTurnResult> FollowTurnAsync(
-        SessionInfo session, ChatTurnResult result, Action<TurnUpdate>? onUpdate, CancellationToken ct)
-    {
-        var elapsed = 0;
-        var sinceProgress = 0;
-        while (result.ShouldKeepPolling && !ct.IsCancellationRequested)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(PollSeconds), ct);
-            elapsed += PollSeconds;
-            sinceProgress += PollSeconds;
-
-            var wantProgress = sinceProgress >= ProgressEverySeconds;
-            if (wantProgress) sinceProgress = 0;
-
-            result = await _client.PollChatAsync(session.TailnetEndpoint, session.SessionId, wantProgress, ct);
-
-            if (wantProgress && !string.IsNullOrWhiteSpace(result.ProgressNote))
-            {
-                onUpdate?.Invoke(new TurnUpdate("progress", result.ProgressNote));
-                await SpeakAsync(session.TailnetEndpoint,result.ProgressNote, ct);
-            }
-        }
-        ClientLog.Write($"[VoiceConversation] FollowTurn done: status={result.Status}, elapsed~{elapsed}s");
-        return result;
     }
 
     /// <summary>

--- a/phone/CcDirectorClient/Voice/VoiceTurnResults.cs
+++ b/phone/CcDirectorClient/Voice/VoiceTurnResults.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// 202 Accepted response from the Gateway's POST /sessions/{sid}/voice-turn/submit:
+/// the <paramref name="TurnId"/> the phone polls with and when the cached result
+/// expires on the Gateway (10-minute TTL).
+/// </summary>
+public sealed record VoiceTurnSubmitResult(string TurnId, DateTimeOffset? ExpiresAt);
+
+/// <summary>
+/// One poll response from the Gateway's GET /sessions/{sid}/voice-turn/{turnId}.
+/// <see cref="Stage"/> is one of: submitted, transcribing, transcript, waiting,
+/// thinking, summarizing, reply (terminal), error (terminal) - see
+/// docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md.
+/// </summary>
+public sealed record VoiceTurnPollResult(
+    string Stage,
+    string? Transcript,
+    string? Summary,
+    string? AudioBase64,
+    string? Error);
+
+/// <summary>
+/// Parsers for the Gateway's async voice-turn responses. Kept free of MAUI/Android
+/// dependencies so the wire-shape handling (snake_case turn_id/expires_at on submit,
+/// camelCase fields on poll) is unit tested off-device.
+/// </summary>
+public static class VoiceTurnResults
+{
+    /// <summary>
+    /// Parse the submit response body. The Gateway emits snake_case
+    /// (<c>turn_id</c>, <c>expires_at</c>). Throws when the body carries no turn id,
+    /// so a malformed 202 surfaces immediately instead of producing a poll loop
+    /// against an empty id.
+    /// </summary>
+    public static VoiceTurnSubmitResult ParseSubmit(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var turnId = ReadString(root, "turn_id");
+        if (string.IsNullOrWhiteSpace(turnId))
+            throw new InvalidOperationException("voice-turn/submit returned no turn id");
+
+        DateTimeOffset? expiresAt = null;
+        var expiresRaw = ReadString(root, "expires_at");
+        if (!string.IsNullOrWhiteSpace(expiresRaw) && DateTimeOffset.TryParse(expiresRaw, out var parsed))
+            expiresAt = parsed;
+
+        return new VoiceTurnSubmitResult(turnId!, expiresAt);
+    }
+
+    /// <summary>
+    /// Parse one poll response body ({ turn_id, stage, transcript, summary,
+    /// audioBase64, message, expires_at }). A missing stage maps to "unknown" so the
+    /// caller's poll loop keeps going rather than crashing on a partial body.
+    /// </summary>
+    public static VoiceTurnPollResult ParsePoll(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        return new VoiceTurnPollResult(
+            ReadString(root, "stage") ?? "unknown",
+            ReadString(root, "transcript"),
+            ReadString(root, "summary"),
+            ReadString(root, "audioBase64"),
+            ReadString(root, "message"));
+    }
+
+    private static string? ReadString(JsonElement el, string name)
+        => el.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+}


### PR DESCRIPTION
Closes #378. Depends on #376 (merged).

## What changed

The phone walkie-talkie agent turn now submits and polls voice turns on the **Gateway** (`POST /sessions/{sid}/voice-turn/submit` + `GET /sessions/{sid}/voice-turn/{turnId}`, added in #376) instead of addressing the owning Director directly. The Gateway URL comes from the phone app's own settings (the `gateway_url` preference every page already uses for the roster) - **no session-DTO change was needed** (the DoR gate in the issue).

Note for reviewers: the `SubmitVoiceTurnAsync`/`PollVoiceTurnAsync` methods the issue references existed only on the unmerged `issue-347-voice-dictation-recording-indicator` branch (commit 044e1c3, what the currently deployed phone runs). This PR ports that submit/poll design into main's evolved phone code, pointed at the Gateway per `docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md` Phase 3.

- `Voice/VoiceTurnResults.cs` (new, dependency-free): wire-shape parsers; the Gateway submit response is **snake_case** (`turn_id`/`expires_at`) - pinned by unit tests.
- `Voice/DirectorVoiceClient.cs`: `SubmitVoiceTurnAsync` / `PollVoiceTurnAsync` taking the Gateway base URL; bearer token attached as before.
- `Voice/VoiceConversation.cs`: `SpeakTurnAsync` agent path = submit once + poll every 1.5s; reply audio arrives base64 in the poll result and plays directly (no separate `/tts` call). Wingman path stays Director-direct (read-only). Dead `WaitUntilReadyAsync`/`FollowTurnAsync`/`SummarizeForVoiceAsync` removed - the server-side pipeline owns waiting + summarizing now.
- `TalkPage.xaml.cs` / `Controls/VoiceSessionView.xaml.cs` / `FifoPage.xaml.cs`: pass the Gateway URL through.

## Proof

- `dotnet build phone\CcDirectorClient\CcDirectorClient.csproj -f net10.0-android`: **0 errors**, no new CS warnings.
- 11 new unit tests green (`VoiceTurnResultTests`); the 5 failing `ConductorStateTests` fail identically on clean main (pre-existing).
- Gateway contract tests green on this branch (`GatewayVoiceTurnAsyncTests`, 11/11).
- Proof report: `docs/cencon/proof/issue-378/report.html` (committed to this branch).

## On-device e2e: PENDING HARDWARE

No Android device is attached/reachable from this machine (`adb devices` empty), and the production Gateway still runs a **pre-#376 build** (a probe of `GET /sessions/{guid}/voice-turn/{guid}` fell through to the session catch-all). To finish verification QA must:
1. Deploy a post-#376 Gateway build.
2. Deploy the app to the test phone: `scripts\deploy-phone.ps1`.
3. Run a live voice turn and confirm the Gateway log shows `POST /sessions/{sid}/voice-turn/submit` from the phone and the Director log shows the request arriving from the Gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)