### PR TITLE
feat(#369): require API key on Gateway voice-turn endpoints

### DIFF
--- a/docs/cencon/proof/issue-369/curl-trace.txt
+++ b/docs/cencon/proof/issue-369/curl-trace.txt
@@ -1,0 +1,88 @@
+GATEWAY: real GatewayHost, PRODUCTION auth mode (authEnabled=false -> global middleware OFF)
+LISTENING: http://127.0.0.1:57743  (loopback, Tailscale disabled, isolated instances dir)
+TOKEN: proof-token-369
+
+SETUP: POST /directors/register -> 201 Created (fake owning Director 57ebd605...)
+SETUP: session 0479e49e-c8e6-42c5-bfcf-37d3424a5519 owner-cached to that Director
+
+=== AC1: submit, NO token ===
+$ curl -s -i -X POST http://127.0.0.1:57743/sessions/0479e49e-c8e6-42c5-bfcf-37d3424a5519/voice-turn/submit -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Fri, 12 Jun 2026 23:55:03 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: submit without token answers 401
+
+    ASSERT PASS: 401 body names the reason
+
+=== AC1b: submit, WRONG token ===
+$ curl -s -i -X POST http://127.0.0.1:57743/sessions/0479e49e-c8e6-42c5-bfcf-37d3424a5519/voice-turn/submit -H "Authorization: Bearer wrong-token" -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Fri, 12 Jun 2026 23:55:03 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: submit with wrong token answers 401
+
+=== AC3: submit, VALID Bearer token ===
+$ curl -s -i -X POST http://127.0.0.1:57743/sessions/0479e49e-c8e6-42c5-bfcf-37d3424a5519/voice-turn/submit -H "Authorization: Bearer proof-token-369" -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 202 Accepted
+Content-Type: application/json; charset=utf-8
+Date: Fri, 12 Jun 2026 23:55:03 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"turn_id":"6890295e-b4ef-4545-931c-c5807d89051f","expires_at":"2026-06-13T00:05:03.9035341Z"}
+
+    ASSERT PASS: submit with valid token answers 202 Accepted
+
+    ASSERT PASS: 202 body carries turn_id
+
+    turn_id = 6890295e-b4ef-4545-931c-c5807d89051f
+
+=== AC2: poll, NO token ===
+$ curl -s -i http://127.0.0.1:57743/sessions/0479e49e-c8e6-42c5-bfcf-37d3424a5519/voice-turn/6890295e-b4ef-4545-931c-c5807d89051f
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Fri, 12 Jun 2026 23:55:03 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: poll without token answers 401
+
+=== AC2b: poll, WRONG token ===
+$ curl -s -i http://127.0.0.1:57743/sessions/0479e49e-c8e6-42c5-bfcf-37d3424a5519/voice-turn/6890295e-b4ef-4545-931c-c5807d89051f -H "Authorization: Bearer wrong-token"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Fri, 12 Jun 2026 23:55:03 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: poll with wrong token answers 401
+
+=== AC3b: poll, VALID Bearer token ===
+$ curl -s -i http://127.0.0.1:57743/sessions/0479e49e-c8e6-42c5-bfcf-37d3424a5519/voice-turn/6890295e-b4ef-4545-931c-c5807d89051f -H "Authorization: Bearer proof-token-369"
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Fri, 12 Jun 2026 23:55:03 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"turn_id":"6890295e-b4ef-4545-931c-c5807d89051f","stage":"submitted","transcript":null,"summary":null,"audioBase64":null,"message":null,"expires_at":"2026-06-13T00:05:03.9035341Z"}
+
+    ASSERT PASS: poll with valid token answers 200
+
+    ASSERT PASS: 200 body carries the job stage
+
+ALL ASSERTIONS PASSED.

