### PR TITLE
feat(#405): phone voice-turn client resilience - submit retry + poll backoff/deadline

### DIFF
--- a/docs/cencon/proof/issue-405/qa-report.html
+++ b/docs/cencon/proof/issue-405/qa-report.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof - Issue #405 Voice client resilience</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1a1a2e; }
+  h1 { border-bottom: 3px solid #5319e7; padding-bottom: .4rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .55rem .7rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: #f0ecfb; }
+  .pass { color: #0a7d33; font-weight: bold; }
+  .verdict { background: #eafbe8; border: 2px solid #0a7d33; padding: 1rem; border-radius: 6px; margin: 1.5rem 0; font-size: 1.05rem; }
+  code { background: #f4f4f8; padding: .1rem .35rem; border-radius: 3px; font-size: .85rem; }
+  pre { background: #1a1a2e; color: #e8e8f0; padding: .8rem; border-radius: 6px; overflow-x: auto; font-size: .82rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #405</h1>
+<p><strong>[Voice] Client resilience: poll-loop + submit retry/backoff (survive spotty data)</strong></p>
+<p>PR #410, branch <code>issue-405-voice-resilience</code> @ <code>2a26467</code>. Independently verified by the QA Agent in an isolated worktree
+(<code>D:\ReposFred\cc-director-wt-405</code>). The QA session is a different identity from the Developer session (SOC 2 separation of duties); the
+Developer's report and screenshots were treated as context only, not proof.</p>
+
+<h2>How verified</h2>
+<p>This is a phone-client logic change (xUnit tests + MAUI Android build) - no Director/Control API needed. QA checked out the PR branch into its own
+worktree, read the changed code to confirm the poll loop and submit now retry transient failures, stop on terminal stages, and respect a TTL-aligned
+deadline, then built and ran the tests itself.</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-run)</th><th>Verdict</th></tr>
+<tr>
+  <td>1</td>
+  <td>A transient poll failure (network error / 5xx) does NOT end the turn; the loop retries and completes once the cached reply is available.</td>
+  <td>Loop tolerates one drop, re-polls, returns the reply.</td>
+  <td><code>Poll_ThrowsOnceThenSucceeds_TurnCompletes</code> and <code>Poll_TransientServerErrorThenReply_Completes</code> PASS - both assert 2 poll calls (retried) and a final reply. Code: <code>VoiceTurnRunner.PollToCompletionAsync</code> catches transient (HttpRequestException / 5xx <code>VoiceTurnHttpException</code> / TaskCanceledException) and <code>continue</code>s with backoff.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>A transient submit failure is retried (bounded) before the turn is surfaced as failed; the clip is not discarded on first failure.</td>
+  <td>Submit retried up to the budget, succeeds on retry; fails cleanly only after budget.</td>
+  <td><code>Submit_ThrowsOnceThenSucceeds_ReturnsTurnId</code>, <code>Submit_ServerError5xx_IsRetried</code>, <code>Submit_ThrowsPastBudget_FailsCleanly</code> PASS. <code>SubmitAttempts=4</code> bounded loop with backoff; failure message "please try again".</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>Gives up only at a deadline aligned with the server job TTL or on a terminal stage; an expired 404 surfaces a clear "please resend", not an unhandled exception.</td>
+  <td>Deadline = ~10 min (server TTL); 404 -> clean VoiceTurnExpiredException; error/410 stop immediately.</td>
+  <td><code>OverallDeadline = TimeSpan.FromMinutes(10)</code> (matches Gateway job TTL). <code>Poll_ThrowsRepeatedlyPastDeadline_FailsCleanly</code> (VoiceTurnTimeoutException), <code>Poll_Expired404_SurfacesPleaseResend_NotUnhandled</code> ("send it again"), <code>Poll_ErrorStage_StopsImmediately</code> (1 poll call), <code>Poll_SessionGone410_StopsImmediately</code> all PASS.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>4</td>
+  <td>Unit tests with a fake voice client cover: poll throws once then succeeds; poll throws repeatedly past deadline; error stage stops immediately; submit throws once then succeeds.</td>
+  <td>All four scenarios covered by tests against a fake IVoiceTurnChannel.</td>
+  <td>11 <code>VoiceTurnRunnerTests</code> against a scripted fake channel + injected virtual clock (instant). All four scenarios present and PASS.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>QA-run evidence</h2>
+<p><strong>Targeted test run (PR branch):</strong></p>
+<pre>dotnet test CcDirectorClient.Tests/CcDirectorClient.Tests.csproj --filter VoiceTurnRunnerTests
+Passed!  - Failed: 0, Passed: 11, Skipped: 0, Total: 11, Duration: 74 ms</pre>
+
+<p><strong>Full test project (PR branch):</strong></p>
+<pre>Failed! - Failed: 5, Passed: 132, Skipped: 0, Total: 137
+(the 5 failures are all in ConductorStateTests)</pre>
+
+<p><strong>MAUI Android app build (PR branch):</strong></p>
+<pre>dotnet build CcDirectorClient/CcDirectorClient.csproj -c Debug
+104 Warning(s) / 0 Error(s)   (warnings are pre-existing package/obsolete-API noise)</pre>
+
+<h2>Regression / pre-existing-failure check (Developer claim independently verified)</h2>
+<p>The Developer claimed the 5 <code>ConductorStateTests</code> failures are pre-existing on clean <code>main</code>, not a regression from #405. QA verified this
+independently by running those tests on a clean <code>main</code> checkout (commit <code>11fe600</code>, clean working tree):</p>
+<pre>dotnet test CcDirectorClient.Tests/CcDirectorClient.Tests.csproj --filter ConductorStateTests   # on main
+Failed! - Failed: 5, Passed: 2, Skipped: 0, Total: 7</pre>
+<p>The SAME 5 tests fail identically on clean <code>main</code> (same assertion mismatches Expected 1/2 vs Actual 0, same NullReferenceExceptions).
+<code>ConductorStateTests.cs</code> is NOT in PR #410's changed-file set. <strong>Confirmed pre-existing - not a regression introduced by #405.</strong></p>
+
+<h2>Method / CenCon check</h2>
+<p>Client-side resilience only: no new Gateway endpoints, no new data flows, no security-relevant change. No DT-* blocking rule touched. No
+<code>docs/cencon/</code> architecture/security doc update required.</p>
+
+<div class="verdict">VERIFIED - all 4 acceptance criteria met. 11/11 new VoiceTurnRunnerTests pass; MAUI app builds 0 errors; the only test failures are pre-existing
+ConductorStateTests confirmed failing identically on clean main. No regression. PASS.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-405/report.html
+++ b/docs/cencon/proof/issue-405/report.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #405 - Voice client resilience: poll-loop + submit retry/backoff</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem auto; max-width: 60rem; color: #1a1a1a; line-height: 1.5; padding: 0 1rem; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #2563eb; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; color: #1e3a8a; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cbd5e1; padding: .5rem .6rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: #eff6ff; }
+  code { background: #f1f5f9; padding: .1rem .3rem; border-radius: 3px; font-size: .88rem; }
+  pre { background: #0f172a; color: #e2e8f0; padding: 1rem; border-radius: 6px; overflow-x: auto; font-size: .82rem; }
+  .pass { color: #15803d; font-weight: 600; }
+  .note { background: #fffbeb; border-left: 4px solid #f59e0b; padding: .6rem .9rem; margin: 1rem 0; }
+  .done { background: #ecfdf5; border-left: 4px solid #10b981; padding: .8rem 1rem; margin: 1.5rem 0; font-weight: 600; }
+</style>
+</head>
+<body>
+
+<h1>Issue #405 - [Voice] Client resilience: poll-loop + submit retry/backoff (survive spotty data)</h1>
+
+<p><strong>Branch:</strong> <code>issue-405-voice-resilience</code> &nbsp;|&nbsp;
+<strong>Surface:</strong> phone client (.NET MAUI), <code>phone/CcDirectorClient</code> &nbsp;|&nbsp;
+<strong>Proof type:</strong> xUnit unit tests against a fake voice-turn channel (pure-logic phone-client change - no Director slot needed).</p>
+
+<h2>What was implemented</h2>
+<p>The Gateway async voice-turn pipeline is designed to survive a signal drop (submit once,
+the Gateway caches the result ~10 min, the phone just polls), but the client did not implement
+that resilience: a single dropped poll or submit threw straight out of the turn. This change
+makes the client live up to the design.</p>
+
+<ul>
+  <li><strong>New resilient seam</strong> <code>VoiceTurnRunner</code> holding the submit-retry +
+      poll-retry/backoff/deadline loop, depending only on a new <code>IVoiceTurnChannel</code>
+      interface (implemented by <code>DirectorVoiceClient</code> over real HTTP). The clock and the
+      inter-poll delay are injected (<code>VoiceTurnRetryPolicy</code>) so the loop is MAUI-free and
+      timer-free and unit-tested off-device with instant waits.</li>
+  <li><strong>Poll retry/backoff:</strong> each poll is wrapped; a transient failure (network error,
+      5xx, request timeout) waits a backoff (1.5s steady -> up to ~5s) and re-polls rather than
+      throwing out of the loop.</li>
+  <li><strong>Deadline aligned with the server TTL:</strong> the loop gives up only at an overall
+      ~10-minute deadline (<code>VoiceTurnTimeoutException</code>) or on a terminal stage.</li>
+  <li><strong>Transient vs terminal classification:</strong> a 5xx is transient; the <code>error</code>
+      stage and a <code>410 Gone</code> (session exited) stop immediately; a <code>404</code> after
+      holding a valid turn id is a clean <code>VoiceTurnExpiredException</code> ("please resend"),
+      never an unhandled crash. <code>DirectorVoiceClient.PollVoiceTurnAsync</code> now throws
+      <code>VoiceTurnHttpException</code> carrying the status code so the runner can classify.</li>
+  <li><strong>Submit retry:</strong> <code>VoiceTurnRunner.SubmitAsync</code> retries a bounded number
+      of times (default 4) with backoff before surfacing a failure, so a drop mid-upload does not
+      discard the recorded clip.</li>
+  <li><code>VoiceConversation.SpeakTurnAsync</code> now delegates its agent path to the runner,
+      keeping the same <code>onUpdate</code> stage callbacks and reply-audio playback.</li>
+</ul>
+
+<h2>Acceptance criteria -&gt; proof</h2>
+<table>
+  <tr><th>Criterion (from the issue)</th><th>How the code satisfies it</th><th>Proving test (PASS)</th></tr>
+  <tr>
+    <td>A transient poll failure does NOT end the turn; the loop retries and completes once the cached reply is available.</td>
+    <td>Poll wrapped in try/catch; transient failure -&gt; backoff + re-poll; reply stage returns.</td>
+    <td class="pass">Poll_ThrowsOnceThenSucceeds_TurnCompletes; Poll_TransientServerErrorThenReply_Completes</td>
+  </tr>
+  <tr>
+    <td>A transient submit failure is retried (bounded) before the turn is surfaced as failed.</td>
+    <td><code>SubmitAsync</code> retries up to <code>SubmitAttempts</code> with backoff; clip re-sent.</td>
+    <td class="pass">Submit_ThrowsOnceThenSucceeds_ReturnsTurnId; Submit_ServerError5xx_IsRetried; Submit_ThrowsPastBudget_FailsCleanly</td>
+  </tr>
+  <tr>
+    <td>The loop gives up only at a deadline aligned with the server job TTL, or on a terminal stage; an expired-turn 404 surfaces a clear "please resend", not an unhandled exception.</td>
+    <td>Overall ~10-min deadline -&gt; <code>VoiceTurnTimeoutException</code>; 404 -&gt; <code>VoiceTurnExpiredException</code> ("send it again").</td>
+    <td class="pass">Poll_ThrowsRepeatedlyPastDeadline_FailsCleanly; Poll_Expired404_SurfacesPleaseResend_NotUnhandled</td>
+  </tr>
+  <tr>
+    <td>Unit tests cover: poll throws once then succeeds; poll throws repeatedly past the deadline; error stage stops immediately; submit throws once then succeeds.</td>
+    <td>All four required cases plus 410-gone, cancellation, and once-per-stage callback coverage.</td>
+    <td class="pass">All 11 VoiceTurnRunnerTests (see run below); Poll_ErrorStage_StopsImmediately; Poll_SessionGone410_StopsImmediately</td>
+  </tr>
+</table>
+
+<h2>Test run (primary proof)</h2>
+<pre>
+dotnet test CcDirectorClient.Tests --filter VoiceTurnRunnerTests
+
+  Passed Poll_Cancelled_ThrowsOperationCanceled
+  Passed Poll_SessionGone410_StopsImmediately
+  Passed Poll_ErrorStage_StopsImmediately
+  Passed Poll_TransientServerErrorThenReply_Completes
+  Passed Poll_ThrowsOnceThenSucceeds_TurnCompletes
+  Passed Submit_ThrowsPastBudget_FailsCleanly
+  Passed Poll_ThrowsRepeatedlyPastDeadline_FailsCleanly
+  Passed Submit_ServerError5xx_IsRetried
+  Passed Poll_Expired404_SurfacesPleaseResend_NotUnhandled
+  Passed Submit_ThrowsOnceThenSucceeds_ReturnsTurnId
+  Passed Poll_FiresOnStageOncePerDistinctStage
+
+Passed!  - Failed: 0, Passed: 11, Skipped: 0, Total: 11
+</pre>
+
+<p><strong>Test project build:</strong> <span class="pass">Build succeeded. 0 Warning(s), 0 Error(s).</span><br>
+<strong>MAUI app build</strong> (<code>CcDirectorClient.csproj</code>, net10.0-android):
+<span class="pass">0 Error(s)</span> - the only warnings are pre-existing Android SDK/NuGet version
+warnings unrelated to these files.</p>
+
+<div class="note">
+<strong>Pre-existing baseline note:</strong> The full test project shows 5 failing tests in
+<code>ConductorStateTests</code>. These were verified to fail identically on clean <code>main</code>
+(same 5, same assertions) BEFORE this change - they are a pre-existing baseline issue, NOT a
+regression from #405. This change adds 11 new passing tests and introduces 0 new failures.
+</div>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security drift. This is a client-side resilience change within the existing
+phone voice-turn pipeline; it adds no new endpoints, no new data flows, and touches no security
+control (DT-01..DT-NN). No <code>docs/cencon/</code> manifest update required.</p>
+
+<h2>Files changed</h2>
+<ul>
+  <li><code>phone/CcDirectorClient/Voice/VoiceTurnRunner.cs</code> (new) - resilient submit + poll loop</li>
+  <li><code>phone/CcDirectorClient/Voice/IVoiceTurnChannel.cs</code> (new) - the testable seam</li>
+  <li><code>phone/CcDirectorClient/Voice/VoiceTurnRetryPolicy.cs</code> (new) - injectable backoff/clock/delay</li>
+  <li><code>phone/CcDirectorClient/Voice/VoiceTurnHttpException.cs</code> (new) - status-carrying exception (5xx/404/410)</li>
+  <li><code>phone/CcDirectorClient/Voice/VoiceTurnTerminalExceptions.cs</code> (new) - timeout + expired terminal types</li>
+  <li><code>phone/CcDirectorClient/Voice/VoiceConversation.cs</code> - agent path delegates to the runner</li>
+  <li><code>phone/CcDirectorClient/Voice/DirectorVoiceClient.cs</code> - implements <code>IVoiceTurnChannel</code>; poll throws status-carrying exception</li>
+  <li><code>phone/CcDirectorClient.Tests/VoiceTurnRunnerTests.cs</code> (new) - 11 tests</li>
+  <li><code>phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj</code> - link-include the new pure-logic files</li>
+</ul>
+
+<div class="done">I believe this is finished. All four required test cases (and three extra) pass, both the test project and the MAUI app build clean, and there is no CenCon drift.</div>
+
+</body>
+</html>

--- a/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
+++ b/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
@@ -31,6 +31,11 @@
     <Compile Include="..\CcDirectorClient\Voice\SessionFilter.cs" Link="Voice\SessionFilter.cs" />
     <Compile Include="..\CcDirectorClient\Voice\ChatTurnResult.cs" Link="Voice\ChatTurnResult.cs" />
     <Compile Include="..\CcDirectorClient\Voice\VoiceTurnResults.cs" Link="Voice\VoiceTurnResults.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\IVoiceTurnChannel.cs" Link="Voice\IVoiceTurnChannel.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\VoiceTurnHttpException.cs" Link="Voice\VoiceTurnHttpException.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\VoiceTurnTerminalExceptions.cs" Link="Voice\VoiceTurnTerminalExceptions.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\VoiceTurnRetryPolicy.cs" Link="Voice\VoiceTurnRetryPolicy.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\VoiceTurnRunner.cs" Link="Voice\VoiceTurnRunner.cs" />
     <Compile Include="..\CcDirectorClient\Voice\ConductorState.cs" Link="Voice\ConductorState.cs" />
     <Compile Include="..\CcDirectorClient\Voice\RawTerminalPage.cs" Link="Voice\RawTerminalPage.cs" />
     <Compile Include="..\CcDirectorClient\Voice\TurnBrief.cs" Link="Voice\TurnBrief.cs" />

--- a/phone/CcDirectorClient.Tests/VoiceTurnRunnerTests.cs
+++ b/phone/CcDirectorClient.Tests/VoiceTurnRunnerTests.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using CcDirectorClient.Voice;
+using Xunit;
+
+namespace CcDirectorClient.Tests;
+
+/// <summary>
+/// Resilience tests for the Gateway async voice-turn submit + poll loop (issue #405).
+/// The pipeline is designed so the phone submits once and the Gateway caches the result for
+/// ~10 minutes; these tests prove the client now lives up to that design - a transient drop on
+/// submit or poll no longer aborts the turn, while a terminal condition (error stage, expired
+/// 404, gone 410, deadline) stops cleanly with a clear message.
+///
+/// A fake <see cref="IVoiceTurnChannel"/> scripts each submit/poll outcome, and the retry policy's
+/// clock and delay are injected so the whole loop runs instantly with no real wall-clock waits.
+/// </summary>
+public class VoiceTurnRunnerTests
+{
+    private const string Gw = "http://gw";
+    private const string Sid = "session-1";
+    private const string Tid = "turn-abc";
+
+    // ===== test seam: a scripted fake channel + a virtual clock =============
+
+    /// <summary>A scripted channel: each call dequeues the next outcome (a result or an
+    /// exception to throw). Records how many times submit/poll were called.</summary>
+    private sealed class FakeChannel : IVoiceTurnChannel
+    {
+        private readonly Queue<Func<VoiceTurnSubmitResult>> _submits = new();
+        private readonly Queue<Func<VoiceTurnPollResult>> _polls = new();
+
+        public int SubmitCalls { get; private set; }
+        public int PollCalls { get; private set; }
+
+        public FakeChannel SubmitReturns(VoiceTurnSubmitResult r) { _submits.Enqueue(() => r); return this; }
+        public FakeChannel SubmitThrows(Exception ex) { _submits.Enqueue(() => throw ex); return this; }
+        public FakeChannel PollReturns(VoiceTurnPollResult r) { _polls.Enqueue(() => r); return this; }
+        public FakeChannel PollThrows(Exception ex) { _polls.Enqueue(() => throw ex); return this; }
+
+        public Task<VoiceTurnSubmitResult> SubmitVoiceTurnAsync(
+            string gatewayBase, string sessionId, byte[] audio, string mime, CancellationToken ct = default)
+        {
+            SubmitCalls++;
+            return Task.FromResult(_submits.Dequeue()());
+        }
+
+        public Task<VoiceTurnPollResult> PollVoiceTurnAsync(
+            string gatewayBase, string sessionId, string turnId, CancellationToken ct = default)
+        {
+            PollCalls++;
+            // When the script runs dry on a "throws forever" test, keep throwing the last kind
+            // so the deadline (not an empty-queue crash) is what stops the loop.
+            var next = _polls.Count > 0 ? _polls.Dequeue() : (() => throw new HttpRequestException("still offline"));
+            return Task.FromResult(next());
+        }
+    }
+
+    /// <summary>A virtual clock that advances by exactly the delay the runner asks to wait, so
+    /// the overall deadline is reached deterministically without any real sleeping.</summary>
+    private static VoiceTurnRetryPolicy FastPolicy(TimeSpan? deadline = null, int submitAttempts = 4)
+    {
+        var now = new DateTimeOffset(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+        return new VoiceTurnRetryPolicy
+        {
+            OverallDeadline = deadline ?? TimeSpan.FromMinutes(10),
+            SubmitAttempts = submitAttempts,
+            UtcNow = () => now,
+            DelayAsync = (d, ct) => { now = now.Add(d); return Task.CompletedTask; },
+        };
+    }
+
+    private static VoiceTurnPollResult Stage(string stage, string? summary = null, string? error = null, string? audio = null)
+        => new(stage, Transcript: null, Summary: summary, AudioBase64: audio, Error: error);
+
+    // ===== POLL: transient drop is tolerated ================================
+
+    [Fact]
+    public async Task Poll_ThrowsOnceThenSucceeds_TurnCompletes()
+    {
+        // A single dropped poll (network error) must NOT end the turn: the loop retries and
+        // completes once connectivity returns and the cached reply is available.
+        var channel = new FakeChannel()
+            .PollThrows(new HttpRequestException("connection reset"))
+            .PollReturns(Stage("reply", summary: "All done."));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var result = await runner.PollToCompletionAsync(Gw, Sid, Tid);
+
+        Assert.Equal("reply", result.Stage);
+        Assert.Equal("All done.", result.Summary);
+        Assert.Equal(2, channel.PollCalls); // proves it retried rather than threw out
+    }
+
+    [Fact]
+    public async Task Poll_TransientServerErrorThenReply_Completes()
+    {
+        // A 5xx is transient too - re-poll the same cached turn id.
+        var channel = new FakeChannel()
+            .PollThrows(new VoiceTurnHttpException(HttpStatusCode.BadGateway, "502 upstream"))
+            .PollReturns(Stage("reply", summary: "Done."));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var result = await runner.PollToCompletionAsync(Gw, Sid, Tid);
+
+        Assert.Equal("reply", result.Stage);
+        Assert.Equal(2, channel.PollCalls);
+    }
+
+    [Fact]
+    public async Task Poll_ThrowsRepeatedlyPastDeadline_FailsCleanly()
+    {
+        // Poll keeps failing forever; the loop must give up at the deadline with a clear
+        // timeout, not loop endlessly or throw the raw network exception.
+        var channel = new FakeChannel(); // empty script -> the fake throws HttpRequestException forever
+        var runner = new VoiceTurnRunner(channel, FastPolicy(deadline: TimeSpan.FromSeconds(20)));
+
+        await Assert.ThrowsAsync<VoiceTurnTimeoutException>(
+            () => runner.PollToCompletionAsync(Gw, Sid, Tid));
+
+        Assert.True(channel.PollCalls > 0); // it actually tried before giving up
+    }
+
+    // ===== POLL: terminal conditions stop immediately =======================
+
+    [Fact]
+    public async Task Poll_ErrorStage_StopsImmediately()
+    {
+        var channel = new FakeChannel()
+            .PollReturns(Stage("error", error: "director unreachable: timeout"));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runner.PollToCompletionAsync(Gw, Sid, Tid));
+
+        Assert.Contains("director unreachable", ex.Message);
+        Assert.Equal(1, channel.PollCalls); // did NOT keep polling after the terminal stage
+    }
+
+    [Fact]
+    public async Task Poll_Expired404_SurfacesPleaseResend_NotUnhandled()
+    {
+        var channel = new FakeChannel()
+            .PollThrows(new VoiceTurnHttpException(HttpStatusCode.NotFound, "404 unknown turn"));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var ex = await Assert.ThrowsAsync<VoiceTurnExpiredException>(
+            () => runner.PollToCompletionAsync(Gw, Sid, Tid));
+
+        Assert.Contains("send it again", ex.Message);
+    }
+
+    [Fact]
+    public async Task Poll_SessionGone410_StopsImmediately()
+    {
+        var channel = new FakeChannel()
+            .PollThrows(new VoiceTurnHttpException(HttpStatusCode.Gone, "410 gone"));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runner.PollToCompletionAsync(Gw, Sid, Tid));
+
+        Assert.Contains("exited", ex.Message);
+    }
+
+    [Fact]
+    public async Task Poll_FiresOnStageOncePerDistinctStage()
+    {
+        var channel = new FakeChannel()
+            .PollReturns(Stage("transcribing"))
+            .PollReturns(Stage("transcribing")) // duplicate - must NOT fire again
+            .PollReturns(Stage("thinking"))
+            .PollReturns(Stage("reply", summary: "ok"));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var stages = new List<string>();
+        await runner.PollToCompletionAsync(Gw, Sid, Tid, onStage: p => stages.Add(p.Stage));
+
+        Assert.Equal(new[] { "transcribing", "thinking", "reply" }, stages);
+    }
+
+    [Fact]
+    public async Task Poll_Cancelled_ThrowsOperationCanceled()
+    {
+        var channel = new FakeChannel().PollReturns(Stage("reply", summary: "ok"));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runner.PollToCompletionAsync(Gw, Sid, Tid, ct: cts.Token));
+    }
+
+    // ===== SUBMIT: transient drop is retried ================================
+
+    [Fact]
+    public async Task Submit_ThrowsOnceThenSucceeds_ReturnsTurnId()
+    {
+        // A drop mid-upload must be retried (bounded) before the turn is surfaced as failed,
+        // and the recorded clip is re-sent rather than discarded on the first failure.
+        var channel = new FakeChannel()
+            .SubmitThrows(new HttpRequestException("upload reset"))
+            .SubmitReturns(new VoiceTurnSubmitResult(Tid, ExpiresAt: null));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var result = await runner.SubmitAsync(Gw, Sid, new byte[] { 1, 2, 3 }, "audio/mp4");
+
+        Assert.Equal(Tid, result.TurnId);
+        Assert.Equal(2, channel.SubmitCalls);
+    }
+
+    [Fact]
+    public async Task Submit_ThrowsPastBudget_FailsCleanly()
+    {
+        var channel = new FakeChannel()
+            .SubmitThrows(new HttpRequestException("offline"))
+            .SubmitThrows(new HttpRequestException("offline"));
+        var runner = new VoiceTurnRunner(channel, FastPolicy(submitAttempts: 2));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runner.SubmitAsync(Gw, Sid, new byte[] { 1 }, "audio/mp4"));
+
+        Assert.Contains("please try again", ex.Message);
+        Assert.Equal(2, channel.SubmitCalls); // exactly the budget, no more
+    }
+
+    [Fact]
+    public async Task Submit_ServerError5xx_IsRetried()
+    {
+        var channel = new FakeChannel()
+            .SubmitThrows(new VoiceTurnHttpException(HttpStatusCode.ServiceUnavailable, "503"))
+            .SubmitReturns(new VoiceTurnSubmitResult(Tid, ExpiresAt: null));
+        var runner = new VoiceTurnRunner(channel, FastPolicy());
+
+        var result = await runner.SubmitAsync(Gw, Sid, new byte[] { 1 }, "audio/mp4");
+
+        Assert.Equal(Tid, result.TurnId);
+        Assert.Equal(2, channel.SubmitCalls);
+    }
+}

--- a/phone/CcDirectorClient/Voice/DirectorVoiceClient.cs
+++ b/phone/CcDirectorClient/Voice/DirectorVoiceClient.cs
@@ -41,7 +41,7 @@ public sealed record BufferSlice(string Text, long NewCursor);
 /// the phone sounds identical to the web instead of falling back to a robotic
 /// on-device engine.
 /// </summary>
-public sealed class DirectorVoiceClient
+public sealed class DirectorVoiceClient : IVoiceTurnChannel
 {
     private static readonly JsonSerializerOptions Json = new()
     {
@@ -220,10 +220,11 @@ public sealed class DirectorVoiceClient
     /// <summary>
     /// Poll the GATEWAY for the result of a previously submitted voice turn
     /// (GET {gatewayBase}/sessions/{sid}/voice-turn/{turnId}). Answered from the
-    /// Gateway's job cache - no Director call. Call every ~1.5 seconds until
-    /// <see cref="VoiceTurnPollResult.Stage"/> is "reply" or "error". Throws on HTTP
-    /// failure (including the 404 for an unknown/expired turn id) so the caller
-    /// surfaces the real reason.
+    /// Gateway's job cache - no Director call. Driven by <see cref="VoiceTurnRunner"/>, which
+    /// polls on a steady cadence and tolerates a transient drop. On a non-2xx response this
+    /// throws <see cref="VoiceTurnHttpException"/> carrying the status code so the runner can
+    /// classify it - a 5xx is transient (re-poll), a 404 is an expired/unknown turn, a 410 is
+    /// a gone session.
     /// </summary>
     public async Task<VoiceTurnPollResult> PollVoiceTurnAsync(
         string gatewayBase, string sessionId, string turnId, CancellationToken ct = default)
@@ -233,7 +234,7 @@ public sealed class DirectorVoiceClient
         var resp = await http.GetAsync($"{b}/sessions/{sessionId}/voice-turn/{turnId}", ct);
         var body = await resp.Content.ReadAsStringAsync(ct);
         if (!resp.IsSuccessStatusCode)
-            throw new HttpRequestException($"voice-turn poll failed: {(int)resp.StatusCode} {body}");
+            throw new VoiceTurnHttpException(resp.StatusCode, $"voice-turn poll failed: {(int)resp.StatusCode} {body}");
         return VoiceTurnResults.ParsePoll(body);
     }
 

--- a/phone/CcDirectorClient/Voice/IVoiceTurnChannel.cs
+++ b/phone/CcDirectorClient/Voice/IVoiceTurnChannel.cs
@@ -1,0 +1,28 @@
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// The submit/poll seam the Gateway async voice-turn pipeline rides on (issue #378).
+/// Extracted from <see cref="DirectorVoiceClient"/> (which implements it over real HTTP)
+/// so the resilient submit-retry + poll-retry/backoff loop in <see cref="VoiceTurnRunner"/>
+/// can be exercised with a fake channel off-device (issue #405). The runner depends only
+/// on this interface, never on the concrete HTTP client, so a unit test can make submit or
+/// poll throw, return a 404/410, or land a terminal stage on demand.
+/// </summary>
+public interface IVoiceTurnChannel
+{
+    /// <summary>
+    /// Submit a recorded utterance to the Gateway and return the turn id to poll with.
+    /// May throw on a transport failure; the runner decides whether to retry.
+    /// </summary>
+    Task<VoiceTurnSubmitResult> SubmitVoiceTurnAsync(
+        string gatewayBase, string sessionId, byte[] audio, string mime, CancellationToken ct = default);
+
+    /// <summary>
+    /// Poll the Gateway for the result of a previously submitted turn. On a non-2xx
+    /// response it throws <see cref="VoiceTurnHttpException"/> carrying the status code
+    /// so the runner can tell a transient failure (network / 5xx) from a terminal one
+    /// (404 expired, 410 session gone).
+    /// </summary>
+    Task<VoiceTurnPollResult> PollVoiceTurnAsync(
+        string gatewayBase, string sessionId, string turnId, CancellationToken ct = default);
+}

--- a/phone/CcDirectorClient/Voice/VoiceConversation.cs
+++ b/phone/CcDirectorClient/Voice/VoiceConversation.cs
@@ -11,9 +11,6 @@ namespace CcDirectorClient.Voice;
 /// </summary>
 public sealed class VoiceConversation
 {
-    /// <summary>Cadence of the Gateway voice-turn poll loop (~1.5s; cheap cache reads).</summary>
-    private const int VoiceTurnPollMs = 1_500;
-
     // FIFO delivery: we deliberately do NOT wait for the agent's turn - the point of FIFO
     // is to deposit the answer and move on. The /chat call sends the text to the PTY before
     // it begins polling, so a short timeout returns right after delivery (status "working"),
@@ -23,18 +20,25 @@ public sealed class VoiceConversation
     private readonly DirectorVoiceClient _client;
     private readonly IReplySpeaker _tts;
     private readonly string _gatewayBaseUrl;
+    private readonly VoiceTurnRetryPolicy _retryPolicy;
 
     /// <summary>
     /// <paramref name="gatewayBaseUrl"/> is the Gateway's base URL (the same address
     /// the roster comes from) - required by <see cref="SpeakTurnAsync"/>'s agent path,
     /// which submits/polls the voice turn on the Gateway (issue #378). Hosts that only
     /// use the Director-direct members (FIFO deliver, briefing, one-off lines) may omit it.
+    /// <paramref name="retryPolicy"/> tunes the agent path's submit-retry + poll-backoff
+    /// loop (issue #405); production omits it to take the resilient defaults (~1.5s cadence,
+    /// backoff to ~5s, ~10-minute deadline aligned with the Gateway job TTL).
     /// </summary>
-    public VoiceConversation(DirectorVoiceClient client, IReplySpeaker tts, string gatewayBaseUrl = "")
+    public VoiceConversation(
+        DirectorVoiceClient client, IReplySpeaker tts, string gatewayBaseUrl = "",
+        VoiceTurnRetryPolicy? retryPolicy = null)
     {
         _client = client;
         _tts = tts;
         _gatewayBaseUrl = (gatewayBaseUrl ?? "").TrimEnd('/');
+        _retryPolicy = retryPolicy ?? VoiceTurnRetryPolicy.Default;
     }
 
     /// <summary>Status callback so the UI can show what is happening at each step.</summary>
@@ -99,36 +103,33 @@ public sealed class VoiceConversation
             throw new InvalidOperationException(
                 "gateway URL is not configured - set the Gateway address in settings to run a voice turn");
 
-        // Submit once: the Gateway queues the turn and answers 202 with a turn id
-        // immediately, so the phone is free while the Director does the work.
+        // Submit once, with bounded retry: the Gateway queues the turn and answers 202 with a
+        // turn id, so the phone is free while the Director does the work. A drop mid-upload is
+        // retried with backoff (issue #405) rather than losing the recorded clip on the first
+        // failure.
         onUpdate?.Invoke(new TurnUpdate("transcribing", "Sending to the gateway..."));
-        var submit = await _client.SubmitVoiceTurnAsync(
+        var runner = new VoiceTurnRunner(_client, _retryPolicy);
+        var submit = await runner.SubmitAsync(
             _gatewayBaseUrl, session.SessionId, audio.Bytes, audio.Mime, ct);
         ClientLog.Write($"[VoiceConversation] SpeakTurn: submitted turnId={submit.TurnId}");
 
-        // Poll the Gateway's job cache until the turn lands in a terminal stage.
+        // Poll the Gateway's job cache until the turn lands in a terminal stage. The runner
+        // tolerates transient drops (network error, 5xx, timeout) by re-polling with backoff
+        // and gives up only at the server-TTL deadline or on a terminal condition (issue #405).
         // Stage vocabulary: submitted, transcribing, transcript, waiting, thinking,
         // summarizing, reply (terminal), error (terminal).
-        var lastStage = "";
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-            await Task.Delay(TimeSpan.FromMilliseconds(VoiceTurnPollMs), ct);
-
-            var poll = await _client.PollVoiceTurnAsync(
-                _gatewayBaseUrl, session.SessionId, submit.TurnId, ct);
-
-            if (!string.Equals(poll.Stage, lastStage, StringComparison.Ordinal))
+        var poll = await runner.PollToCompletionAsync(
+            _gatewayBaseUrl, session.SessionId, submit.TurnId,
+            onStage: p =>
             {
-                lastStage = poll.Stage;
-                switch (poll.Stage)
+                switch (p.Stage)
                 {
                     case "transcribing":
                         onUpdate?.Invoke(new TurnUpdate("transcribing", "Transcribing..."));
                         break;
                     case "transcript":
-                        if (!string.IsNullOrWhiteSpace(poll.Transcript))
-                            onUpdate?.Invoke(new TurnUpdate("transcript", poll.Transcript));
+                        if (!string.IsNullOrWhiteSpace(p.Transcript))
+                            onUpdate?.Invoke(new TurnUpdate("transcript", p.Transcript));
                         break;
                     case "waiting":
                         onUpdate?.Invoke(new TurnUpdate("waiting", "Waiting for the session to be ready..."));
@@ -140,33 +141,27 @@ public sealed class VoiceConversation
                         onUpdate?.Invoke(new TurnUpdate("summarizing", "Summarizing..."));
                         break;
                 }
-            }
+            },
+            ct: ct);
 
-            if (string.Equals(poll.Stage, "error", StringComparison.Ordinal))
-                throw new InvalidOperationException($"gateway voice turn failed: {poll.Error ?? "unknown error"}");
+        var summary = poll.Summary ?? "";
+        onUpdate?.Invoke(new TurnUpdate("reply", summary));
 
-            if (!string.Equals(poll.Stage, "reply", StringComparison.Ordinal))
-                continue;
-
-            var summary = poll.Summary ?? "";
-            onUpdate?.Invoke(new TurnUpdate("reply", summary));
-
-            // "speaking" fires before playback begins so the status label reads
-            // "Speaking..." only while audio is actually playing. The Gateway returns
-            // the reply audio with the result; audioBase64 is empty (never null) when
-            // the Director has no TTS key, in which case the on-screen summary is the
-            // whole reply.
-            onUpdate?.Invoke(new TurnUpdate("speaking", "Speaking..."));
-            if (!string.IsNullOrWhiteSpace(poll.AudioBase64))
-            {
-                var mp3 = Convert.FromBase64String(poll.AudioBase64);
-                if (mp3.Length > 0)
-                    await _tts.PlayAsync(mp3, ct);
-            }
-
-            ClientLog.Write($"[VoiceConversation] SpeakTurn done: turnId={submit.TurnId}, summaryChars={summary.Length}");
-            return summary;
+        // "speaking" fires before playback begins so the status label reads
+        // "Speaking..." only while audio is actually playing. The Gateway returns
+        // the reply audio with the result; audioBase64 is empty (never null) when
+        // the Director has no TTS key, in which case the on-screen summary is the
+        // whole reply.
+        onUpdate?.Invoke(new TurnUpdate("speaking", "Speaking..."));
+        if (!string.IsNullOrWhiteSpace(poll.AudioBase64))
+        {
+            var mp3 = Convert.FromBase64String(poll.AudioBase64);
+            if (mp3.Length > 0)
+                await _tts.PlayAsync(mp3, ct);
         }
+
+        ClientLog.Write($"[VoiceConversation] SpeakTurn done: turnId={submit.TurnId}, summaryChars={summary.Length}");
+        return summary;
     }
 
     /// <summary>

--- a/phone/CcDirectorClient/Voice/VoiceTurnHttpException.cs
+++ b/phone/CcDirectorClient/Voice/VoiceTurnHttpException.cs
@@ -1,0 +1,34 @@
+using System.Net;
+
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// Raised by the voice-turn channel on a non-2xx Gateway response. Carries the HTTP
+/// <see cref="StatusCode"/> so <see cref="VoiceTurnRunner"/> can classify the failure:
+/// a 5xx is transient (re-poll after a backoff), a 404 means the cached turn expired
+/// ("please resend"), and a 410 means the owning session has gone. A bare
+/// <see cref="HttpRequestException"/> (no response at all - DNS/connect/reset) is treated
+/// as transient because the carrier signal dropped, not the turn.
+/// </summary>
+public sealed class VoiceTurnHttpException : Exception
+{
+    public HttpStatusCode StatusCode { get; }
+
+    public VoiceTurnHttpException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>True for a 5xx server error - the Gateway is up enough to answer but
+    /// momentarily faulted, so re-polling the same turn id is the right move.</summary>
+    public bool IsServerError => (int)StatusCode >= 500 && (int)StatusCode <= 599;
+
+    /// <summary>True for the 404 the Gateway returns once a cached turn has expired
+    /// (10-minute TTL) or for an unknown turn id - a clean "please resend", not a crash.</summary>
+    public bool IsExpired => StatusCode == HttpStatusCode.NotFound;
+
+    /// <summary>True for the 410 the Gateway returns when the owning session has exited -
+    /// terminal, stop immediately.</summary>
+    public bool IsSessionGone => StatusCode == HttpStatusCode.Gone;
+}

--- a/phone/CcDirectorClient/Voice/VoiceTurnRetryPolicy.cs
+++ b/phone/CcDirectorClient/Voice/VoiceTurnRetryPolicy.cs
@@ -1,0 +1,48 @@
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// The retry/backoff knobs for <see cref="VoiceTurnRunner"/>, with the clock and the inter-poll
+/// delay injected so the loop is unit tested off-device with instant (no real wall-clock) waits.
+/// In production the defaults apply: ~1.5s steady poll cadence, backoff growing to ~5s while a
+/// run of polls is failing, an overall deadline aligned with the Gateway's ~10-minute job TTL,
+/// and a small bounded submit-retry budget.
+/// </summary>
+public sealed class VoiceTurnRetryPolicy
+{
+    /// <summary>Steady poll cadence while the turn is progressing (matches the prior 1.5s).</summary>
+    public TimeSpan PollInterval { get; init; } = TimeSpan.FromMilliseconds(1_500);
+
+    /// <summary>First backoff step after a transient failure.</summary>
+    public TimeSpan BackoffBase { get; init; } = TimeSpan.FromMilliseconds(1_500);
+
+    /// <summary>Backoff ceiling - it never waits longer than this between retries (~5s).</summary>
+    public TimeSpan BackoffMax { get; init; } = TimeSpan.FromMilliseconds(5_000);
+
+    /// <summary>Overall deadline for the poll loop, aligned with the Gateway job TTL (~10 min).</summary>
+    public TimeSpan OverallDeadline { get; init; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>How many times to attempt the submit before surfacing a failure (1 initial + retries).</summary>
+    public int SubmitAttempts { get; init; } = 4;
+
+    /// <summary>The clock. Injected so tests advance time without waiting.</summary>
+    public Func<DateTimeOffset> UtcNow { get; init; } = () => DateTimeOffset.UtcNow;
+
+    /// <summary>The wait primitive. Injected so tests run instantly instead of sleeping.</summary>
+    public Func<TimeSpan, CancellationToken, Task> DelayAsync { get; init; }
+        = (d, ct) => Task.Delay(d, ct);
+
+    public static VoiceTurnRetryPolicy Default => new();
+
+    /// <summary>
+    /// The backoff for the Nth consecutive transient failure: linear growth off
+    /// <see cref="BackoffBase"/> capped at <see cref="BackoffMax"/> (e.g. 1.5s, 3s, 4.5s, 5s...).
+    /// Kept simple and bounded - no jitter - so the cadence is predictable and testable.
+    /// </summary>
+    public TimeSpan BackoffFor(int consecutiveFailures)
+    {
+        if (consecutiveFailures < 1) consecutiveFailures = 1;
+        var ms = BackoffBase.TotalMilliseconds * consecutiveFailures;
+        if (ms > BackoffMax.TotalMilliseconds) ms = BackoffMax.TotalMilliseconds;
+        return TimeSpan.FromMilliseconds(ms);
+    }
+}

--- a/phone/CcDirectorClient/Voice/VoiceTurnRunner.cs
+++ b/phone/CcDirectorClient/Voice/VoiceTurnRunner.cs
@@ -1,0 +1,177 @@
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// The resilient submit + poll loop for the Gateway async voice-turn pipeline (issue #405).
+///
+/// The pipeline is designed to survive a signal drop: the phone submits the audio once, the
+/// Gateway drives the turn server-side and caches the result for ~10 minutes, and the phone
+/// just polls. This runner makes the client actually live up to that design - a single dropped
+/// poll (network error, 5xx, request timeout) no longer aborts the whole turn. It retries with
+/// a small backoff and keeps re-polling until either a terminal stage (reply / error) or an
+/// overall deadline aligned with the Gateway job TTL. Submit is retried the same way so a drop
+/// mid-upload does not lose the recorded clip.
+///
+/// MAUI-free and timer-free by construction: the clock and the inter-poll delay are injected
+/// (<see cref="VoiceTurnRetryPolicy"/>), so the whole loop is unit tested off-device with a fake
+/// <see cref="IVoiceTurnChannel"/> and instant (no real wall-clock) delays.
+/// </summary>
+public sealed class VoiceTurnRunner
+{
+    private readonly IVoiceTurnChannel _channel;
+    private readonly VoiceTurnRetryPolicy _policy;
+
+    public VoiceTurnRunner(IVoiceTurnChannel channel, VoiceTurnRetryPolicy? policy = null)
+    {
+        _channel = channel;
+        _policy = policy ?? VoiceTurnRetryPolicy.Default;
+    }
+
+    /// <summary>
+    /// Submit the utterance to the Gateway, retrying a bounded number of times with backoff on
+    /// a transient failure so a drop mid-upload does not discard the clip. A terminal failure
+    /// (the Gateway answered but rejected the request) surfaces immediately; the last transient
+    /// failure surfaces only after the retry budget is spent.
+    /// </summary>
+    public async Task<VoiceTurnSubmitResult> SubmitAsync(
+        string gatewayBase, string sessionId, byte[] audio, string mime, CancellationToken ct = default)
+    {
+        ClientLog.Write($"[VoiceTurnRunner] Submit: sid={sessionId}, bytes={audio.Length}, mime={mime}, maxAttempts={_policy.SubmitAttempts}");
+        Exception? lastTransient = null;
+        for (var attempt = 1; attempt <= _policy.SubmitAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var result = await _channel.SubmitVoiceTurnAsync(gatewayBase, sessionId, audio, mime, ct);
+                ClientLog.Write($"[VoiceTurnRunner] Submit OK on attempt {attempt}: turnId={result.TurnId}");
+                return result;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex) when (IsTransientSubmit(ex))
+            {
+                lastTransient = ex;
+                ClientLog.Write($"[VoiceTurnRunner] Submit transient failure on attempt {attempt}/{_policy.SubmitAttempts}: {ex.Message}");
+                if (attempt < _policy.SubmitAttempts)
+                    await _policy.DelayAsync(_policy.BackoffFor(attempt), ct);
+            }
+        }
+
+        ClientLog.Write($"[VoiceTurnRunner] Submit FAILED after {_policy.SubmitAttempts} attempts: {lastTransient?.Message}");
+        throw new InvalidOperationException(
+            $"could not send your recording to the gateway after {_policy.SubmitAttempts} attempts - please try again",
+            lastTransient);
+    }
+
+    /// <summary>
+    /// Poll the Gateway until the turn reaches a terminal stage. Transient poll failures
+    /// (network error, 5xx, request timeout) are tolerated: the loop waits a backoff interval
+    /// and re-polls rather than throwing out. It gives up only at the overall deadline
+    /// (aligned with the Gateway job TTL) or on a terminal condition - the "error" stage, a
+    /// 410 (session gone), or a 404 (the cached turn expired -> a clean "please resend",
+    /// never an unhandled crash). <paramref name="onStage"/> fires once per distinct stage so
+    /// the caller can surface progress.
+    /// </summary>
+    public async Task<VoiceTurnPollResult> PollToCompletionAsync(
+        string gatewayBase, string sessionId, string turnId,
+        Action<VoiceTurnPollResult>? onStage = null, CancellationToken ct = default)
+    {
+        var deadline = _policy.UtcNow() + _policy.OverallDeadline;
+        ClientLog.Write($"[VoiceTurnRunner] Poll start: sid={sessionId}, turnId={turnId}, deadline={deadline:O}");
+
+        var lastStage = "";
+        var consecutiveTransient = 0;
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (_policy.UtcNow() >= deadline)
+            {
+                ClientLog.Write($"[VoiceTurnRunner] Poll deadline reached for turnId={turnId} (last stage='{lastStage}')");
+                throw new VoiceTurnTimeoutException(
+                    "the gateway did not finish this turn in time - please try again");
+            }
+
+            // The cadence: a steady interval while healthy, a growing backoff while a run of
+            // polls is failing. A success resets the run so we return to the steady cadence.
+            var wait = consecutiveTransient == 0
+                ? _policy.PollInterval
+                : _policy.BackoffFor(consecutiveTransient);
+            await _policy.DelayAsync(wait, ct);
+
+            VoiceTurnPollResult poll;
+            try
+            {
+                poll = await _channel.PollVoiceTurnAsync(gatewayBase, sessionId, turnId, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (VoiceTurnHttpException ex) when (ex.IsExpired)
+            {
+                // 404 after we held a valid turn id: the cached job expired (TTL) or is
+                // unknown. Terminal, but a clean "please resend" - not a crash.
+                ClientLog.Write($"[VoiceTurnRunner] Poll: turn {turnId} expired (404)");
+                throw new VoiceTurnExpiredException(
+                    "this turn has expired on the gateway - please record and send it again");
+            }
+            catch (VoiceTurnHttpException ex) when (ex.IsSessionGone)
+            {
+                ClientLog.Write($"[VoiceTurnRunner] Poll: session gone (410) for turnId={turnId}");
+                throw new InvalidOperationException("that session has exited");
+            }
+            catch (Exception ex) when (IsTransientPoll(ex))
+            {
+                consecutiveTransient++;
+                ClientLog.Write($"[VoiceTurnRunner] Poll transient failure #{consecutiveTransient} for turnId={turnId}: {ex.Message}");
+                continue;
+            }
+
+            consecutiveTransient = 0;
+
+            if (!string.Equals(poll.Stage, lastStage, StringComparison.Ordinal))
+            {
+                lastStage = poll.Stage;
+                onStage?.Invoke(poll);
+            }
+
+            if (string.Equals(poll.Stage, "error", StringComparison.Ordinal))
+            {
+                ClientLog.Write($"[VoiceTurnRunner] Poll terminal error for turnId={turnId}: {poll.Error}");
+                throw new InvalidOperationException($"gateway voice turn failed: {poll.Error ?? "unknown error"}");
+            }
+
+            if (string.Equals(poll.Stage, "reply", StringComparison.Ordinal))
+            {
+                ClientLog.Write($"[VoiceTurnRunner] Poll complete for turnId={turnId}");
+                return poll;
+            }
+        }
+    }
+
+    /// <summary>A transient submit failure is one the carrier signal caused, so a retry can
+    /// succeed: a bare network error, a 5xx, or a request timeout that is NOT the caller's
+    /// cancellation. A 4xx (other than the ones the runner treats terminally elsewhere) is the
+    /// Gateway rejecting the request and is not retried.</summary>
+    private static bool IsTransientSubmit(Exception ex) => ex switch
+    {
+        VoiceTurnHttpException http => http.IsServerError,
+        HttpRequestException => true,
+        TaskCanceledException => true, // request timeout (caller cancellation is filtered above)
+        _ => false,
+    };
+
+    /// <summary>Same classification as submit for the poll path. The expired (404) and
+    /// session-gone (410) cases are handled as terminal by the caller's catch clauses before
+    /// this is consulted.</summary>
+    private static bool IsTransientPoll(Exception ex) => ex switch
+    {
+        VoiceTurnHttpException http => http.IsServerError,
+        HttpRequestException => true,
+        TaskCanceledException => true,
+        _ => false,
+    };
+}

--- a/phone/CcDirectorClient/Voice/VoiceTurnTerminalExceptions.cs
+++ b/phone/CcDirectorClient/Voice/VoiceTurnTerminalExceptions.cs
@@ -1,0 +1,20 @@
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// The poll loop hit its overall deadline (aligned with the Gateway job TTL) without the turn
+/// reaching a terminal stage. Distinct from a transient drop (which is retried) - this means the
+/// turn genuinely did not finish in time, so the caller surfaces it as a clean "please try again".
+/// </summary>
+public sealed class VoiceTurnTimeoutException : Exception
+{
+    public VoiceTurnTimeoutException(string message) : base(message) { }
+}
+
+/// <summary>
+/// The Gateway returned 404 for a turn id we had already submitted: the cached job expired
+/// (10-minute TTL) or is unknown. A clean terminal "please resend" - never an unhandled crash.
+/// </summary>
+public sealed class VoiceTurnExpiredException : Exception
+{
+    public VoiceTurnExpiredException(string message) : base(message) { }
+}


### PR DESCRIPTION
## Release Notes
Phone voice turns now survive spotty data: a transient network drop on submit or poll no longer aborts the turn. The phone retries with backoff and keeps re-polling the Gateway's cached result until a terminal stage or a deadline aligned with the ~10-minute server job TTL.

## Changes
- New `VoiceTurnRunner` seam (`IVoiceTurnChannel` + injectable `VoiceTurnRetryPolicy`) holding the resilient submit-retry + poll-retry/backoff/deadline loop. MAUI-free and timer-free so it is unit-tested off-device with instant waits.
- Poll: transient failures (network error, 5xx, request timeout) back off and re-poll; gives up only at a ~10-min deadline or on a terminal stage.
- Classify transient vs terminal: `error` stage and `410 Gone` stop immediately; a `404` after holding a valid turn id is a clean `VoiceTurnExpiredException` ("please resend"), not a crash. `DirectorVoiceClient.PollVoiceTurnAsync` now throws a status-carrying `VoiceTurnHttpException`.
- Submit: bounded retry with backoff so a drop mid-upload does not discard the recorded clip.
- `VoiceConversation.SpeakTurnAsync` delegates its agent path to the runner (same stage callbacks + reply-audio playback).

## How to Test
```
cd phone
dotnet test CcDirectorClient.Tests/CcDirectorClient.Tests.csproj --filter VoiceTurnRunnerTests
```

## Expected Result
All 11 `VoiceTurnRunnerTests` pass. Test project builds with 0 warnings / 0 errors; the MAUI app project (`CcDirectorClient.csproj`) builds with 0 errors.

## Before/After
- Before: a single dropped poll or submit threw `HttpRequestException` straight out of `SpeakTurnAsync`, ending the turn even though the Gateway still held the answer cached.
- After: transient drops are tolerated via retry/backoff; only a terminal condition or the server-TTL deadline ends the turn, and an expired turn surfaces a clear "please resend".

Proof: docs/cencon/proof/issue-405/report.html

Note: the 5 pre-existing `ConductorStateTests` failures were verified to fail identically on clean `main` before this change - not a regression from #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)