--- a/docs/cencon/proof/issue-369/proof-harness.cs
+++ b/docs/cencon/proof/issue-369/proof-harness.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+
+// Proof harness for issue #369: boots a REAL GatewayHost exactly the way the production tray
+// runs it - authEnabled: false, so the global AuthMiddleware is OFF and only the new
+// endpoint-level voice-turn token gate stands between the network and the endpoints.
+// Tailscale is disabled (CC_GATEWAY_NO_TAILSCALE=1) and the instances dir is isolated, so
+// nothing on the machine is touched. Every request in the trace is a REAL curl.exe process
+// (a separate OS process hitting the Gateway over loopback HTTP), per the proof plan.
+//
+// 202 path: a Director is registered via the real POST /directors/register endpoint and the
+// session is seeded into the SessionOwnerCache (the production fast path). The submit then
+// answers 202 Accepted - the genuine endpoint response; the background Director call landing
+// in the error stage afterwards is the documented async contract and irrelevant to auth.
+// (The full 202 -> reply path against a real Director is covered by
+// GatewayVoiceTurnAsyncTests, which now authenticate every request.)
+
+Environment.SetEnvironmentVariable("CC_GATEWAY_NO_TAILSCALE", "1");
+
+const string token = "proof-token-369";
+var instancesDir = Path.Combine(Path.GetTempPath(), "cc-proof-369-" + Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(instancesDir);
+
+var gateway = new GatewayHost(port: FreePort(), token: token, authEnabled: false,
+    instancesDirectory: instancesDir,
+    workListsPath: Path.Combine(instancesDir, "worklists.json"));
+await gateway.StartAsync();
+var baseUrl = $"http://127.0.0.1:{gateway.Port}";
+
+var sb = new StringBuilder();
+void Log(string s) { Console.WriteLine(s); sb.AppendLine(s); }
+
+Log($"GATEWAY: real GatewayHost, PRODUCTION auth mode (authEnabled=false -> global middleware OFF)");
+Log($"LISTENING: {baseUrl}  (loopback, Tailscale disabled, isolated instances dir)");
+Log($"TOKEN: {token}");
+Log("");
+
+// Seed an owning Director for the session (the SessionOwnerCache fast path) so an
+// authenticated submit reaches the 202. The registration goes through the real endpoint.
+var directorId = Guid.NewGuid().ToString();
+using (var http = new HttpClient())
+{
+    var reg = await http.PostAsync($"{baseUrl}/directors/register",
+        new StringContent(JsonSerializer.Serialize(new DirectorRegistrationRequest
+        {
+            DirectorId = directorId,
+            TailnetEndpoint = $"http://127.0.0.1:{FreePort()}",
+            MachineName = "proof-369-machine",
+        }), Encoding.UTF8, "application/json"));
+    Log($"SETUP: POST /directors/register -> {(int)reg.StatusCode} {reg.StatusCode} (fake owning Director {directorId[..8]}...)");
+}
+var sid = Guid.NewGuid().ToString();
+gateway.SessionOwners.Remember(sid, directorId);
+Log($"SETUP: session {sid} owner-cached to that Director");
+Log("");
+
+// ---- the curl trace ---------------------------------------------------------
+
+async Task<string> Curl(string label, string args)
+{
+    var psi = new ProcessStartInfo("curl.exe", $"-s -i {args}")
+    {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+    };
+    var p = Process.Start(psi)
+        ?? throw new InvalidOperationException("curl.exe failed to start");
+    var output = await p.StandardOutput.ReadToEndAsync();
+    await p.WaitForExitAsync();
+    Log($"=== {label} ===");
+    Log($"$ curl -s -i {args}");
+    Log(output.TrimEnd());
+    Log("");
+    return output;
+}
+
+void Check(string output, string mustContain, string what)
+{
+    var ok = output.Contains(mustContain, StringComparison.OrdinalIgnoreCase);
+    Log($"    ASSERT {(ok ? "PASS" : "FAIL")}: {what}");
+    Log("");
+    if (!ok) { Console.Error.WriteLine($"PROOF FAILED: {what}"); Environment.Exit(2); }
+}
+
+// AC1: submit with NO token -> 401
+var o1 = await Curl("AC1: submit, NO token",
+    $"-X POST {baseUrl}/sessions/{sid}/voice-turn/submit -H \"Content-Type: application/json\" -d \"{{\\\"text\\\":\\\"hello\\\"}}\"");
+Check(o1, "401", "submit without token answers 401");
+Check(o1, "missing or invalid token", "401 body names the reason");
+
+// AC1b: submit with a WRONG token -> 401
+var o2 = await Curl("AC1b: submit, WRONG token",
+    $"-X POST {baseUrl}/sessions/{sid}/voice-turn/submit -H \"Authorization: Bearer wrong-token\" -H \"Content-Type: application/json\" -d \"{{\\\"text\\\":\\\"hello\\\"}}\"");
+Check(o2, "401", "submit with wrong token answers 401");
+
+// AC3: submit with the VALID token (the header the phone sends via DirectorVoiceClient.NewClient) -> 202
+var o3 = await Curl("AC3: submit, VALID Bearer token",
+    $"-X POST {baseUrl}/sessions/{sid}/voice-turn/submit -H \"Authorization: Bearer {token}\" -H \"Content-Type: application/json\" -d \"{{\\\"text\\\":\\\"hello\\\"}}\"");
+Check(o3, "202", "submit with valid token answers 202 Accepted");
+Check(o3, "turn_id", "202 body carries turn_id");
+
+// Extract the turn id for the poll legs.
+var turnId = JsonDocument.Parse(o3[o3.IndexOf('{')..]).RootElement.GetProperty("turn_id").GetString()
+    ?? throw new InvalidOperationException("202 body had no turn_id string");
+Log($"    turn_id = {turnId}");
+Log("");
+
+// AC2: poll with NO token -> 401 (even for a REAL turn id - existence never leaks)
+var o4 = await Curl("AC2: poll, NO token",
+    $"{baseUrl}/sessions/{sid}/voice-turn/{turnId}");
+Check(o4, "401", "poll without token answers 401");
+
+// AC2b: poll with a WRONG token -> 401
+var o5 = await Curl("AC2b: poll, WRONG token",
+    $"{baseUrl}/sessions/{sid}/voice-turn/{turnId} -H \"Authorization: Bearer wrong-token\"");
+Check(o5, "401", "poll with wrong token answers 401");
+
+// AC3b: poll with the VALID token -> 200 with the job stage
+var o6 = await Curl("AC3b: poll, VALID Bearer token",
+    $"{baseUrl}/sessions/{sid}/voice-turn/{turnId} -H \"Authorization: Bearer {token}\"");
+Check(o6, "200", "poll with valid token answers 200");
+Check(o6, "stage", "200 body carries the job stage");
+
+Log("ALL ASSERTIONS PASSED.");
+
+await gateway.StopAsync();
+try { Directory.Delete(instancesDir, true); } catch { }
+
+File.WriteAllText(args.Length > 0 ? args[0] : "proof-output.txt", sb.ToString());
+Console.WriteLine("\nProof transcript written.");
+return 0;
+
+static int FreePort()
+{
+    var l = new TcpListener(IPAddress.Loopback, 0);
+    l.Start();
+    int p = ((IPEndPoint)l.LocalEndpoint).Port;
+    l.Stop();
+    return p;
+}

--- a/docs/cencon/proof/issue-369/qa-curl-trace.txt
+++ b/docs/cencon/proof/issue-369/qa-curl-trace.txt
@@ -1,0 +1,136 @@
+GATEWAY: real GatewayHost, PRODUCTION auth mode (authEnabled=false -> global middleware OFF)
+LISTENING: http://127.0.0.1:52918  (loopback, Tailscale disabled, isolated instances dir)
+TOKEN: proof-token-369
+
+SETUP: POST /directors/register -> 201 Created (fake owning Director 437dcdba...)
+SETUP: session 5682f81d-430a-4fca-addb-0011c7d1f5d5 owner-cached to that Director
+
+=== AC1: submit, NO token ===
+$ curl -s -i -X POST http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/submit -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: submit without token answers 401
+
+    ASSERT PASS: 401 body names the reason
+
+=== AC1b: submit, WRONG token ===
+$ curl -s -i -X POST http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/submit -H "Authorization: Bearer wrong-token" -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: submit with wrong token answers 401
+
+=== AC3: submit, VALID Bearer token ===
+$ curl -s -i -X POST http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/submit -H "Authorization: Bearer proof-token-369" -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 202 Accepted
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"turn_id":"23bd6855-f555-4efe-97c9-17e0a955f906","expires_at":"2026-06-13T00:15:33.2185127Z"}
+
+    ASSERT PASS: submit with valid token answers 202 Accepted
+
+    ASSERT PASS: 202 body carries turn_id
+
+    turn_id = 23bd6855-f555-4efe-97c9-17e0a955f906
+
+=== AC2: poll, NO token ===
+$ curl -s -i http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/23bd6855-f555-4efe-97c9-17e0a955f906
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: poll without token answers 401
+
+=== AC2b: poll, WRONG token ===
+$ curl -s -i http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/23bd6855-f555-4efe-97c9-17e0a955f906 -H "Authorization: Bearer wrong-token"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: poll with wrong token answers 401
+
+=== AC3b: poll, VALID Bearer token ===
+$ curl -s -i http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/23bd6855-f555-4efe-97c9-17e0a955f906 -H "Authorization: Bearer proof-token-369"
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"turn_id":"23bd6855-f555-4efe-97c9-17e0a955f906","stage":"submitted","transcript":null,"summary":null,"audioBase64":null,"message":null,"expires_at":"2026-06-13T00:15:33.2185127Z"}
+
+    ASSERT PASS: poll with valid token answers 200
+
+    ASSERT PASS: 200 body carries the job stage
+
+=== QA-EXTRA: submit, EMPTY Bearer token ===
+$ curl -s -i -X POST http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/submit -H "Authorization: Bearer " -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: submit with EMPTY bearer token answers 401
+
+=== QA-EXTRA: submit, case-variant token ===
+$ curl -s -i -X POST http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/submit -H "Authorization: Bearer PROOF-TOKEN-369" -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: submit with case-variant token answers 401
+
+=== QA-EXTRA: submit, empty gateway cookie ===
+$ curl -s -i -X POST http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/submit -H "Cookie: cc-gateway-token=" -H "Content-Type: application/json" -d "{\"text\":\"hello\"}"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: submit with empty cookie value answers 401
+
+=== QA-EXTRA: poll, wrong cookie ===
+$ curl -s -i http://127.0.0.1:52918/sessions/5682f81d-430a-4fca-addb-0011c7d1f5d5/voice-turn/23bd6855-f555-4efe-97c9-17e0a955f906 -H "Cookie: cc-gateway-token=wrong-token"
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Sat, 13 Jun 2026 00:05:32 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}
+
+    ASSERT PASS: poll with wrong cookie answers 401
+
+ALL ASSERTIONS PASSED.

--- a/docs/cencon/proof/issue-369/qa-report.html
+++ b/docs/cencon/proof/issue-369/qa-report.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #369: require API key on Gateway voice-turn endpoints</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 1000px; color: #1a202c; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #2b6cb0; padding-bottom: .4rem; }
+  h2 { color: #2b6cb0; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cbd5e0; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #edf2f7; }
+  .pass { color: #276749; font-weight: bold; }
+  .verdict { background: #f0fff4; border: 2px solid #276749; padding: 1rem 1.4rem; margin: 1.5rem 0; font-size: 1.1rem; }
+  code, pre { background: #f7fafc; border: 1px solid #e2e8f0; border-radius: 4px; font-family: Consolas, monospace; font-size: .9rem; }
+  code { padding: .1rem .3rem; }
+  pre { padding: .8rem; overflow-x: auto; }
+  .meta { color: #4a5568; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>QA Proof Report - Issue #369</h1>
+<p class="meta">
+  Issue: <strong>Security: require API key on Gateway voice-turn endpoints</strong><br>
+  PR: #384 (branch <code>issue-369-voice-turn-auth</code>, head 160ca79, base = current main 246d439)<br>
+  QA Agent: independent verification, 2026-06-12/13. Nothing from the Developer report was trusted;
+  every result below was reproduced by the QA seat with its own builds, test runs, and curl traffic.
+</p>
+
+<div class="verdict">VERIFIED - all acceptance criteria met. 4/4 criteria PASS, design scrutiny PASS,
+regression sweep PASS, full solution build clean. Recommendation: merge.</div>
+
+<h2>1. Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-observed)</th><th>Verdict</th></tr>
+  <tr>
+    <td>1</td>
+    <td><code>POST /sessions/{sid}/voice-turn/submit</code> without a valid token returns 401</td>
+    <td>401 Unauthorized, no token / wrong token</td>
+    <td>Real <code>curl.exe</code> against a real <code>GatewayHost</code> booted by QA in PRODUCTION
+        auth mode (<code>authEnabled=false</code>, global middleware OFF): no token -&gt; <code>HTTP/1.1 401</code>
+        with body <code>{"error":"missing or invalid token"}</code>; wrong token -&gt; 401.
+        Unit tests <code>Submit_MissingToken_Returns401</code> and <code>Submit_InvalidToken_Returns401</code> green.
+        Full trace: <code>qa-curl-trace.txt</code> (this directory).</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td><code>GET /sessions/{sid}/voice-turn/{turnId}</code> without a valid token returns 401</td>
+    <td>401 Unauthorized, even for a REAL turn id</td>
+    <td>QA curl: poll of a genuinely-created turn id with no token -&gt; 401; wrong token -&gt; 401;
+        wrong cookie -&gt; 401. The gate sits BEFORE the job lookup, so turn existence never leaks.
+        Tests <code>Poll_MissingToken_Returns401</code> / <code>Poll_InvalidToken_Returns401</code> green.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>Phone app with a valid token succeeds end-to-end</td>
+    <td>Authenticated submit -&gt; 202 + turn_id; poll -&gt; 200 + stage; full turn reaches reply</td>
+    <td>QA curl with <code>Authorization: Bearer &lt;token&gt;</code>: submit -&gt; <code>202 Accepted</code>
+        with <code>turn_id</code>; poll -&gt; <code>200 OK</code> with <code>stage</code>.
+        Phone code verified: <code>phone/CcDirectorClient/Voice/DirectorVoiceClient.cs</code> -
+        <code>NewClient()</code> (line 58-67) attaches <code>Authorization: Bearer</code> and BOTH
+        <code>SubmitVoiceTurnAsync</code> and <code>PollVoiceTurnAsync</code> use it.
+        <code>GatewayVoiceTurnAsyncTests</code> default client authenticates exactly like the phone and
+        the full 202 -&gt; reply path passes (16/16). Phone wire-contract parsing tests
+        (<code>VoiceTurnResultTests</code>, merged #378): 11/11 green.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>Existing authenticated Gateway endpoints are unaffected</td>
+    <td>No behavior change outside the two voice-turn routes</td>
+    <td><code>AuthMiddleware</code> diff vs main reviewed line-by-line: pure extraction of the
+        existing bearer-or-cookie logic into <code>HasValidToken</code>; <code>Run</code> behavior
+        identical. Full <code>Gateway.Tests</code>: 603 passed / 1 failed - and QA reproduced the SAME
+        single failure (<code>DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider</code>,
+        "expected at least 1 partial transcript, got 0") on CLEAN MAIN, confirming it is pre-existing
+        and unrelated.</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>2. Design scrutiny: endpoint-level enforcement vs global middleware</h2>
+<p>The Developer enforced the token AT THE ENDPOINT on the grounds that production gateways run
+<code>authEnabled=false</code>. QA scrutinized and CONFIRMED this design call:</p>
+<ul>
+  <li><strong>Holds in production mode.</strong> Both production construction sites -
+      <code>GatewayTrayController.StartHostAsync</code> (<code>new GatewayHost(_port)</code>) and
+      <code>GatewayWorker.ExecuteAsync</code> - pass <code>token: null</code>, so
+      <code>GatewayHost.Token = GatewayAuth.LoadOrCreate()</code>: a 32-byte crypto-random token that
+      can never be empty (empty/missing file regenerates). That token is what <code>Map</code> closes
+      over, and the check runs inside the handler regardless of <code>authEnabled</code>. QA's own
+      harness booted the real <code>GatewayHost</code> with <code>authEnabled=false</code> and observed
+      the 401s directly.</li>
+  <li><strong>Consistent with other protected routes.</strong> The endpoints reuse the exact
+      <code>AuthMiddleware.HasValidToken</code> (Bearer header OR <code>cc-gateway-token</code> cookie,
+      Ordinal compare) the global middleware uses - one mechanism, one error body. The cookie path was
+      verified accepted (<code>Submit_GatewayCookie_IsAcceptedLikeOtherProtectedRoutes</code>).
+      Note: in production the OTHER routes are unprotected (middleware off) - these two routes are now
+      strictly stronger, which is precisely the issue's intent.</li>
+  <li><strong>No token-comparison weakness found.</strong> QA added 4 adversarial probes beyond the
+      Developer's trace (see <code>qa-curl-trace.txt</code>, QA-EXTRA sections):
+      EMPTY bearer (<code>Authorization: Bearer </code>) -&gt; 401 (no empty-token bypass);
+      case-variant token (<code>PROOF-TOKEN-369</code>) -&gt; 401 (Ordinal, case-sensitive);
+      empty cookie value -&gt; 401; wrong cookie -&gt; 401.
+      The compare is not constant-time, but that is byte-identical to the pre-existing global
+      middleware - consistent, not a regression (noted as a possible future hardening, non-blocking).</li>
+  <li><strong>No existence leak.</strong> The auth gate runs before any session/turn lookup on both
+      routes, so an unauthenticated caller cannot probe which sessions or turn ids exist.</li>
+</ul>
+
+<h2>3. QA-executed evidence (independent)</h2>
+<table>
+  <tr><th>Check</th><th>Command</th><th>Result</th></tr>
+  <tr><td>Voice-turn test filter (PR branch)</td>
+      <td><code>dotnet test src/CcDirector.Gateway.Tests --filter "FullyQualifiedName~GatewayVoiceTurnAsync"</code></td>
+      <td class="pass">16/16 passed (incl. the 5 auth tests)</td></tr>
+  <tr><td>Full Gateway.Tests (PR branch)</td>
+      <td><code>dotnet test src/CcDirector.Gateway.Tests</code></td>
+      <td class="pass">603 passed / 1 failed (pre-existing live-OpenAI dictation flake)</td></tr>
+  <tr><td>Flake claim verified on clean main</td>
+      <td><code>git checkout main; dotnet test ... --filter "...FullPipeline_transcribes_phase0_clip2..."</code></td>
+      <td class="pass">Fails IDENTICALLY on main ("expected at least 1 partial transcript, got 0") - pre-existing confirmed</td></tr>
+  <tr><td>Full solution build (PR branch)</td>
+      <td><code>dotnet build cc-director.sln</code></td>
+      <td class="pass">Build succeeded. 0 Warning(s), 0 Error(s)</td></tr>
+  <tr><td>Live curl reproduction + QA extras</td>
+      <td>QA-built harness: real GatewayHost, authEnabled=false, real curl.exe over loopback</td>
+      <td class="pass">ALL ASSERTIONS PASSED (11 original + 4 QA-EXTRA) - <code>qa-curl-trace.txt</code></td></tr>
+  <tr><td>Phone wire-contract tests (#378)</td>
+      <td><code>dotnet test phone/CcDirectorClient.Tests --filter "FullyQualifiedName~VoiceTurnResultTests"</code></td>
+      <td class="pass">11/11 passed</td></tr>
+  <tr><td>Committed dev proof consistency</td>
+      <td>Compared <code>curl-trace.txt</code> (committed) against QA's own run</td>
+      <td class="pass">Consistent: same status codes, same bodies, same shapes</td></tr>
+</table>
+
+<p class="meta">Note: <code>phone/CcDirectorClient.Tests</code> has 5 failing <code>ConductorStateTests</code>
+(FIFO queue logic) unrelated to this change - the PR diff touches zero phone files
+(<code>git diff main..HEAD --stat</code> shows only the 7 Gateway/test/proof files), so those failures
+are pre-existing on main by construction. The voice-turn-relevant phone tests are green.</p>
+
+<h2>4. Regression and method sweep</h2>
+<ul>
+  <li>Nothing adjacent broke: full Gateway.Tests delta vs main is zero (same single pre-existing failure on both).</li>
+  <li>Rejections are logged (<code>FileLog</code> line per 401 with route, sid, and remote IP) - enterprise logging rule met.</li>
+  <li>No fallback programming: missing/invalid token fails explicitly with a clear error body; no degraded path.</li>
+  <li>Tests added for the new behavior (5 auth tests) including the negative cases - testing rule met.</li>
+  <li>No CenCon blocking security rule violated; the change closes a documented unauthenticated-tailnet exposure.</li>
+</ul>
+
+<div class="verdict">VERDICT: PASS. All 4 acceptance criteria verified with QA-owned proof.
+Squash-merge authorized under the implementation-loop (DECIDED D5).</div>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-369/report.html
+++ b/docs/cencon/proof/issue-369/report.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof - Issue #369: Security: require API key on Gateway voice-turn endpoints</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; background: #0f1420; color: #dde3ee; margin: 0; padding: 32px; }
+  h1 { color: #5fd08a; font-size: 22px; }
+  h2 { color: #8ab4f8; font-size: 17px; margin-top: 28px; border-bottom: 1px solid #2a3349; padding-bottom: 4px; }
+  .meta { color: #8a93a8; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; font-size: 13.5px; }
+  th, td { border: 1px solid #2a3349; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #1a2235; color: #aebadd; }
+  .pass { color: #5fd08a; font-weight: 600; }
+  pre { background: #131a2b; border: 1px solid #2a3349; padding: 12px; overflow-x: auto; font-size: 12px; color: #c7d0e3; }
+  code { background: #1a2235; padding: 1px 5px; border-radius: 3px; font-size: 12.5px; }
+  .note { background: #2a2410; border: 1px solid #5c4d1a; padding: 12px; border-radius: 4px; margin: 12px 0; }
+</style>
+</head>
+<body>
+
+<h1>Proof - Issue #369: Security: require API key on Gateway voice-turn endpoints</h1>
+<p class="meta">Developer Agent | 2026-06-12 | Branch <code>issue-369-voice-turn-auth</code> | Depends on #376 (merged, ead9299) and verified against #378 (merged, 246d439)</p>
+
+<h2>What was implemented</h2>
+<p>
+The Gateway's async voice-turn routes (<code>POST /sessions/{sid}/voice-turn/submit</code> and
+<code>GET /sessions/{sid}/voice-turn/{turnId}</code>, added by #376) are now token-gated with the
+Gateway's <strong>existing</strong> auth mechanism: <code>AuthMiddleware</code>'s Bearer-header-or-cookie
+check against the per-machine gateway token. No new auth scheme was invented - the exact validation
+logic was extracted from <code>AuthMiddleware.Run</code> into <code>AuthMiddleware.HasValidToken</code>
+and reused verbatim by both voice-turn handlers.
+</p>
+<p>
+<strong>Why endpoint-level enforcement matters:</strong> the production Gateway
+(<code>GatewayTrayController.StartHostAsync</code> and the dev <code>GatewayWorker</code>) constructs
+<code>GatewayHost</code> with <code>authEnabled: false</code>, so the global <code>AuthMiddleware</code>
+pipeline never runs in production - the voice-turn routes were reachable over the tailnet with no
+credentials at all (the exact exposure the issue describes). The gate now sits inside the handlers
+themselves, so it holds in production mode; when <code>authEnabled</code> is true the global middleware
+runs first and the endpoint check is a harmless second validation of the same token.
+</p>
+<p>
+<strong>Phone compatibility (verified, not assumed):</strong>
+<code>phone/CcDirectorClient/Voice/DirectorVoiceClient.NewClient()</code> (lines 58-67, merged in #378)
+sets <code>Authorization: Bearer &lt;token&gt;</code> on every client it hands to
+<code>SubmitVoiceTurnAsync</code>/<code>PollVoiceTurnAsync</code>, so a phone with its token configured
+keeps working unchanged. The cookie path (<code>cc-gateway-token</code>, the Cockpit browser mechanism)
+is accepted too, because the reused check is bearer-OR-cookie - identical to every other protected route.
+</p>
+
+<h2>Files changed</h2>
+<table>
+<tr><th>File</th><th>Change</th></tr>
+<tr><td>src/CcDirector.Gateway/Util/AuthMiddleware.cs</td><td>Pure refactor: bearer-or-cookie validation extracted into <code>HasValidToken(HttpContext, string)</code>; <code>Run</code> now calls it. Behavior unchanged.</td></tr>
+<tr><td>src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs</td><td>Both handlers check <code>AuthMiddleware.HasValidToken</code> FIRST (before any session/turn lookup, so 401 never leaks existence) and answer <code>401 {"error":"missing or invalid token"}</code> (same body as the middleware) with a FileLog line on rejection.</td></tr>
+<tr><td>src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs</td><td>Default test client now authenticates with <code>Bearer test-token</code> (like the phone); 5 new tests: <code>Submit_MissingToken_Returns401</code>, <code>Submit_InvalidToken_Returns401</code>, <code>Poll_MissingToken_Returns401</code>, <code>Poll_InvalidToken_Returns401</code>, <code>Submit_GatewayCookie_IsAcceptedLikeOtherProtectedRoutes</code>. Gateway stays <code>authEnabled: false</code>, proving the endpoint gate stands alone in production mode.</td></tr>
+</table>
+
+<h2>Acceptance criteria - status</h2>
+<table>
+<tr><th>Criterion</th><th>Status</th><th>Evidence</th></tr>
+<tr>
+  <td>1. Submit without a valid token returns 401</td>
+  <td class="pass">PASS</td>
+  <td><code>curl-trace.txt</code> AC1 + AC1b (no token / wrong token, both <code>HTTP/1.1 401</code> with <code>{"error":"missing or invalid token"}</code>) against a real GatewayHost in production auth mode; tests <code>Submit_MissingToken_Returns401</code>, <code>Submit_InvalidToken_Returns401</code>.</td>
+</tr>
+<tr>
+  <td>2. Poll without a valid token returns 401</td>
+  <td class="pass">PASS</td>
+  <td><code>curl-trace.txt</code> AC2 + AC2b - a REAL turn id (created with the valid token) still answers 401 without one; tests <code>Poll_MissingToken_Returns401</code>, <code>Poll_InvalidToken_Returns401</code>.</td>
+</tr>
+<tr>
+  <td>3. Valid token succeeds end-to-end</td>
+  <td class="pass">PASS</td>
+  <td><code>curl-trace.txt</code> AC3 (submit with <code>Authorization: Bearer</code> -&gt; <code>202 Accepted</code> + <code>turn_id</code>) and AC3b (poll -&gt; <code>200</code> + stage). The full 202-to-reply pipeline against a real Director runs in <code>GatewayVoiceTurnAsyncTests</code>, where EVERY request now carries the Bearer token exactly as the phone sends it - 16/16 green (<code>test-output.txt</code>). Phone header verified in <code>DirectorVoiceClient.NewClient()</code>.</td>
+</tr>
+<tr>
+  <td>4. Existing authenticated Gateway endpoints are unaffected</td>
+  <td class="pass">PASS</td>
+  <td><code>AuthMiddleware</code> change is a pure extract-method refactor; full Gateway.Tests suite: 603/604 passed - the single failure (<code>DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider</code>) was re-run on a clean <code>origin/main</code> worktree and fails identically there (pre-existing live-OpenAI flake, unrelated).</td>
+</tr>
+</table>
+
+<h2>Proof artifacts (this directory)</h2>
+<table>
+<tr><th>File</th><th>What it shows</th></tr>
+<tr><td><code>curl-trace.txt</code></td><td>The full curl trace: six real <code>curl.exe</code> requests (separate OS process) against a real <code>GatewayHost</code> launched in production auth mode (<code>authEnabled=false</code>, Tailscale off, isolated instances dir) - 401 without/with-wrong token on both routes, 202 + 200 with the valid Bearer token. All assertions PASS.</td></tr>
+<tr><td><code>proof-harness.cs</code></td><td>The harness that launched the Gateway and drove curl (the issue-273 precedent; run via a temp net10.0 console referencing CcDirector.Gateway).</td></tr>
+<tr><td><code>test-output.txt</code></td><td><code>GatewayVoiceTurnAsync</code> filter: 16/16 passed (11 pre-existing, now authenticated + 5 new auth tests).</td></tr>
+</table>
+
+<div class="note">
+<strong>Why the proof Gateway is harness-hosted rather than an isolation-script slot:</strong> the
+per-session isolation script (<code>agent-session-isolation.ps1</code>) launches a <em>Director</em>,
+not a Gateway; a raw <code>dotnet run</code> Gateway would load the REAL per-machine token, discover
+the user's real Directors, and touch the Tailscale serve table. The harness boots the same
+<code>GatewayHost</code> class the tray runs, in the same production auth mode, on loopback with
+<code>CC_GATEWAY_NO_TAILSCALE=1</code> and an isolated instances dir - the established proof pattern
+from issue #273 - and every traced request is genuine <code>curl.exe</code>. Nothing on the machine
+was touched and no user process was started or stopped.
+</div>
+
+<h2>Build and regression</h2>
+<pre>dotnet build cc-director.sln   ->  Build succeeded. 0 Warning(s), 0 Error(s)
+dotnet test CcDirector.Gateway.Tests (full)  ->  Failed: 1, Passed: 603 of 604
+  (the 1 failure is pre-existing on clean origin/main: live realtime-transcription flake, unrelated)
+dotnet test --filter GatewayVoiceTurnAsync   ->  16/16 passed</pre>
+
+<h2>CenCon impact</h2>
+<p>
+No drift. This implements the posture already documented in
+<code>docs/architecture/gateway/VOICE_TURN_ARCHITECTURE.md</code> ("Auth (bearer token) - Gateway -
+Same token mechanism as other protected routes") and strengthens the security profile's stated
+invariant that the Gateway surface is gated by the per-machine bearer token.
+</p>
+
+<h2>Statement</h2>
+<p><strong>I believe this is finished.</strong> All four acceptance criteria are met with committed
+tests and a real curl trace; the only red test in the suite is demonstrably pre-existing on main.</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-369/test-output.txt
+++ b/docs/cencon/proof/issue-369/test-output.txt
@@ -1,0 +1,19 @@
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_MissingToken_Returns401 [172 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_ValidTurnId_AfterTTLExpiry_Returns404 [213 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_GatewayCookie_IsAcceptedLikeOtherProtectedRoutes [204 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_InvalidToken_Returns401 [183 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_TextBody_Returns202 [275 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_UnknownSession_Returns404 [254 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_ValidTurnId_AfterCompletion_ReturnsReplyStage [1 s]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_DirectorUnreachable_ReturnsErrorStage [2 s]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_MultiplePolls_SameResult [1 s]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_UnknownTurnId_Returns404 [116 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_SessionAlreadyExited_Returns404OrGone [237 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_ValidTurnId_WhileProcessing_ReturnsInProgressStage [1 s]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_InvalidToken_Returns401 [128 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_ValidIdleSession_Returns202WithTurnId [240 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Submit_InvalidGuid_Returns400 [132 ms]
+  Passed CcDirector.Gateway.Tests.GatewayVoiceTurnAsyncTests.Poll_MissingToken_Returns401 [239 ms]
+Total tests: 16
+     Passed: 16
+ Total time: 15.5108 Seconds

--- a/src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs
@@ -30,6 +30,9 @@ public sealed class GatewayVoiceTurnAsyncTests : IAsyncLifetime
 {
     private static readonly TimeSpan ReplyDeadline = TimeSpan.FromSeconds(120);
 
+    /// <summary>The Gateway's per-instance token; the voice-turn routes require it (issue #369).</summary>
+    private const string GatewayToken = "test-token";
+
     private ControlApiHost _director = null!;
     private SessionManager _sm = null!;
     private GatewayHost _gateway = null!;
@@ -52,15 +55,20 @@ public sealed class GatewayVoiceTurnAsyncTests : IAsyncLifetime
             instancesDirectory: _instancesDir);
         await _director.StartAsync();
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token", authEnabled: false,
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: GatewayToken, authEnabled: false,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
+        // The voice-turn routes are endpoint-level token-gated (issue #369) even with
+        // authEnabled:false (production tray mode), so the default client authenticates
+        // like the phone does (DirectorVoiceClient.NewClient): Authorization: Bearer.
         _http = new HttpClient
         {
             BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
             Timeout = TimeSpan.FromSeconds(30),
         };
+        _http.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GatewayToken);
 
         // Wait for FSW discovery of the in-process Director.
         var deadline = DateTime.UtcNow.AddSeconds(5);
@@ -80,6 +88,94 @@ public sealed class GatewayVoiceTurnAsyncTests : IAsyncLifetime
         Environment.SetEnvironmentVariable("OPENAI_API_KEY", _originalEnv);
         try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
         catch { /* test cleanup, ignore */ }
+    }
+
+    // ===== Auth (issue #369): both routes are token-gated even with authEnabled:false =====
+
+    /// <summary>A client with NO Authorization header (and no cookie) against the same Gateway.</summary>
+    private HttpClient NewAnonymousClient(string? bearer = null)
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        if (bearer is not null)
+            http.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearer);
+        return http;
+    }
+
+    [Fact]
+    public async Task Submit_MissingToken_Returns401()
+    {
+        var sid = AdoptQuickIdleSession();
+
+        using var anon = NewAnonymousClient();
+        var resp = await anon.PostAsJsonAsync($"sessions/{sid}/voice-turn/submit", new { text = "hello" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("missing or invalid token", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Submit_InvalidToken_Returns401()
+    {
+        var sid = AdoptQuickIdleSession();
+
+        using var wrong = NewAnonymousClient(bearer: "wrong-token");
+        var resp = await wrong.PostAsJsonAsync($"sessions/{sid}/voice-turn/submit", new { text = "hello" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("missing or invalid token", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Poll_MissingToken_Returns401()
+    {
+        // A REAL turn id (created with the valid token) must still be unreadable without one:
+        // the gate sits before the job lookup, so the 401 never leaks turn existence.
+        var sid = AdoptQuickIdleSession();
+        var turnId = await SubmitTextTurnAsync(sid, "What is 2 + 2?");
+
+        using var anon = NewAnonymousClient();
+        var resp = await anon.GetAsync($"sessions/{sid}/voice-turn/{turnId}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("missing or invalid token", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Poll_InvalidToken_Returns401()
+    {
+        var sid = AdoptQuickIdleSession();
+        var turnId = await SubmitTextTurnAsync(sid, "What is 2 + 2?");
+
+        using var wrong = NewAnonymousClient(bearer: "wrong-token");
+        var resp = await wrong.GetAsync($"sessions/{sid}/voice-turn/{turnId}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Submit_GatewayCookie_IsAcceptedLikeOtherProtectedRoutes()
+    {
+        // The mechanism is AuthMiddleware's bearer-OR-cookie check, reused verbatim - so the
+        // cc-gateway-token cookie (the Cockpit browser path) authenticates here too.
+        var sid = AdoptQuickIdleSession();
+
+        using var cookieClient = NewAnonymousClient();
+        using var req = new HttpRequestMessage(HttpMethod.Post, $"sessions/{sid}/voice-turn/submit")
+        {
+            Content = new StringContent("""{"text":"What is 2 + 2?"}""", Encoding.UTF8, "application/json"),
+        };
+        req.Headers.Add("Cookie", $"cc-gateway-token={GatewayToken}");
+        var resp = await cookieClient.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
     }
 
     // ===== Submit validation =====

--- a/src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Util;
 using CcDirector.Gateway.Voice;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -28,6 +29,11 @@ namespace CcDirector.Gateway.Api;
 /// TTS); this layer only owns the async interface and the result cache. Owner resolution
 /// mirrors <see cref="SessionWsProxyEndpoints"/>: the <see cref="SessionOwnerCache"/> fast
 /// path first, then a live fleet fan-out.
+///
+/// Both routes require the Gateway token (issue #369) via <see cref="AuthMiddleware.HasValidToken"/>
+/// - the same Bearer-or-cookie check every other protected route uses - enforced HERE so the
+/// gate holds even in production mode, where the global auth middleware is off
+/// (the tray Gateway runs authEnabled=false). Missing/wrong token -> 401.
 /// </summary>
 internal static class GatewayVoiceTurnEndpoint
 {
@@ -41,6 +47,16 @@ internal static class GatewayVoiceTurnEndpoint
         app.MapPost("/sessions/{sid}/voice-turn/submit", async (string sid, HttpContext ctx) =>
         {
             FileLog.Write($"[GatewayVoiceTurn] POST /sessions/{sid}/voice-turn/submit from {ctx.Connection.RemoteIpAddress}");
+
+            // Issue #369: token-gated even when the global AuthMiddleware is off (the
+            // production tray Gateway runs authEnabled=false). Same mechanism as every
+            // other protected Gateway route - Bearer header or the gateway cookie.
+            if (!AuthMiddleware.HasValidToken(ctx, token))
+            {
+                FileLog.Write($"[GatewayVoiceTurn] submit sid={sid}: missing or invalid token from {ctx.Connection.RemoteIpAddress} -> 401");
+                return Results.Json(new { error = "missing or invalid token" },
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
 
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
@@ -102,8 +118,16 @@ internal static class GatewayVoiceTurnEndpoint
                 statusCode: StatusCodes.Status202Accepted);
         });
 
-        app.MapGet("/sessions/{sid}/voice-turn/{turnId}", (string sid, string turnId) =>
+        app.MapGet("/sessions/{sid}/voice-turn/{turnId}", (string sid, string turnId, HttpContext ctx) =>
         {
+            // Issue #369: same token gate as the submit route above.
+            if (!AuthMiddleware.HasValidToken(ctx, token))
+            {
+                FileLog.Write($"[GatewayVoiceTurn] poll sid={sid} turnId={turnId}: missing or invalid token from {ctx.Connection.RemoteIpAddress} -> 401");
+                return Results.Json(new { error = "missing or invalid token" },
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
             var job = store.Get(turnId);
             if (job is null || !string.Equals(job.SessionId, sid, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -30,25 +30,7 @@ internal static class AuthMiddleware
 
         if (PublicPaths.Contains(path)) { await next(); return; }
 
-        // Bearer
-        if (ctx.Request.Headers.TryGetValue("Authorization", out var header))
-        {
-            var raw = header.ToString();
-            const string prefix = "Bearer ";
-            if (raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            {
-                var provided = raw.Substring(prefix.Length).Trim();
-                if (string.Equals(provided, cfg.Token, StringComparison.Ordinal))
-                {
-                    await next();
-                    return;
-                }
-            }
-        }
-
-        // Cookie
-        if (ctx.Request.Cookies.TryGetValue(CookieName, out var cookieValue) &&
-            string.Equals(cookieValue, cfg.Token, StringComparison.Ordinal))
+        if (HasValidToken(ctx, cfg.Token))
         {
             await next();
             return;
@@ -65,6 +47,32 @@ internal static class AuthMiddleware
         ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
         ctx.Response.ContentType = "application/json; charset=utf-8";
         await ctx.Response.WriteAsync("{\"error\":\"missing or invalid token\"}");
+    }
+
+    /// <summary>
+    /// The Gateway's one token check (Bearer header OR the <see cref="CookieName"/> cookie,
+    /// ordinal compare against the per-machine gateway token). Used by the global middleware
+    /// above and by endpoints that must stay token-gated even when the global middleware is
+    /// off (issue #369: the voice-turn submit/poll surface in production mode).
+    /// </summary>
+    public static bool HasValidToken(HttpContext ctx, string token)
+    {
+        // Bearer
+        if (ctx.Request.Headers.TryGetValue("Authorization", out var header))
+        {
+            var raw = header.ToString();
+            const string prefix = "Bearer ";
+            if (raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                var provided = raw.Substring(prefix.Length).Trim();
+                if (string.Equals(provided, token, StringComparison.Ordinal))
+                    return true;
+            }
+        }
+
+        // Cookie
+        return ctx.Request.Cookies.TryGetValue(CookieName, out var cookieValue) &&
+               string.Equals(cookieValue, token, StringComparison.Ordinal);
     }
 
     public sealed class RequireToken


### PR DESCRIPTION
Closes #369. Depends on #376 (merged, ead9299); phone side verified against #378 (merged, 246d439).

## Problem
The Gateway's async voice-turn routes (`POST /sessions/{sid}/voice-turn/submit`, `GET /sessions/{sid}/voice-turn/{turnId}`) were reachable over the tailnet with NO credentials: the production tray Gateway constructs `GatewayHost` with `authEnabled: false`, so the global `AuthMiddleware` never runs there.

## Change
Reuses the Gateway's EXISTING token mechanism (no new auth scheme): `AuthMiddleware`'s bearer-or-cookie check is extracted into `AuthMiddleware.HasValidToken` (pure refactor) and enforced at the top of both voice-turn handlers - before any session/turn lookup, so a 401 never leaks existence. Missing/wrong token -> `401 {"error":"missing or invalid token"}` (the middleware's exact body).

Phone compatibility verified in code: `DirectorVoiceClient.NewClient()` (merged in #378) sets `Authorization: Bearer <token>` on every submit/poll call, so valid phones are unaffected. The `cc-gateway-token` cookie path is accepted too, identical to every other protected route.

## How to test
1. `dotnet test src/CcDirector.Gateway.Tests --filter "FullyQualifiedName~GatewayVoiceTurnAsync"` -> 16/16 (5 new auth tests; all pre-existing tests now authenticate like the phone, gateway still `authEnabled: false`).
2. Or replay the curl trace: `docs/cencon/proof/issue-369/proof-harness.cs` boots a real GatewayHost in production auth mode and drives it with real curl.exe.

## Expected result
- Submit/poll without a token or with a wrong token: 401.
- Submit with `Authorization: Bearer <gateway-token>`: 202 + turn_id; poll: 200 + stage.

## Before / After
- Before: anyone on the tailnet could submit voice turns to arbitrary sessions and read turn results - no token required.
- After: both routes require the per-machine Gateway token even in production mode (global middleware off); valid phone/Cockpit clients unaffected.

## Regression
- `dotnet build cc-director.sln`: 0 warnings, 0 errors.
- Full Gateway.Tests: 603/604 - the single failure (`DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider`) fails identically on a clean `origin/main` worktree (pre-existing live-OpenAI flake, unrelated).

Proof: docs/cencon/proof/issue-369/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)