### PR TITLE
Desktop UI cleanup: status screen, slim menus, panel toggles, four-tab Settings (#439)

### DIFF
--- a/docs/plans/home-status-redesign-mockup.html
+++ b/docs/plans/home-status-redesign-mockup.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CC Director - Home -> Status screen redesign (before / after)</title>
+<style>
+  :root{
+    --bg:#141414; --win:#1e1e1e; --rail:#1b1b1b; --panel:#242424; --panel2:#2a2a2a;
+    --border:#333; --hair:#343434; --text:#dcdcdc; --muted:#8a8a8a; --dim:#666;
+    --accent:#2563EB; --accentText:#3B82F6; --blue:#1f6feb;
+    --ok:#4CAF50; --warn:#F0B848; --bad:#E05656;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:#0f0f0f;color:var(--text);
+       font-family:"Segoe UI",system-ui,sans-serif;line-height:1.5;padding:30px}
+  h1{font-weight:300;letter-spacing:1px;text-align:center;font-size:24px;margin:0 0 4px}
+  h1 b{font-weight:600;color:#fff}
+  .lead{text-align:center;color:var(--muted);max-width:820px;margin:0 auto 26px;font-size:14px}
+  h2{font-size:12px;letter-spacing:2px;text-transform:uppercase;color:#9a9a9a;margin:34px 0 12px;
+     border-bottom:1px solid var(--border);padding-bottom:7px}
+  .tag{display:inline-block;font-size:11px;padding:2px 9px;border-radius:11px;margin-left:8px;vertical-align:middle}
+  .tag.before{background:#3a2424;color:#d99}
+  .tag.after{background:#23341f;color:#9d9}
+  .row{display:flex;gap:22px;flex-wrap:wrap;justify-content:center}
+  .cap{font-size:12.5px;color:var(--muted);text-align:center;margin:8px 0 0}
+  .cap b{color:#cdcdcd}
+
+  /* window frame */
+  .win{width:560px;background:var(--win);border:1px solid #000;border-radius:7px;overflow:hidden;
+       box-shadow:0 10px 30px rgba(0,0,0,.5)}
+  .titlebar{height:30px;background:#181818;display:flex;align-items:center;padding:0 10px;
+            font-size:12px;color:#bbb;border-bottom:1px solid #000}
+  .titlebar .dot{width:13px;height:13px;margin-right:7px;opacity:.8}
+  .titlebar .ctl{margin-left:auto;color:#777;letter-spacing:3px}
+  .menubar{height:28px;background:#1f1f1f;display:flex;align-items:center;gap:18px;
+           padding:0 12px;font-size:12.5px;color:#cfcfcf;border-bottom:1px solid #2a2a2a}
+  .body{display:flex;height:360px}
+
+  /* left rail */
+  .rail{width:188px;background:var(--rail);border-right:1px solid #2a2a2a;padding:10px;flex:0 0 188px;
+        display:flex;flex-direction:column}
+  .railspace{flex:1}
+  .gwbottom{margin-top:8px;border-top:1px solid #2a2a2a;padding-top:8px}
+  .newbtn{background:var(--accent);color:#fff;border-radius:6px;text-align:center;
+          padding:8px;font-size:13px;font-weight:600;margin-bottom:12px}
+  .gw{display:flex;align-items:center;gap:7px;font-size:12px;padding:6px 4px;border-radius:5px;
+      background:#202020;border:1px solid #2c2c2c;margin-bottom:10px}
+  .gw .led{width:11px;height:11px;border-radius:50%;flex:0 0 11px}
+  .gw.ok .led{background:var(--ok);box-shadow:0 0 6px #4CAF5066}
+  .gw.bad .led{background:var(--bad);box-shadow:0 0 6px #E0565666}
+  .gw.ok{color:#bfe6c4} .gw.bad{color:#e8b6b6;border-color:#4a2a2a;background:#241a1a}
+  .railhdr{font-size:10px;letter-spacing:1.5px;color:var(--dim);margin:6px 4px 6px}
+  .railempty{font-size:12px;color:var(--dim);padding:4px}
+  .srow{display:flex;align-items:center;gap:7px;font-size:12.5px;padding:7px 6px;border-radius:5px;color:#cdcdcd}
+  .srow.active{background:#243; background:#1d2b3a;color:#fff}
+  .srow .sled{width:8px;height:8px;border-radius:2px;flex:0 0 8px}
+
+  /* main area */
+  .main{flex:1;background:#1e1e1e;position:relative;display:flex;flex-direction:column}
+  .center{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;
+          text-align:center;padding:20px}
+  .brand{font-weight:300;letter-spacing:5px;color:#cfcfcf;font-size:20px;margin-bottom:14px}
+  .allgo{display:flex;align-items:center;gap:9px;font-size:15px;color:#bfe6c4;font-weight:600;margin-bottom:4px}
+  .allgo .led{width:13px;height:13px;border-radius:50%;background:var(--ok);box-shadow:0 0 8px #4CAF5077}
+  .subq{font-size:12.5px;color:var(--muted);margin-bottom:18px}
+  .ns{background:var(--accent);color:#fff;border-radius:6px;padding:9px 18px;font-size:13px;font-weight:600}
+  .hint{font-size:11.5px;color:var(--dim);margin-top:12px}
+
+  /* problem state */
+  .prob{align-items:stretch;justify-content:flex-start;text-align:left;padding:18px 22px}
+  .probhdr{display:flex;align-items:center;gap:8px;font-size:12px;letter-spacing:1.5px;
+           color:var(--warn);font-weight:700;margin-bottom:14px}
+  .pcard{background:#241a1a;border:1px solid #4a2a2a;border-left:3px solid var(--bad);border-radius:7px;
+         padding:12px 14px;margin-bottom:12px}
+  .pcard .t{font-size:13.5px;color:#f0c9c9;font-weight:600;display:flex;align-items:center;gap:8px}
+  .pcard .d{font-size:12px;color:var(--muted);margin-top:4px;display:flex;align-items:center;gap:10px}
+  .fix{border:1px solid var(--accent);color:var(--accentText);border-radius:5px;padding:2px 11px;font-size:11px}
+  .pnote{font-size:11.5px;color:var(--dim);margin-top:4px}
+
+  /* full-screen BEFORE recreation */
+  .fs{min-height:360px;display:flex;flex-direction:column;align-items:center;padding:22px 18px;overflow:auto}
+  .fs .brand{font-size:22px;letter-spacing:6px;margin-bottom:2px}
+  .fs .tagline{font-size:12px;color:var(--muted);margin-bottom:16px}
+  .fs .ns{margin-bottom:6px}
+  .fs .card{width:86%;background:var(--panel);border:1px solid var(--border);border-radius:8px;
+            padding:12px 14px;margin-top:12px}
+  .fs .gwcard{border-color:#2f5e38;background:#16241a}
+  .fs .gwcard .h{color:var(--ok);font-weight:700;font-size:13px}
+  .fs .gwcard .s{color:#8fb89a;font-size:11px}
+  .fs .ck{display:flex;align-items:center;font-size:12px;padding:5px 0}
+  .fs .ck .g{width:26px;font-weight:700}
+  .fs .ck .nm{width:90px;color:#ddd}
+  .fs .ck .dt{flex:1;color:var(--muted)}
+  .twocol{display:flex;gap:12px;width:86%;margin-top:12px}
+  .twocol .card{width:50%;margin-top:0}
+  .hd{font-size:10px;letter-spacing:1.5px;color:var(--dim);margin-bottom:6px}
+  .rr{font-size:12px;color:#cdcdcd;padding:4px 0;border-top:1px solid var(--hair);display:flex;justify-content:space-between}
+  .rr:first-of-type{border-top:0}
+  .strike{position:relative}
+  .badge{display:inline-block;background:#3a2424;color:#e0a0a0;font-size:10px;padding:1px 7px;border-radius:8px;margin-left:6px}
+
+  /* terminal mock */
+  .term{flex:1;margin:10px;background:#0e0e0e;border:1px solid #2a2a2a;border-radius:6px;
+        padding:10px;font-family:Consolas,monospace;font-size:11px;color:#bdbdbd}
+  .term .o{color:#e0795a}
+  .promptbar{display:flex;gap:8px;padding:0 10px 10px}
+  .promptbar .box{flex:1;background:#1e1e1e;border:1px solid #3c3c3c;border-radius:5px;
+                  padding:7px 9px;font-size:12px;color:var(--dim)}
+  .promptbar .b{background:var(--accent);color:#fff;border-radius:5px;padding:7px 12px;font-size:12px}
+  .tabrow{display:flex;gap:6px;align-items:center;padding:8px 10px;font-size:12px;color:#cfcfcf}
+  .tabrow .ttl{font-weight:600;color:#fff}
+  .tabrow .tabs{margin-left:auto;display:flex;gap:4px}
+  .tabrow .tb{background:#2563EB;color:#fff;border-radius:4px;padding:2px 9px;font-size:11px}
+  .tabrow .tb.off{background:#2a2a2a;color:#aaa}
+  .peek{position:absolute;right:10px;bottom:8px;font-size:11px;color:var(--dim)}
+</style>
+</head>
+<body>
+
+<h1>CC Director &mdash; <b>Home becomes a Status screen</b></h1>
+<p class="lead">
+  Stop the full-screen takeover. Keep the normal window chrome (left rail always present, with a live gateway light).
+  The main area shows a session's terminal when one is selected, or a <b>quiet status</b> when none is &mdash; loud
+  only when something is wrong. Recent/history leaves the local Director (moves to the Gateway).
+</p>
+
+<!-- ============ BEFORE ============ -->
+<h2>Before <span class="tag before">today: full-screen takeover, recent + quick actions, chrome hidden</span></h2>
+<div class="row">
+  <div>
+    <div class="win">
+      <div class="titlebar"><span class="dot">≪</span>CC Director<span class="ctl">&minus; □ ✕</span></div>
+      <div class="menubar"><span>File</span><span>Session</span><span>View</span><span>Help</span></div>
+      <div class="fs">
+        <div class="brand">CC DIRECTOR</div>
+        <div class="tagline">Let's finish setting up</div>
+        <div class="ns">+ New Session</div>
+        <div class="card gwcard"><div class="h">● GATEWAY CONNECTED</div><div class="s">two-way verified 13:25:39</div></div>
+        <div class="card">
+          <div class="hd">READINESS &nbsp;&nbsp; <span style="color:var(--warn)">1 of 2 ready</span></div>
+          <div class="ck"><span class="g" style="color:var(--ok)">OK</span><span class="nm">Agent CLIs</span><span class="dt">Claude Code, Pi, Codex, Gemini, OpenCode</span></div>
+          <div class="ck"><span class="g" style="color:var(--bad)">X</span><span class="nm">cc-* tools</span><span class="dt">0 of 32 on PATH</span></div>
+        </div>
+        <div class="twocol">
+          <div class="card">
+            <div class="hd">RECENT</div>
+            <div class="rr"><span>cc-director</span><span style="color:#555">6m</span></div>
+            <div class="rr"><span>cc-consult</span><span style="color:#555">1h</span></div>
+            <div class="rr"><span>private</span><span style="color:#555">3h</span></div>
+          </div>
+          <div class="card">
+            <div class="hd">QUICK ACTIONS</div>
+            <div class="rr" style="border:0">Open Cockpit</div>
+            <div class="rr" style="border:0">Tools</div>
+            <div class="rr" style="border:0">Settings</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="cap"><b>Problem:</b> takes over the whole window &bull; no rail/chrome &bull; carries Recent + Quick Actions (smarts that belong on the Gateway) &bull; shouts even when all is well</p>
+  </div>
+</div>
+
+<!-- ============ AFTER ============ -->
+<h2>After <span class="tag after">chrome kept &bull; status in main area &bull; quiet when healthy &bull; no recent</span></h2>
+<div class="row">
+
+  <!-- A. healthy, no session -->
+  <div>
+    <div class="win">
+      <div class="titlebar"><span class="dot">≪</span>CC Director<span class="ctl">&minus; □ ✕</span></div>
+      <div class="menubar"><span>File</span><span>Session</span><span>View</span><span>Help</span></div>
+      <div class="body">
+        <div class="rail">
+          <div class="newbtn">+ New Session</div>
+          <div class="railhdr">SESSIONS</div>
+          <div class="railempty">No sessions yet</div>
+          <div class="railspace"></div>
+          <div class="gw ok gwbottom"><span class="led"></span>Gateway connected</div>
+        </div>
+        <div class="main">
+          <div class="center">
+            <div class="brand">CC DIRECTOR</div>
+            <div class="allgo"><span class="led"></span>All systems go</div>
+            <div class="subq">Gateway connected &bull; 1 agent CLI ready</div>
+            <div class="ns">+ New Session</div>
+            <div class="hint">Pick a repo, or start a session.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="cap"><b>A &mdash; healthy, no session.</b> Rail stays; gateway light is green. Main area is a quiet "all good" + the one action. No cards, no recent.</p>
+  </div>
+
+  <!-- B. problem, no session -->
+  <div>
+    <div class="win">
+      <div class="titlebar"><span class="dot">≪</span>CC Director<span class="ctl">&minus; □ ✕</span></div>
+      <div class="menubar"><span>File</span><span>Session</span><span>View</span><span>Help</span></div>
+      <div class="body">
+        <div class="rail">
+          <div class="newbtn">+ New Session</div>
+          <div class="railhdr">SESSIONS</div>
+          <div class="railempty">No sessions yet</div>
+          <div class="railspace"></div>
+          <div class="gw bad gwbottom"><span class="led"></span>Gateway offline</div>
+        </div>
+        <div class="main">
+          <div class="center prob">
+            <div class="probhdr">⚠ NEEDS ATTENTION</div>
+            <div class="pcard">
+              <div class="t"><span style="color:var(--bad)">✕</span> Gateway not connected</div>
+              <div class="d">Last seen 13:02 <span class="fix">Reconnect</span></div>
+            </div>
+            <div class="pcard">
+              <div class="t"><span style="color:var(--bad)">✕</span> No agent CLI found</div>
+              <div class="d">Install Claude Code, Codex, Pi… <span class="fix">Fix</span></div>
+            </div>
+            <div class="pnote">Only failing checks appear here. When all pass, this screen goes quiet (state A).</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="cap"><b>B &mdash; a problem exists.</b> Rail light turns red; main area lists <i>only</i> what's broken, each with a fix action.</p>
+  </div>
+
+  <!-- C. session active -->
+  <div>
+    <div class="win">
+      <div class="titlebar"><span class="dot">≪</span>CC Director<span class="ctl">&minus; □ ✕</span></div>
+      <div class="menubar"><span>File</span><span>Session</span><span>View</span><span>Help</span></div>
+      <div class="body">
+        <div class="rail">
+          <div class="newbtn">+ New Session</div>
+          <div class="railhdr">SESSIONS</div>
+          <div class="srow active"><span class="sled" style="background:#4CAF50"></span>cc-director</div>
+          <div class="srow"><span class="sled" style="background:#888"></span>cc-consult</div>
+          <div class="railspace"></div>
+          <div class="gw ok gwbottom"><span class="led"></span>Gateway connected</div>
+        </div>
+        <div class="main">
+          <div class="tabrow"><span class="ttl">cc-director</span>
+            <span class="tabs"><span class="tb">Terminal</span><span class="tb off">Source Control</span></span></div>
+          <div class="term">Claude Code v2.1.177<br><span class="o">&gt;</span> _<br><br>bypass permissions on</div>
+          <div class="promptbar"><span class="box">Type a message...</span><span class="b">Send</span></div>
+          <div class="peek">click the ● dot or View ▸ Status to peek</div>
+        </div>
+      </div>
+    </div>
+    <p class="cap"><b>C &mdash; session open.</b> Main area is the terminal; status collapses to the rail's green dot. Get the full status back via the rail dot, View ▸ Status, or by deselecting the session &mdash; without closing it.</p>
+  </div>
+
+</div>
+
+<h2>Behavior summary</h2>
+<div class="lead" style="max-width:900px;text-align:left">
+  <ul style="line-height:1.8">
+    <li><b>Chrome always on.</b> The left rail (New Session, gateway light, session list) is present whether or not a session exists. No more full-window takeover.</li>
+    <li><b>Status = the main area when no session is selected.</b> Like VS Code's Welcome tab &mdash; it's not a mode, it's just what fills the pane when nothing else is focused.</li>
+    <li><b>Quiet when healthy, loud when not.</b> All-green = one line. Any failure = only the failing checks, with fixes.</li>
+    <li><b>Recent / history removed</b> from the local Director &mdash; that moves to the Gateway. Local keeps only must-haves.</li>
+    <li><b>Gateway indicator stays at the bottom of the rail</b> (unchanged from today) &mdash; glanceable health at all times. The full Status screen is summonable any time (View ▸ Status, or deselect the session) without closing your session.</li>
+  </ul>
+</div>
+
+</body>
+</html>

--- a/src/CcDirector.Avalonia/Controls/HomeView.axaml
+++ b/src/CcDirector.Avalonia/Controls/HomeView.axaml
@@ -3,182 +3,83 @@
              x:Class="CcDirector.Avalonia.Controls.HomeView"
              Background="#1E1E1E">
 
-    <UserControl.Styles>
-        <!-- Quick-action rows: flat, full-width, left-aligned text with a subtle hover. -->
-        <Style Selector="Button.homeQuickAction">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Foreground" Value="#CFCFCF" />
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="Padding" Value="0,7" />
-            <Setter Property="FontSize" Value="13" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="HorizontalContentAlignment" Value="Left" />
-        </Style>
-        <Style Selector="Button.homeQuickAction:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Foreground" Value="#FFFFFF" />
-        </Style>
-    </UserControl.Styles>
-
-    <!-- Full-screen empty-state home. Shown when this Director has zero sessions:
-         it is the "nothing is running, here is the state, start something" screen.
-         Only the window menu bar sits above it; the session rail and toolbar are
-         hidden by MainWindow while this is visible. Everything is painted from
-         code-behind off the live services (gateway, tools, key, version). -->
+    <!-- Status screen, shown in the main content area when no session is selected (or on
+         demand via View > Status). The window chrome (toolbar + session rail, with the
+         gateway indicator at the bottom of the rail) stays visible around it. It is quiet
+         when everything is healthy and only speaks up when something needs attention.
+         Painted from code-behind off the live services. -->
     <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                   VerticalScrollBarVisibility="Auto">
         <StackPanel HorizontalAlignment="Center"
-                    MaxWidth="760"
-                    Margin="24,44,24,28"
+                    VerticalAlignment="Center"
+                    MaxWidth="520"
+                    Margin="24,40"
                     Spacing="0">
 
-            <!-- Wordmark + tagline -->
+            <!-- Wordmark -->
             <TextBlock Text="CC DIRECTOR"
                        HorizontalAlignment="Center"
                        Foreground="#D6D6D6"
-                       FontSize="26" FontWeight="Light"
-                       LetterSpacing="7" />
-            <TextBlock x:Name="HomeTagline"
-                       Text="Mission critical for multiple agents"
+                       FontSize="24" FontWeight="Light"
+                       LetterSpacing="7"
+                       Margin="0,0,0,22" />
+
+            <!-- Healthy: quiet all-clear. Hidden when there is a problem. -->
+            <StackPanel x:Name="HomeAllClear" HorizontalAlignment="Center" Spacing="4">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
+                    <Ellipse Width="13" Height="13" Fill="#4CAF50" VerticalAlignment="Center" />
+                    <TextBlock Text="All systems go"
+                               Foreground="#BFE6C4"
+                               FontSize="16" FontWeight="SemiBold"
+                               VerticalAlignment="Center" />
+                </StackPanel>
+                <TextBlock x:Name="HomeAllClearSub"
+                           Text=""
+                           HorizontalAlignment="Center"
+                           Foreground="#888888"
+                           FontSize="12.5"
+                           Margin="0,0,0,4" />
+            </StackPanel>
+
+            <!-- Problem: needs-attention header + only the failing rows. Hidden when healthy. -->
+            <StackPanel x:Name="HomeProblems" IsVisible="False" Spacing="0">
+                <TextBlock Text="NEEDS ATTENTION"
+                           Foreground="#F0B848"
+                           FontSize="12" FontWeight="Bold" LetterSpacing="1.5"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,14" />
+                <!-- Rows injected from code-behind -->
+                <StackPanel x:Name="HomeStatusRows" Spacing="10" />
+            </StackPanel>
+
+            <!-- Busy placeholder while the readiness probe runs. -->
+            <TextBlock x:Name="HomeBusyText"
+                       Text="Checking..."
+                       IsVisible="False"
                        HorizontalAlignment="Center"
                        Foreground="#888888"
-                       FontSize="13" LetterSpacing="1"
-                       Margin="0,8,0,30" />
+                       FontSize="13" />
 
-            <!-- Hero: the single entry point. Always present; this is the first
-                 thing you do. -->
+            <!-- The single entry point. -->
             <Button x:Name="HomeNewSessionButton"
                     Click="HomeNewSessionButton_Click"
                     HorizontalAlignment="Center"
                     Background="{DynamicResource AccentBrush}"
                     Foreground="White"
                     BorderThickness="0"
-                    CornerRadius="10"
-                    Padding="56,20"
+                    CornerRadius="8"
+                    Padding="40,14"
+                    Margin="0,28,0,0"
                     Cursor="Hand"
                     ToolTip.Tip="Create a new session">
-                <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                    <Viewbox Width="17" Height="17">
+                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <Viewbox Width="15" Height="15">
                         <Path Fill="White" Data="M6,0 H8 V6 H14 V8 H8 V14 H6 V8 H0 V6 H6 Z" />
                     </Viewbox>
-                    <TextBlock Text="New Session" FontSize="19" FontWeight="SemiBold"
+                    <TextBlock Text="New Session" FontSize="16" FontWeight="SemiBold"
                                VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
-            <TextBlock x:Name="HomeHeroCaption"
-                       Text="Start a Claude session -- it's the first thing you do"
-                       HorizontalAlignment="Center"
-                       Foreground="#888888"
-                       FontSize="12"
-                       Margin="0,10,0,30" />
-
-            <!-- Gateway card (lifted from the old bottom-left indicator). Click opens
-                 the troubleshooter. Colours set from code-behind. -->
-            <Border x:Name="HomeGatewayCard"
-                    Background="#2A2A2A"
-                    BorderBrush="#3C3C3C" BorderThickness="1"
-                    CornerRadius="10"
-                    Padding="16,14"
-                    Cursor="Hand"
-                    Margin="0,0,0,18"
-                    PointerPressed="HomeGatewayCard_PointerPressed">
-                <DockPanel>
-                    <Border x:Name="HomeGatewayRing"
-                            DockPanel.Dock="Left"
-                            Width="34" Height="34" CornerRadius="17"
-                            BorderBrush="#777777" BorderThickness="4"
-                            VerticalAlignment="Center"
-                            Margin="0,0,14,0" />
-                    <Button x:Name="HomeGatewayFix"
-                            DockPanel.Dock="Right"
-                            Content="Fix it"
-                            Click="HomeGatewayFix_Click"
-                            VerticalAlignment="Center"
-                            Background="Transparent"
-                            BorderBrush="{DynamicResource AccentBrush}" BorderThickness="1"
-                            Foreground="#3B82F6"
-                            CornerRadius="5" Padding="12,4" FontSize="11"
-                            Cursor="Hand"
-                            IsVisible="False" />
-                    <StackPanel VerticalAlignment="Center" Spacing="2">
-                        <TextBlock x:Name="HomeGatewayLabel"
-                                   Text="NO GATEWAY"
-                                   Foreground="#777777"
-                                   FontSize="14" FontWeight="Bold" />
-                        <TextBlock x:Name="HomeGatewaySub"
-                                   Text="local-only Director"
-                                   Foreground="#888888"
-                                   FontSize="12" />
-                    </StackPanel>
-                </DockPanel>
-            </Border>
-
-            <!-- System status / readiness card -->
-            <Border Background="#2A2A2A"
-                    BorderBrush="#3C3C3C" BorderThickness="1"
-                    CornerRadius="10"
-                    Padding="18,16">
-                <StackPanel Spacing="0">
-                    <DockPanel Margin="0,0,0,4">
-                        <TextBlock x:Name="HomeStatusHeader"
-                                   Text="SYSTEM STATUS"
-                                   Foreground="#888888"
-                                   FontSize="11" FontWeight="SemiBold"
-                                   LetterSpacing="1.5" />
-                        <TextBlock x:Name="HomeStatusSummary"
-                                   DockPanel.Dock="Right"
-                                   HorizontalAlignment="Right"
-                                   Text=""
-                                   Foreground="#4CAF50"
-                                   FontSize="11" FontWeight="SemiBold" />
-                    </DockPanel>
-                    <!-- Rows injected from code-behind -->
-                    <StackPanel x:Name="HomeStatusRows" Spacing="0" />
-                </StackPanel>
-            </Border>
-
-            <!-- Recent repositories + Quick actions, side by side -->
-            <Grid ColumnDefinitions="*,16,*" Margin="0,18,0,0">
-
-                <!-- Recent: one row per repo, most recent first. Click launches a Claude
-                     session in that repo. Hidden entirely when there is no history. -->
-                <Border x:Name="HomeRecentCard"
-                        Grid.Column="0"
-                        Background="#2A2A2A"
-                        BorderBrush="#3C3C3C" BorderThickness="1"
-                        CornerRadius="10"
-                        Padding="18,16"
-                        VerticalAlignment="Top">
-                    <StackPanel Spacing="0">
-                        <TextBlock Text="RECENT"
-                                   Foreground="#888888"
-                                   FontSize="11" FontWeight="SemiBold"
-                                   LetterSpacing="1.5"
-                                   Margin="0,0,0,4" />
-                        <StackPanel x:Name="HomeRecentRows" Spacing="0" />
-                    </StackPanel>
-                </Border>
-
-                <!-- Quick actions: the same destinations the (hidden) toolbar offered. -->
-                <Border Grid.Column="2"
-                        Background="#2A2A2A"
-                        BorderBrush="#3C3C3C" BorderThickness="1"
-                        CornerRadius="10"
-                        Padding="18,16"
-                        VerticalAlignment="Top">
-                    <StackPanel Spacing="0">
-                        <TextBlock Text="QUICK ACTIONS"
-                                   Foreground="#888888"
-                                   FontSize="11" FontWeight="SemiBold"
-                                   LetterSpacing="1.5"
-                                   Margin="0,0,0,6" />
-                        <Button Classes="homeQuickAction" Click="HomeOpenCockpit_Click" Content="Open Cockpit" />
-                        <Button Classes="homeQuickAction" Click="HomeOpenTools_Click" Content="Tools" />
-                        <Button Classes="homeQuickAction" Click="HomeOpenSettings_Click" Content="Settings" />
-                    </StackPanel>
-                </Border>
-            </Grid>
 
             <!-- Version footer -->
             <TextBlock x:Name="HomeVersionText"
@@ -186,7 +87,7 @@
                        HorizontalAlignment="Center"
                        Foreground="#555555"
                        FontSize="11"
-                       Margin="0,22,0,0" />
+                       Margin="0,24,0,0" />
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/CcDirector.Avalonia/Controls/HomeView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/HomeView.axaml.cs
@@ -9,38 +9,25 @@ using CcDirector.Core.Utilities;
 
 namespace CcDirector.Avalonia.Controls;
 
-/// <summary>One row of the home page's Recent card: a repo you can re-open in one click.</summary>
-public sealed record RecentRepoItem(string Name, string RepoPath, string ColorHex, string When);
-
 /// <summary>
-/// Full-screen empty-state home page, shown by <see cref="MainWindow"/> when this
-/// Director has zero sessions. It is a passive view: MainWindow owns the services and
-/// pushes the gateway visual, readiness rows, tagline and version in; the view raises
-/// events back for the few actions it offers (new session, gateway troubleshooter,
-/// open Tools, open Settings).
+/// Status screen shown in the main content area when no session is selected (or on demand
+/// via View &gt; Status). The window chrome stays visible around it; the gateway indicator
+/// lives at the bottom of the session rail, not here. The screen is quiet when everything
+/// is healthy ("All systems go") and lists only the failing checks when something needs
+/// attention. MainWindow owns the services and pushes state in; the view raises events back
+/// for the few actions it offers.
 /// </summary>
 public partial class HomeView : UserControl
 {
     public event EventHandler? NewSessionRequested;
-    public event EventHandler? GatewayClicked;
     public event EventHandler? OpenToolsRequested;
     public event EventHandler? OpenSettingsRequested;
-    public event EventHandler? OpenCockpitRequested;
-    public event EventHandler<string>? RecentRepoSelected;
+    public event EventHandler? GatewayClicked;
 
     public HomeView()
     {
         InitializeComponent();
     }
-
-    private void HomeOpenCockpit_Click(object? sender, RoutedEventArgs e)
-        => OpenCockpitRequested?.Invoke(this, EventArgs.Empty);
-
-    private void HomeOpenTools_Click(object? sender, RoutedEventArgs e)
-        => OpenToolsRequested?.Invoke(this, EventArgs.Empty);
-
-    private void HomeOpenSettings_Click(object? sender, RoutedEventArgs e)
-        => OpenSettingsRequested?.Invoke(this, EventArgs.Empty);
 
     private void HomeNewSessionButton_Click(object? sender, RoutedEventArgs e)
     {
@@ -48,173 +35,75 @@ public partial class HomeView : UserControl
         NewSessionRequested?.Invoke(this, EventArgs.Empty);
     }
 
-    private void HomeGatewayCard_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        FileLog.Write("[HomeView] Gateway card clicked");
-        GatewayClicked?.Invoke(this, EventArgs.Empty);
-    }
-
-    private void HomeGatewayFix_Click(object? sender, RoutedEventArgs e)
-    {
-        FileLog.Write("[HomeView] Gateway Fix-it clicked");
-        GatewayClicked?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <summary>Switch the tagline between the healthy and the setup wording.</summary>
-    public void SetTagline(string text) => HomeTagline.Text = text;
-
     /// <summary>Paint the version footer (e.g. "v0.6.23 (e6f6af8)").</summary>
     public void SetVersion(string display) => HomeVersionText.Text = display;
 
-    /// <summary>
-    /// Paint the gateway card from values MainWindow already computes for the sidebar
-    /// indicator, so both surfaces always agree. <paramref name="showFix"/> reveals the
-    /// "Fix it" affordance for the error states only.
-    /// </summary>
-    public void SetGateway(string accentHex, string backgroundHex, string borderHex,
-                           string label, string sub, bool showFix)
-    {
-        HomeGatewayRing.BorderBrush = Brush.Parse(accentHex);
-        HomeGatewayCard.Background = Brush.Parse(backgroundHex);
-        HomeGatewayCard.BorderBrush = Brush.Parse(borderHex);
-        HomeGatewayLabel.Text = label;
-        HomeGatewayLabel.Foreground = Brush.Parse(accentHex);
-        HomeGatewaySub.Text = sub;
-        HomeGatewayFix.IsVisible = showFix;
-    }
-
-    /// <summary>
-    /// Render the readiness rows. <paramref name="healthy"/> drives the card header
-    /// (ALL GREEN vs N of M ready) and its colour.
-    /// </summary>
-    public void SetStatus(HomeStatus status, bool healthy)
-    {
-        HomeStatusHeader.Text = healthy ? "SYSTEM STATUS" : "READINESS";
-        HomeStatusSummary.Text = healthy ? "ALL GREEN" : $"{status.ReadyCount} of {status.TotalCount} ready";
-        HomeStatusSummary.Foreground = Brush.Parse(healthy ? "#4CAF50" : "#F0B848");
-
-        HomeStatusRows.Children.Clear();
-        var first = true;
-        foreach (var check in status.Checks)
-        {
-            HomeStatusRows.Children.Add(BuildRow(check, first));
-            first = false;
-        }
-    }
-
-    /// <summary>Show a single "Checking..." placeholder row while the async probe runs.</summary>
+    /// <summary>Show the "Checking..." placeholder while the async readiness probe runs.</summary>
     public void SetBusy()
     {
-        HomeStatusHeader.Text = "SYSTEM STATUS";
-        HomeStatusSummary.Text = "Checking...";
-        HomeStatusSummary.Foreground = Brush.Parse("#888888");
+        HomeBusyText.IsVisible = true;
+        HomeAllClear.IsVisible = false;
+        HomeProblems.IsVisible = false;
         HomeStatusRows.Children.Clear();
     }
 
     /// <summary>
-    /// Render the Recent card. Each row re-opens that repo in one click. Empty history
-    /// shows a quiet placeholder rather than an empty card.
+    /// Render the status. When <paramref name="healthy"/> the screen is quiet (all-clear line
+    /// + <paramref name="allClearSummary"/>); otherwise it lists only the failing checks, with
+    /// a gateway row first when <paramref name="gatewayError"/> is set.
     /// </summary>
-    public void SetRecent(IReadOnlyList<RecentRepoItem> recent)
+    public void SetStatus(HomeStatus status, bool healthy, bool gatewayError, string allClearSummary)
     {
-        HomeRecentRows.Children.Clear();
+        HomeBusyText.IsVisible = false;
+        HomeStatusRows.Children.Clear();
 
-        if (recent.Count == 0)
+        if (healthy)
         {
-            HomeRecentRows.Children.Add(new TextBlock
-            {
-                Text = "No recent repositories yet",
-                Foreground = Brush.Parse("#666666"),
-                FontSize = 12,
-                Margin = new global::Avalonia.Thickness(0, 7, 0, 0),
-            });
+            HomeAllClear.IsVisible = true;
+            HomeProblems.IsVisible = false;
+            HomeAllClearSub.Text = allClearSummary;
             return;
         }
 
-        var first = true;
-        foreach (var item in recent)
+        HomeAllClear.IsVisible = false;
+        HomeProblems.IsVisible = true;
+
+        // Gateway trouble is surfaced here too (its glanceable light is in the rail), so the
+        // status screen is a single place to see and fix everything that is wrong.
+        if (gatewayError)
+            HomeStatusRows.Children.Add(BuildProblemRow(
+                "Gateway not connected",
+                "The Gateway is unreachable or unverified.",
+                "Reconnect",
+                () => GatewayClicked?.Invoke(this, EventArgs.Empty)));
+
+        foreach (var check in status.Checks)
         {
-            HomeRecentRows.Children.Add(BuildRecentRow(item, first));
-            first = false;
+            if (check.Level == HomeCheckLevel.Ok) continue;
+            Action? fix = check.Action switch
+            {
+                HomeCheckAction.OpenTools => () => OpenToolsRequested?.Invoke(this, EventArgs.Empty),
+                HomeCheckAction.OpenSettings => () => OpenSettingsRequested?.Invoke(this, EventArgs.Empty),
+                _ => null,
+            };
+            HomeStatusRows.Children.Add(BuildProblemRow(
+                check.Title, check.Detail, fix is null ? null : "Fix", fix,
+                warn: check.Level == HomeCheckLevel.Warn));
         }
     }
 
-    private Control BuildRecentRow(RecentRepoItem item, bool first)
+    /// <summary>A single failing-check card: icon + title + detail, with an optional fix button.</summary>
+    private Control BuildProblemRow(string title, string detail, string? fixLabel, Action? onFix, bool warn = false)
     {
-        var swatch = new Border
-        {
-            Width = 9,
-            Height = 9,
-            CornerRadius = new global::Avalonia.CornerRadius(2),
-            Background = Brush.Parse(item.ColorHex),
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new global::Avalonia.Thickness(0, 0, 9, 0),
-        };
-        DockPanel.SetDock(swatch, Dock.Left);
+        var accent = warn ? "#F0B848" : "#E05656";
 
-        var when = new TextBlock
-        {
-            Text = item.When,
-            Foreground = Brush.Parse("#555555"),
-            FontSize = 11,
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new global::Avalonia.Thickness(8, 0, 0, 0),
-        };
-        DockPanel.SetDock(when, Dock.Right);
+        var dock = new DockPanel();
 
-        var name = new TextBlock
-        {
-            Text = item.Name,
-            Foreground = Brush.Parse("#CFCFCF"),
-            FontSize = 13,
-            VerticalAlignment = VerticalAlignment.Center,
-            TextTrimming = TextTrimming.CharacterEllipsis,
-        };
-
-        var row = new DockPanel();
-        row.Children.Add(swatch);
-        row.Children.Add(when);
-        row.Children.Add(name);
-
-        var button = new Button
-        {
-            Background = Brushes.Transparent,
-            BorderThickness = new global::Avalonia.Thickness(0),
-            Padding = new global::Avalonia.Thickness(0, 7),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Stretch,
-            Cursor = new Cursor(StandardCursorType.Hand),
-            Content = row,
-            BorderBrush = Brush.Parse("#343434"),
-        };
-        // Hairline above every row except the first.
-        if (!first)
-            button.BorderThickness = new global::Avalonia.Thickness(0, 1, 0, 0);
-        ToolTip.SetTip(button, $"Start a Claude session in {item.RepoPath}");
-        button.Click += (_, _) =>
-        {
-            FileLog.Write($"[HomeView] Recent repo selected: {item.RepoPath}");
-            RecentRepoSelected?.Invoke(this, item.RepoPath);
-        };
-        return button;
-    }
-
-    private Control BuildRow(HomeCheck check, bool first)
-    {
-        var (glyph, color) = check.Level switch
-        {
-            HomeCheckLevel.Ok => ("OK", "#4CAF50"),
-            HomeCheckLevel.Warn => ("!", "#F0B848"),
-            _ => ("X", "#E05656"),
-        };
-
-        var dock = new DockPanel { Margin = new global::Avalonia.Thickness(0, 8, 0, 8) };
-
-        if (check.Action != HomeCheckAction.None)
+        if (fixLabel is not null && onFix is not null)
         {
             var fix = new Button
             {
-                Content = "Fix it",
+                Content = fixLabel,
                 Cursor = new Cursor(StandardCursorType.Hand),
                 Background = Brushes.Transparent,
                 BorderBrush = Brush.Parse("#2563EB"),
@@ -225,65 +114,48 @@ public partial class HomeView : UserControl
                 FontSize = 11,
                 VerticalAlignment = VerticalAlignment.Center,
             };
-            var action = check.Action;
-            fix.Click += (_, _) => RaiseAction(action);
+            fix.Click += (_, _) => onFix();
             DockPanel.SetDock(fix, Dock.Right);
             dock.Children.Add(fix);
         }
 
         var icon = new TextBlock
         {
-            Text = glyph,
-            Foreground = Brush.Parse(color),
+            Text = warn ? "!" : "X",
+            Foreground = Brush.Parse(accent),
             FontWeight = FontWeight.Bold,
-            FontSize = 12,
-            Width = 28,
+            FontSize = 13,
+            Width = 24,
             VerticalAlignment = VerticalAlignment.Center,
         };
         DockPanel.SetDock(icon, Dock.Left);
         dock.Children.Add(icon);
 
-        var title = new TextBlock
+        var text = new StackPanel { Spacing = 2, VerticalAlignment = VerticalAlignment.Center };
+        text.Children.Add(new TextBlock
         {
-            Text = check.Title,
-            Foreground = Brush.Parse("#DDDDDD"),
-            FontSize = 13,
-            Width = 150,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        DockPanel.SetDock(title, Dock.Left);
-        dock.Children.Add(title);
-
-        var detail = new TextBlock
+            Text = title,
+            Foreground = Brush.Parse("#EDEDED"),
+            FontSize = 13.5,
+            FontWeight = FontWeight.SemiBold,
+        });
+        text.Children.Add(new TextBlock
         {
-            Text = check.Detail,
-            Foreground = Brush.Parse("#888888"),
+            Text = detail,
+            Foreground = Brush.Parse("#999999"),
             FontSize = 12,
             TextWrapping = TextWrapping.Wrap,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        dock.Children.Add(detail);
+        });
+        dock.Children.Add(text);
 
-        // Hairline separator above every row except the first.
         return new Border
         {
-            BorderBrush = Brush.Parse("#343434"),
-            BorderThickness = new global::Avalonia.Thickness(0, first ? 0 : 1, 0, 0),
+            Background = Brush.Parse(warn ? "#241f17" : "#241a1a"),
+            BorderBrush = Brush.Parse(warn ? "#4a3f22" : "#4a2a2a"),
+            BorderThickness = new global::Avalonia.Thickness(1),
+            CornerRadius = new global::Avalonia.CornerRadius(7),
+            Padding = new global::Avalonia.Thickness(14, 12),
             Child = dock,
         };
-    }
-
-    private void RaiseAction(HomeCheckAction action)
-    {
-        FileLog.Write($"[HomeView] Fix-it action: {action}");
-        switch (action)
-        {
-            case HomeCheckAction.OpenTools:
-                OpenToolsRequested?.Invoke(this, EventArgs.Empty);
-                break;
-            case HomeCheckAction.OpenSettings:
-                OpenSettingsRequested?.Invoke(this, EventArgs.Empty);
-                break;
-        }
     }
 }

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -28,6 +28,33 @@
         <Style Selector="Button.toolbarBtn:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="#2D2D30" />
         </Style>
+
+        <!-- Panel collapse/expand chevrons: a subtle vector chevron that brightens on
+             hover. Replaces the old "&lt;&lt;"/"&gt;&gt;" text toggles. Each chevron points
+             toward the edge its panel tucks into (left panel -> left, right panel -> right). -->
+        <Style Selector="Button.panelToggle">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Padding" Value="4,2" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+        </Style>
+        <Style Selector="Button.panelToggle Path">
+            <Setter Property="Stroke" Value="#888888" />
+        </Style>
+        <Style Selector="Button.panelToggle:pointerover Path">
+            <Setter Property="Stroke" Value="#E0E0E0" />
+        </Style>
+        <Style Selector="Button.panelToggle:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#3A3A3A" />
+            <Setter Property="CornerRadius" Value="4" />
+        </Style>
+
+        <!-- Collapsed-sidebar status dots: subtle border that brightens on hover. -->
+        <Style Selector="Button.slimDot:pointerover Border">
+            <Setter Property="BorderBrush" Value="#FFFFFF" />
+        </Style>
     </Window.Styles>
 
     <!-- The menu bar and toolbar span the full window width above the sidebar and
@@ -142,20 +169,20 @@
                      to the toolbar. -->
                 <Border DockPanel.Dock="Top" Padding="8,6">
                     <DockPanel>
-                        <!-- Collapse the sidebar to the slim status strip. -->
+                        <!-- Collapse the sidebar to the slim status strip. Chevron points
+                             left, toward the edge the panel tucks into. -->
                         <Button DockPanel.Dock="Right"
-                                Content="&lt;&lt;"
                                 Click="SidebarCollapse_Click"
                                 Focusable="False"
-                                Padding="6,1"
-                                Background="Transparent"
-                                Foreground="#AAAAAA"
-                                BorderThickness="0"
-                                Cursor="Hand"
-                                FontSize="11" FontWeight="Bold"
                                 VerticalAlignment="Center"
                                 ToolTip.Tip="Collapse the session panel"
-                                Classes="sessionMenuBtn" />
+                                Classes="panelToggle">
+                            <Viewbox Width="8" Height="12">
+                                <Path Data="M 7,2 L 3,7 L 7,12"
+                                      StrokeThickness="1.6"
+                                      StrokeLineCap="Round" StrokeJoin="Round" />
+                            </Viewbox>
+                        </Button>
                         <TextBlock Text="SESSIONS"
                                    Foreground="{DynamicResource TextForeground}"
                                    FontSize="12" FontWeight="Bold"
@@ -490,21 +517,21 @@
                  dots (clickable, tooltip = session name) and the expand button.
                  Toggled with SidebarFullPanel from code-behind. -->
             <DockPanel x:Name="SidebarSlimPanel" IsVisible="False">
+                <!-- Expand back to the full panel. Chevron points right, pulling the
+                     panel out from the left edge. -->
                 <Button DockPanel.Dock="Top"
-                        Content="&gt;&gt;"
                         Click="SidebarExpand_Click"
                         Focusable="False"
-                        Padding="0,4"
                         Margin="2,6,2,4"
                         HorizontalAlignment="Stretch"
-                        HorizontalContentAlignment="Center"
-                        Background="Transparent"
-                        Foreground="#AAAAAA"
-                        BorderThickness="0"
-                        Cursor="Hand"
-                        FontSize="11" FontWeight="Bold"
                         ToolTip.Tip="Expand the session panel"
-                        Classes="sessionMenuBtn" />
+                        Classes="panelToggle">
+                    <Viewbox Width="8" Height="12">
+                        <Path Data="M 3,2 L 7,7 L 3,12"
+                              StrokeThickness="1.6"
+                              StrokeLineCap="Round" StrokeJoin="Round" />
+                    </Viewbox>
+                </Button>
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                               VerticalScrollBarVisibility="Auto">
                     <ItemsControl x:Name="SlimSessionList" Margin="0,2">
@@ -514,12 +541,15 @@
                                         Background="Transparent"
                                         BorderThickness="0"
                                         Padding="0"
-                                        Margin="0,2"
+                                        Margin="0,3"
                                         HorizontalAlignment="Center"
                                         Cursor="Hand"
+                                        Classes="slimDot"
                                         ToolTip.Tip="{Binding DisplayName}">
-                                    <Border Width="16" Height="16"
-                                            CornerRadius="4"
+                                    <Border Width="18" Height="18"
+                                            CornerRadius="5"
+                                            BorderThickness="1"
+                                            BorderBrush="Transparent"
                                             Background="{Binding StatusColorBrush}" />
                                 </Button>
                             </DataTemplate>
@@ -652,7 +682,7 @@
         </Border>
 
         <!-- ==================== MAIN CONTENT + RIGHT PANEL ==================== -->
-        <Grid Grid.Row="1" Grid.Column="2" ColumnDefinitions="*,Auto,Auto">
+        <Grid Grid.Row="1" Grid.Column="2" ColumnDefinitions="*,Auto">
 
             <!-- Left: Terminal + Prompt -->
             <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto,Auto">
@@ -1226,27 +1256,28 @@
                 </Border>
             </Grid>
 
-            <!-- Right panel toggle button -->
-            <Button x:Name="RightPanelToggle"
-                    Grid.Column="1"
-                    Content="&lt;&lt;"
-                    Width="24"
-                    Background="#2D2D30"
-                    Foreground="#888888"
-                    BorderThickness="0"
-                    FontSize="10"
-                    Padding="0"
-                    VerticalContentAlignment="Center"
-                    HorizontalContentAlignment="Center"
-                    Click="RightPanelToggle_Click"
-                    ToolTip.Tip="Toggle right panel" />
-
             <!-- ==================== RIGHT PANEL ==================== -->
             <Border x:Name="RightPanel"
-                    Grid.Column="2"
+                    Grid.Column="1"
                     Width="280"
                     Background="{DynamicResource SidebarBackground}"
                     BorderBrush="#3C3C3C" BorderThickness="1,0,0,0">
+
+              <Grid>
+                <!-- Collapse chevron at the TOP-RIGHT of the panel header, mirroring the
+                     session rail's toggle. Points right (tuck into the right edge). -->
+                <Button HorizontalAlignment="Right" VerticalAlignment="Top"
+                        Margin="0,3,6,0"
+                        ZIndex="5"
+                        Classes="panelToggle"
+                        Click="RightPanelToggle_Click"
+                        ToolTip.Tip="Collapse the right panel">
+                    <Viewbox Width="8" Height="12">
+                        <Path Data="M 3,2 L 7,7 L 3,12"
+                              StrokeThickness="1.6"
+                              StrokeLineCap="Round" StrokeJoin="Round" />
+                    </Viewbox>
+                </Button>
 
                 <TabControl x:Name="RightPanelTabs"
                             Background="Transparent"
@@ -1458,6 +1489,29 @@
                     </TabItem>
 
                 </TabControl>
+              </Grid>
+            </Border>
+
+            <!-- Collapsed right panel: a thin strip on the right edge with the expand
+                 chevron at the TOP (mirrors the session rail's slim strip). Shown instead
+                 of the full panel when collapsed; the Auto column sizes to whichever is up. -->
+            <Border x:Name="RightPanelCollapsedStrip"
+                    Grid.Column="1"
+                    Width="22"
+                    IsVisible="False"
+                    Background="{DynamicResource SidebarBackground}"
+                    BorderBrush="#3C3C3C" BorderThickness="1,0,0,0">
+                <Button VerticalAlignment="Top" HorizontalAlignment="Center"
+                        Margin="0,8,0,0"
+                        Classes="panelToggle"
+                        Click="RightPanelToggle_Click"
+                        ToolTip.Tip="Expand the right panel">
+                    <Viewbox Width="8" Height="12">
+                        <Path Data="M 7,2 L 3,7 L 7,12"
+                              StrokeThickness="1.6"
+                              StrokeLineCap="Round" StrokeJoin="Round" />
+                    </Viewbox>
+                </Button>
             </Border>
         </Grid>
 
@@ -1635,14 +1689,13 @@
             </DockPanel>
         </Border>
 
-        <!-- ==================== HOME (empty-state) ====================
-             Full-screen home shown when this Director has zero sessions. It covers the
-             session rail and the content column (all rows/columns); MainWindow also
-             hides the toolbar while it is visible, so only the window menu bar shows
-             above it. Topmost child so it sits over everything; opaque background. -->
+        <!-- ==================== STATUS / HOME ====================
+             Status screen shown in the MAIN CONTENT cell (row 1, column 2) when no session
+             is selected, or on demand via View > Status. The window chrome - toolbar and the
+             session rail (with the gateway light at its bottom) - stays visible around it.
+             It overlays the terminal content (higher ZIndex) and has an opaque background. -->
         <controls:HomeView x:Name="HomeView"
-                           Grid.Row="0" Grid.RowSpan="2"
-                           Grid.Column="0" Grid.ColumnSpan="3"
+                           Grid.Row="1" Grid.Column="2"
                            ZIndex="30"
                            IsVisible="False" />
 

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -255,9 +255,7 @@ public partial class MainWindow : Window
         HomeView.NewSessionRequested += (_, _) => { FileLog.Write("[MainWindow] Home -> New Session"); _ = ShowNewSessionDialog(); };
         HomeView.OpenToolsRequested += (_, _) => BtnTools_Click(this, new RoutedEventArgs());
         HomeView.OpenSettingsRequested += (_, _) => BtnSettings_Click(this, new RoutedEventArgs());
-        HomeView.OpenCockpitRequested += (_, _) => BtnCockpit_Click(this, new RoutedEventArgs());
         HomeView.GatewayClicked += (_, _) => OpenGatewayTroubleshooter();
-        HomeView.RecentRepoSelected += (_, path) => { FileLog.Write($"[MainWindow] Home -> recent repo {path}"); _ = StartSessionInRepoAsync(path); };
         UpdateHomeVisibility();
 
         // Start session git status polling (15s interval)
@@ -532,12 +530,11 @@ public partial class MainWindow : Window
         tip += "\nClick to open the troubleshooter.";
         ToolTip.SetTip(GatewayIndicator, tip);
 
-        // Mirror the same gateway state onto the home-page card (shown at zero sessions),
-        // so both surfaces always agree. A missing gateway is NOT an error (legitimate
-        // local-only Director), so the Fix-it affordance shows for the error states only.
+        // The gateway light lives only in the rail now (GatewayIndicator, above). A missing
+        // gateway is NOT an error (legitimate local-only Director); only the failure states
+        // count against readiness and surface a problem row on the status screen.
         var gatewayError = m.Status is GatewayConnectionStatus.Failed or GatewayConnectionStatus.NoTailnetIdentity;
         _gatewayError = gatewayError;
-        HomeView.SetGateway(accent, bg, border, label, sub, gatewayError);
         ApplyHomeHealth();
 
         // #223: auto-pop the troubleshooter ONCE per distinct failure. A failure that
@@ -596,6 +593,18 @@ public partial class MainWindow : Window
     /// A simply-absent gateway is NOT an error - a local-only Director is legitimate.</summary>
     private bool _gatewayError;
 
+    /// <summary>True when the user asked to see the status screen (View &gt; Status) while a
+    /// session is open. Cleared the moment a session is selected, so the terminal returns.</summary>
+    private bool _statusRequested;
+
+    /// <summary>Show the status screen over the content area without closing any session.</summary>
+    private void ShowStatusView()
+    {
+        FileLog.Write("[MainWindow] ShowStatusView");
+        _statusRequested = true;
+        UpdateHomeVisibility();
+    }
+
     /// <summary>
     /// True when any full-content in-window overlay (Tools / Comms / Connections / Scheduler)
     /// is open. The Home page must not paint over an open overlay, so UpdateHomeVisibility
@@ -613,15 +622,15 @@ public partial class MainWindow : Window
     /// </summary>
     private void UpdateHomeVisibility()
     {
-        // Home covers the whole window at ZIndex 30; the content overlays (Tools/Comms/etc.)
-        // sit lower in the same grid. If Home paints while an overlay is open, the overlay is
-        // hidden behind it and its actions look dead (issue #447). So Home shows only at zero
-        // sessions AND when no overlay is up; opening/closing an overlay re-runs this method.
+        // The status screen sits in the main content cell (ZIndex 30, over the terminal). The
+        // window chrome - toolbar and session rail - stays visible around it. It shows when
+        // there are no sessions, or on demand (View > Status, _statusRequested). The content
+        // overlays (Tools/Comms/etc.) sit lower in the same cell; if the status screen paints
+        // over an open overlay its actions look dead (issue #447), so it yields while one is up.
         var overlayOpen = IsContentOverlayOpen();
-        var showHome = _sessions.Count == 0 && !overlayOpen;
-        MainToolbar.IsVisible = !showHome;
+        var showHome = (_sessions.Count == 0 || _statusRequested) && !overlayOpen;
         HomeView.IsVisible = showHome;
-        FileLog.Write($"[MainWindow] UpdateHomeVisibility: showHome={showHome}, sessions={_sessions.Count}, overlayOpen={overlayOpen}");
+        FileLog.Write($"[MainWindow] UpdateHomeVisibility: showHome={showHome}, sessions={_sessions.Count}, statusRequested={_statusRequested}, overlayOpen={overlayOpen}");
 
         if (!showHome) return;
 
@@ -666,10 +675,6 @@ public partial class MainWindow : Window
             _lastHomeStatus = HomeStatusBuilder.Build(facts.clis, facts.built, facts.total);
 
             ApplyHomeHealth();
-
-            // Recent repos are file I/O (a folder of history JSON), so load them off the UI thread too.
-            var recent = await Task.Run(BuildRecentRepos);
-            HomeView.SetRecent(recent);
         }
         catch (Exception ex)
         {
@@ -678,85 +683,21 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// The most recently used repositories, newest first, one per repo path. Drawn from the
-    /// session history store; the swatch reuses the colour of that repo's latest session.
-    /// </summary>
-    private List<FileViewerControls.RecentRepoItem> BuildRecentRepos()
-    {
-        var app = (App)global::Avalonia.Application.Current!;
-        return app.SessionHistoryStore.LoadAll()
-            .Where(e => !string.IsNullOrWhiteSpace(e.RepoPath))
-            .GroupBy(e => e.RepoPath, StringComparer.OrdinalIgnoreCase)
-            .Select(g => g.OrderByDescending(e => e.LastUsedAt).First())
-            .OrderByDescending(e => e.LastUsedAt)
-            .Take(5)
-            .Select(e => new FileViewerControls.RecentRepoItem(
-                RepoDisplayName(e.RepoPath),
-                e.RepoPath,
-                e.CustomColor is { } color && !string.IsNullOrWhiteSpace(color) ? color : "#3C3C3C",
-                RelativeTime.Ago(DateTimeOffset.UtcNow - e.LastUsedAt.ToUniversalTime())))
-            .ToList();
-    }
-
-    private static string RepoDisplayName(string repoPath)
-    {
-        var name = Path.GetFileName(repoPath.TrimEnd('\\', '/'));
-        return string.IsNullOrEmpty(name) ? repoPath : name;
-    }
-
-    /// <summary>
-    /// One-click launch from the home Recent card: start a Claude session in the given repo
-    /// with the configured defaults (no dialog). Mirrors the non-group, non-resume path of
-    /// <see cref="ShowNewSessionDialog"/>, including the missing-CLI preflight.
-    /// </summary>
-    private async Task StartSessionInRepoAsync(string repoPath)
-    {
-        FileLog.Write($"[MainWindow] StartSessionInRepoAsync: {repoPath}");
-        if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
-        {
-            await MessageBox.ShowAsync(this, "Folder not found",
-                $"This repository folder no longer exists:\n\n{repoPath}\n\nUse New Session to pick another.");
-            return;
-        }
-
-        var app = (App)global::Avalonia.Application.Current!;
-        var agent = CreateAgent(AgentKind.ClaudeCode);
-        var agentExe = agent.ExecutablePath;
-        if (ExecutableResolver.Resolve(agentExe) is null)
-        {
-            var (agentName, installHint) = AgentInstallInfo(AgentKind.ClaudeCode);
-            FileLog.Write($"[MainWindow] StartSessionInRepoAsync: {agentName} '{agentExe}' not found on PATH; aborting");
-            await MessageBox.ShowAsync(this, $"{agentName} is not installed",
-                $"CC Director could not find its command line tool.\n\nLooked for: {agentExe}\n\n{installHint}");
-            return;
-        }
-
-        var vm = CreateSession(repoPath, null, null, agent, SessionType.Developer);
-        if (vm == null)
-        {
-            FileLog.Write("[MainWindow] StartSessionInRepoAsync: CreateSession returned null");
-            await MessageBox.ShowAsync(this, "Could not start session",
-                _lastSessionCreateError ?? "See the Director log for details.");
-            return;
-        }
-
-        app.RepositoryRegistry?.MarkUsed(repoPath);
-        SaveSessionToHistory(vm);
-        FileLog.Write($"[MainWindow] StartSessionInRepoAsync: started session {vm.Session.Id} in {repoPath}");
-    }
-
-    /// <summary>
-    /// Combine the cached readiness with the live gateway state into the home's tagline and
-    /// status header. "Healthy" requires every check green AND the gateway not in an error
-    /// state. Cheap and idempotent: called after a refresh and on every gateway change.
+    /// Combine the cached readiness with the live gateway state into the status screen.
+    /// "Healthy" requires every check green AND the gateway not in an error state. When
+    /// healthy the screen is quiet (all-clear); otherwise it lists only the failing checks.
+    /// Cheap and idempotent: called after a refresh and on every gateway change.
     /// </summary>
     private void ApplyHomeHealth()
     {
         if (_lastHomeStatus is not { } status) return;
 
         var healthy = status.AllReady && !_gatewayError;
-        HomeView.SetTagline(healthy ? "Mission critical for multiple agents" : "Let's finish setting up");
-        HomeView.SetStatus(status, healthy);
+        var gw = GatewayIndicatorLabel.Text ?? "";
+        var summary = gw.Contains("CONNECTED", StringComparison.OrdinalIgnoreCase)
+            ? "Gateway connected - ready to work"
+            : "Ready to start a session";
+        HomeView.SetStatus(status, healthy, _gatewayError, summary);
     }
 
     private global::Avalonia.Threading.DispatcherTimer? _schedulerLeaderTimer;
@@ -1119,6 +1060,13 @@ public partial class MainWindow : Window
 
     private void SelectSession(SessionViewModel? vm)
     {
+        // Selecting a session returns to its terminal, dismissing an on-demand status view.
+        if (vm != null && _statusRequested)
+        {
+            _statusRequested = false;
+            HomeView.IsVisible = false;
+        }
+
         // Close overlays when switching to any session
         if (CommsOverlay.IsVisible)
         {
@@ -2620,12 +2568,21 @@ public partial class MainWindow : Window
         App AppRef() => global::Avalonia.Application.Current as App
             ?? throw new InvalidOperationException("Application.Current is not the CC Director App");
 
+        // Ruthless default menu (2026-06-15): only items known to work are visible by
+        // default. Anything experimental or not yet verified is gated behind alpha mode
+        // (AlphaMode.IsEnabled) rather than deleted, so it stays recoverable and can be
+        // un-gated once proven. The menu is rebuilt on AlphaMode.Changed.
+        var alpha = AlphaMode.IsEnabled;
         var menu = new NativeMenu();
 
         // ===== File =====
         var file = new NativeMenuItem("File") { Menu = new NativeMenu() };
         file.Menu.Items.Add(Item("New Session", () => BtnNewSession_Click(this, new RoutedEventArgs()),
             new KeyGesture(Key.N, KeyModifiers.Control)));
+        // Settings lives here so it is reachable from the Home (empty-state) page, where
+        // the session toolbar (which also has a Settings button) is hidden.
+        file.Menu.Items.Add(Item("Settings...", () => BtnSettings_Click(this, new RoutedEventArgs()),
+            new KeyGesture(Key.OemComma, KeyModifiers.Control)));
         file.Menu.Items.Add(new NativeMenuItemSeparator());
         file.Menu.Items.Add(Item("Save Workspace...", async () =>
         {
@@ -2652,33 +2609,6 @@ public partial class MainWindow : Window
             await CloseAllSessionsAsync();
         }));
         file.Menu.Items.Add(new NativeMenuItemSeparator());
-        file.Menu.Items.Add(Item("Open Sessions File", () =>
-        {
-            var filePath = AppRef().SessionStateStore.FilePath;
-            if (File.Exists(filePath))
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath)
-                    { UseShellExecute = true });
-            else
-                ShowNotification($"Sessions file not found: {filePath}");
-        }));
-        file.Menu.Items.Add(Item("Open History Folder", () =>
-        {
-            var folder = AppRef().SessionHistoryStore.FolderPath;
-            if (Directory.Exists(folder))
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                    { FileName = folder, UseShellExecute = true });
-            else
-                ShowNotification($"History folder not found: {folder}");
-        }));
-        file.Menu.Items.Add(Item("History in VS Code", () =>
-        {
-            var folder = AppRef().SessionHistoryStore.FolderPath;
-            if (Directory.Exists(folder))
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("code", $"\"{folder}\"")
-                    { UseShellExecute = true });
-            else
-                ShowNotification($"History folder not found: {folder}");
-        }));
         file.Menu.Items.Add(Item("Open Logs", () =>
         {
             var logDir = Path.GetDirectoryName(FileLog.CurrentLogPath);
@@ -2686,15 +2616,43 @@ public partial class MainWindow : Window
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                     { FileName = logDir, UseShellExecute = true });
         }));
+        if (alpha)
+        {
+            // Debug/utility file openers - useful for development, noise for users.
+            file.Menu.Items.Add(Item("Open Sessions File", () =>
+            {
+                var filePath = AppRef().SessionStateStore.FilePath;
+                if (File.Exists(filePath))
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath)
+                        { UseShellExecute = true });
+                else
+                    ShowNotification($"Sessions file not found: {filePath}");
+            }));
+            file.Menu.Items.Add(Item("Open History Folder", () =>
+            {
+                var folder = AppRef().SessionHistoryStore.FolderPath;
+                if (Directory.Exists(folder))
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                        { FileName = folder, UseShellExecute = true });
+                else
+                    ShowNotification($"History folder not found: {folder}");
+            }));
+            file.Menu.Items.Add(Item("History in VS Code", () =>
+            {
+                var folder = AppRef().SessionHistoryStore.FolderPath;
+                if (Directory.Exists(folder))
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("code", $"\"{folder}\"")
+                        { UseShellExecute = true });
+                else
+                    ShowNotification($"History folder not found: {folder}");
+            }));
+        }
         file.Menu.Items.Add(new NativeMenuItemSeparator());
         file.Menu.Items.Add(Item("Exit", Close));
         menu.Items.Add(file);
 
         // ===== Session =====
         var session = new NativeMenuItem("Session") { Menu = new NativeMenu() };
-        if (AlphaMode.IsEnabled) // Start FIFO is an alpha feature
-            session.Menu.Items.Add(Item("Start FIFO", () => BtnFifo_Click(this, new RoutedEventArgs())));
-        session.Menu.Items.Add(new NativeMenuItemSeparator());
         session.Menu.Items.Add(Item("Repositories...", async () =>
         {
             FileLog.Write("[MainWindow] Menu: Repositories");
@@ -2711,38 +2669,47 @@ public partial class MainWindow : Window
                 }
             }
         }));
-        session.Menu.Items.Add(Item("Accounts...", async () =>
+        if (alpha)
         {
-            FileLog.Write("[MainWindow] Menu: Accounts");
-            var dialog = new AccountsDialog(AppRef().ClaudeAccountStore);
-            await dialog.ShowDialog<bool?>(this);
-        }));
-        session.Menu.Items.Add(new NativeMenuItemSeparator());
-        session.Menu.Items.Add(Item("Show Reviews", async () =>
-        {
-            FileLog.Write("[MainWindow] Menu: Show Reviews");
-            var dialog = new TurnReviewDialog();
-            await dialog.ShowDialog(this);
-        }));
+            session.Menu.Items.Add(new NativeMenuItemSeparator());
+            session.Menu.Items.Add(Item("Start FIFO", () => BtnFifo_Click(this, new RoutedEventArgs())));
+            session.Menu.Items.Add(Item("Accounts...", async () =>
+            {
+                FileLog.Write("[MainWindow] Menu: Accounts");
+                var dialog = new AccountsDialog(AppRef().ClaudeAccountStore);
+                await dialog.ShowDialog<bool?>(this);
+            }));
+            session.Menu.Items.Add(Item("Show Reviews", async () =>
+            {
+                FileLog.Write("[MainWindow] Menu: Show Reviews");
+                var dialog = new TurnReviewDialog();
+                await dialog.ShowDialog(this);
+            }));
+        }
         menu.Items.Add(session);
 
         // ===== View =====
         var view = new NativeMenuItem("View") { Menu = new NativeMenu() };
+        view.Menu.Items.Add(Item("Status", ShowStatusView));
+        view.Menu.Items.Add(new NativeMenuItemSeparator());
         view.Menu.Items.Add(Item("Toggle Right Panel", () => RightPanelToggle_Click(this, new RoutedEventArgs())));
         view.Menu.Items.Add(Item("Reset Terminal View", () => TabBarRefreshButton_Click(this, new RoutedEventArgs())));
         menu.Items.Add(view);
 
-        // ===== Tools =====
-        var tools = new NativeMenuItem("Tools") { Menu = new NativeMenu() };
-        tools.Menu.Items.Add(Item("Communications", () => BtnComms_Click(this, new RoutedEventArgs())));
-        tools.Menu.Items.Add(Item("Connections", () => BtnConnections_Click(this, new RoutedEventArgs())));
-        tools.Menu.Items.Add(Item("Scheduler", () => BtnScheduler_Click(this, new RoutedEventArgs())));
-        tools.Menu.Items.Add(new NativeMenuItemSeparator());
-        tools.Menu.Items.Add(Item("Claude View...", () => BtnClaudeView_Click(this, new RoutedEventArgs())));
-        tools.Menu.Items.Add(Item("MCP Servers...", () => BtnMcpServers_Click(this, new RoutedEventArgs())));
-        tools.Menu.Items.Add(Item("Agent Templates...", () => BtnAgentTemplates_Click(this, new RoutedEventArgs())));
-        tools.Menu.Items.Add(Item("Claude Code Settings...", () => BtnClaudeConfig_Click(this, new RoutedEventArgs())));
-        menu.Items.Add(tools);
+        // ===== Tools (alpha only - none of these are verified working yet) =====
+        if (alpha)
+        {
+            var tools = new NativeMenuItem("Tools") { Menu = new NativeMenu() };
+            tools.Menu.Items.Add(Item("Communications", () => BtnComms_Click(this, new RoutedEventArgs())));
+            tools.Menu.Items.Add(Item("Connections", () => BtnConnections_Click(this, new RoutedEventArgs())));
+            tools.Menu.Items.Add(Item("Scheduler", () => BtnScheduler_Click(this, new RoutedEventArgs())));
+            tools.Menu.Items.Add(new NativeMenuItemSeparator());
+            tools.Menu.Items.Add(Item("Claude View...", () => BtnClaudeView_Click(this, new RoutedEventArgs())));
+            tools.Menu.Items.Add(Item("MCP Servers...", () => BtnMcpServers_Click(this, new RoutedEventArgs())));
+            tools.Menu.Items.Add(Item("Agent Templates...", () => BtnAgentTemplates_Click(this, new RoutedEventArgs())));
+            tools.Menu.Items.Add(Item("Claude Code Settings...", () => BtnClaudeConfig_Click(this, new RoutedEventArgs())));
+            menu.Items.Add(tools);
+        }
 
         // ===== Help =====
         var help = new NativeMenuItem("Help") { Menu = new NativeMenu() };
@@ -4479,18 +4446,10 @@ public partial class MainWindow : Window
         FileLog.Write("[MainWindow] RightPanelToggle_Click");
         _rightPanelExpanded = !_rightPanelExpanded;
 
-        if (_rightPanelExpanded)
-        {
-            RightPanel.IsVisible = true;
-            RightPanel.Width = 280;
-            RightPanelToggle.Content = "<<";
-        }
-        else
-        {
-            RightPanel.IsVisible = false;
-            RightPanel.Width = 0;
-            RightPanelToggle.Content = ">>";
-        }
+        // Full panel and the slim strip share the Auto column; swap which one is visible.
+        // The collapse chevron lives in the panel header; the expand chevron in the strip.
+        RightPanel.IsVisible = _rightPanelExpanded;
+        RightPanelCollapsedStrip.IsVisible = !_rightPanelExpanded;
     }
 
     // ==================== QUEUE ====================

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml
@@ -88,28 +88,6 @@
                    Margin="0,0,0,8" />
 
         <TabControl Grid.Row="2" x:Name="SettingsTabs" IsVisible="False">
-            <TabItem Header="Files">
-                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,14,0">
-                    <StackPanel Spacing="8" Margin="0,4,0,0">
-                        <TextBlock Classes="sectionTitle" Text="Screenshots" />
-                        <TextBlock Classes="hint" Text="Where phone-uploaded images are filed so a session can read them by path. On a Mac this must be set explicitly." />
-                        <Grid ColumnDefinitions="*,Auto,Auto">
-                            <TextBox x:Name="ScreenshotsDirBox" Grid.Column="0" Classes="settingsInput"
-                                     Watermark="e.g. /Users/username/Desktop" />
-                            <Button x:Name="DetectScreenshotsButton" Grid.Column="1" Classes="dialogButton"
-                                    Content="Detect" Margin="8,0,0,0"
-                                    ToolTip.Tip="Find the folder where this OS saves screenshots"
-                                    Click="BtnDetectScreenshots_Click" />
-                            <Button x:Name="BrowseButton" Grid.Column="2" Classes="dialogButton"
-                                    Content="Browse..." Margin="8,0,0,0"
-                                    Click="BtnBrowse_Click" />
-                        </Grid>
-                        <TextBlock x:Name="ScreenshotsStatus" Text="" Foreground="#888888"
-                                   FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0" IsVisible="False" />
-                    </StackPanel>
-                </ScrollViewer>
-            </TabItem>
-
             <TabItem Header="Gateway">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,14,0">
                     <StackPanel Spacing="8" Margin="0,4,0,0">
@@ -357,25 +335,23 @@
                 </Grid>
             </TabItem>
 
-            <TabItem Header="Voice">
+            <TabItem Header="Directories">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,14,0">
                     <StackPanel Spacing="8" Margin="0,4,0,0">
-                        <TextBlock Classes="sectionTitle" Text="Voice and dictation" />
-                        <TextBlock Classes="hint" Text="Local OpenAI key for when this Director runs standalone (not connected to a Gateway). The Speak / dictation feature transcribes your microphone with OpenAI; paste a key here to enable it on this machine. It is stored in this machine's CC Director config and is never sent to browsers." />
-                        <TextBlock Classes="hint" Text="When this Director is connected to a Gateway, the key is managed centrally in the Cockpit instead and this local field is ignored." />
-
-                        <TextBlock Classes="fieldLabel" Text="OpenAI API key" />
-                        <Grid ColumnDefinitions="*,Auto">
-                            <TextBox x:Name="OpenAiKeyBox" Grid.Column="0" Classes="settingsInput"
-                                     PasswordChar="*"
-                                     Watermark="sk-..." />
-                            <CheckBox x:Name="ShowKeyCheck" Grid.Column="1" Content="Show"
-                                      Foreground="#CCCCCC" Margin="8,0,0,0" VerticalAlignment="Center"
-                                      IsCheckedChanged="ShowKeyCheck_Changed"
-                                      ToolTip.Tip="Reveal the key text" />
+                        <TextBlock Classes="sectionTitle" Text="Screenshots" />
+                        <TextBlock Classes="hint" Text="Where phone-uploaded images are filed so a session can read them by path. On a Mac this must be set explicitly." />
+                        <Grid ColumnDefinitions="*,Auto,Auto">
+                            <TextBox x:Name="ScreenshotsDirBox" Grid.Column="0" Classes="settingsInput"
+                                     Watermark="e.g. /Users/username/Desktop" />
+                            <Button x:Name="DetectScreenshotsButton" Grid.Column="1" Classes="dialogButton"
+                                    Content="Detect" Margin="8,0,0,0"
+                                    ToolTip.Tip="Find the folder where this OS saves screenshots"
+                                    Click="BtnDetectScreenshots_Click" />
+                            <Button x:Name="BrowseButton" Grid.Column="2" Classes="dialogButton"
+                                    Content="Browse..." Margin="8,0,0,0"
+                                    Click="BtnBrowse_Click" />
                         </Grid>
-                        <TextBlock Classes="hint" Text="Create a key at platform.openai.com/api-keys." />
-                        <TextBlock x:Name="VoiceStatus" Text="" Foreground="#888888"
+                        <TextBlock x:Name="ScreenshotsStatus" Text="" Foreground="#888888"
                                    FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0" IsVisible="False" />
                     </StackPanel>
                 </ScrollViewer>
@@ -407,34 +383,28 @@
                 </ScrollViewer>
             </TabItem>
 
-            <TabItem Header="Advanced">
-                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,14,0">
-                    <StackPanel Spacing="8" Margin="0,4,0,0">
-                        <TextBlock Classes="sectionTitle" Text="Full config.json (read-only)" />
-                        <TextBlock Classes="hint" Text="Read-only view of the current CC Director config. Use the other tabs for safe edits." />
-                        <TextBox x:Name="RawConfigBox" IsReadOnly="True"
-                                 AcceptsReturn="True" TextWrapping="NoWrap"
-                                 MinHeight="360"
-                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                                 Background="#1E1E1E" Foreground="#888888"
-                                 BorderBrush="#3C3C3C" BorderThickness="1" Padding="8,6"
-                                 FontFamily="Cascadia Mono, Consolas, Courier New" FontSize="11" />
-                    </StackPanel>
-                </ScrollViewer>
-            </TabItem>
         </TabControl>
 
         <TextBlock x:Name="StatusText" Grid.Row="3"
                    Text="" Foreground="#888888" FontSize="11"
                    TextWrapping="Wrap" Margin="0,8,0,0" />
 
-        <StackPanel Grid.Row="4" Orientation="Horizontal"
-                    HorizontalAlignment="Right" Margin="0,12,0,0">
-            <Button x:Name="SaveButton" Classes="primaryButton" Content="Save and Close"
-                    IsDefault="True" Click="BtnSave_Click" />
-            <Button Content="Cancel" Classes="dialogButton" Width="100" Margin="8,0,0,0"
-                    IsCancel="True" Click="BtnClose_Click" />
-        </StackPanel>
+        <!-- Bottom row: Open config.json link on the left (replaces the old Advanced
+             read-only dump); Save / Cancel on the right. -->
+        <Grid Grid.Row="4" Margin="0,12,0,0" ColumnDefinitions="*,Auto">
+            <Button Grid.Column="0" x:Name="OpenConfigButton"
+                    Content="Open config.json"
+                    Background="Transparent" BorderThickness="0"
+                    Foreground="#3B82F6" Cursor="Hand"
+                    Padding="0" HorizontalAlignment="Left" VerticalAlignment="Center"
+                    ToolTip.Tip="Open the CC Director config.json in your default editor"
+                    Click="BtnOpenConfig_Click" />
+            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <Button x:Name="SaveButton" Classes="primaryButton" Content="Save and Close"
+                        IsDefault="True" Click="BtnSave_Click" />
+                <Button Content="Cancel" Classes="dialogButton" Width="100" Margin="8,0,0,0"
+                        IsCancel="True" Click="BtnClose_Click" />
+            </StackPanel>
+        </Grid>
     </Grid>
 </Window>

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using Avalonia.Platform.Storage;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Settings;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Avalonia;
@@ -42,7 +44,6 @@ public partial class SettingsDialog : Window
     private string _loadedCodexPath = "";
     private string _loadedGeminiPath = "";
     private string _loadedOpenCodePath = "";
-    private string _loadedOpenAiKey = "";
     private bool _loadedAlpha;
 
     public SettingsDialog() : this(null, 0, null) { }
@@ -66,7 +67,7 @@ public partial class SettingsDialog : Window
         FileLog.Write("[SettingsDialog] LoadAsync: reading config.json");
         try
         {
-            var (screenshots, url, advertised, token, claudePath, piPath, codexPath, geminiPath, openCodePath, openAiKey, raw) = await Task.Run(ReadConfigSnapshot);
+            var (screenshots, url, advertised, token, claudePath, piPath, codexPath, geminiPath, openCodePath) = await Task.Run(ReadConfigSnapshot);
 
             _loadedScreenshots = screenshots;
             _loadedGatewayUrl = url;
@@ -77,7 +78,6 @@ public partial class SettingsDialog : Window
             _loadedCodexPath = codexPath;
             _loadedGeminiPath = geminiPath;
             _loadedOpenCodePath = openCodePath;
-            _loadedOpenAiKey = openAiKey;
             _loadedAlpha = AlphaMode.IsEnabled;
 
             ScreenshotsDirBox.Text = screenshots;
@@ -89,9 +89,7 @@ public partial class SettingsDialog : Window
             CodexPathBox.Text = codexPath;
             GeminiPathBox.Text = geminiPath;
             OpenCodePathBox.Text = openCodePath;
-            OpenAiKeyBox.Text = openAiKey;
             AlphaFeaturesCheck.IsChecked = _loadedAlpha;
-            RawConfigBox.Text = raw;
 
             LoadToolPresets();
 
@@ -107,13 +105,12 @@ public partial class SettingsDialog : Window
         }
     }
 
-    /// <summary>Read config off the UI thread. Returns the current field values + pretty raw JSON.</summary>
-    private static (string Screenshots, string Url, string Advertised, string Token, string ClaudePath, string PiPath, string CodexPath, string GeminiPath, string OpenCodePath, string OpenAiKey, string Raw) ReadConfigSnapshot()
+    /// <summary>Read config off the UI thread. Returns the current field values.</summary>
+    private static (string Screenshots, string Url, string Advertised, string Token, string ClaudePath, string PiPath, string CodexPath, string GeminiPath, string OpenCodePath) ReadConfigSnapshot()
     {
         var root = CcDirectorConfigService.ReadRaw();
         var gateway = root["gateway"] as JsonObject;
         var agent = root["agent"] as JsonObject ?? root["Agent"] as JsonObject;
-        var voice = root["Voice"] as JsonObject ?? root["voice"] as JsonObject;
         var options = (global::Avalonia.Application.Current as App)?.SessionManager?.Options
             ?? (global::Avalonia.Application.Current as App)?.Options
             ?? new AgentOptions();
@@ -134,10 +131,8 @@ public partial class SettingsDialog : Window
         var codexPath = GetTool("codex_path", "CodexPath", options.CodexPath);
         var geminiPath = GetTool("gemini_path", "GeminiPath", options.GeminiPath);
         var openCodePath = GetTool("opencode_path", "OpenCodePath", options.OpenCodePath);
-        var openAiKey = Get(voice, "OpenAiKey");
-        var raw = root.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
 
-        return (screenshots, url, advertised, token, claudePath, piPath, codexPath, geminiPath, openCodePath, openAiKey, raw);
+        return (screenshots, url, advertised, token, claudePath, piPath, codexPath, geminiPath, openCodePath);
     }
 
     /// <summary>
@@ -219,7 +214,6 @@ public partial class SettingsDialog : Window
             var codexPath = CodexPathBox.Text?.Trim() ?? "";
             var geminiPath = GeminiPathBox.Text?.Trim() ?? "";
             var openCodePath = OpenCodePathBox.Text?.Trim() ?? "";
-            var openAiKey = OpenAiKeyBox.Text?.Trim() ?? "";
 
             // Build a patch with ONLY the sections the user changed, so we touch nothing else.
             var patch = new JsonObject();
@@ -258,10 +252,6 @@ public partial class SettingsDialog : Window
                 };
             }
 
-            var voiceChanged = openAiKey != _loadedOpenAiKey;
-            if (voiceChanged)
-                patch["Voice"] = new JsonObject { ["OpenAiKey"] = openAiKey };
-
             var alpha = AlphaFeaturesCheck.IsChecked == true;
             var alphaChanged = alpha != _loadedAlpha;
 
@@ -296,13 +286,7 @@ public partial class SettingsDialog : Window
             if (toolsChanged)
                 ApplyToolPathsToRunningOptions(claudePath, piPath, codexPath, geminiPath, openCodePath);
 
-            // Apply the key to the running options so Speak/dictation works without a restart.
-            // The dictation endpoint reads ResolveOpenAiKey() per connection off this same
-            // AgentOptions instance, so the Cockpit Speak button on this Director picks it up too.
-            if (voiceChanged)
-                ApplyOpenAiKeyToRunningOptions(openAiKey);
-
-            FileLog.Write($"[SettingsDialog] BtnSave_Click: saved sections={patch.Count}, gatewayChanged={gatewayChanged}, toolsChanged={toolsChanged}, voiceChanged={voiceChanged}, alphaChanged={alphaChanged}");
+            FileLog.Write($"[SettingsDialog] BtnSave_Click: saved sections={patch.Count}, gatewayChanged={gatewayChanged}, toolsChanged={toolsChanged}, alphaChanged={alphaChanged}");
 
             // Re-register with the gateway live so a URL/endpoint/token change takes effect now.
             if (gatewayChanged && _reapplyGateway is not null)
@@ -328,11 +312,7 @@ public partial class SettingsDialog : Window
             _loadedCodexPath = codexPath;
             _loadedGeminiPath = geminiPath;
             _loadedOpenCodePath = openCodePath;
-            _loadedOpenAiKey = openAiKey;
             _loadedAlpha = alpha;
-            RawConfigBox.Text = await Task.Run(() =>
-                CcDirectorConfigService.ReadRaw().ToJsonString(
-                    new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
 
             // Saved cleanly - closing the dialog is the user's confirmation it worked.
             FileLog.Write("[SettingsDialog] BtnSave_Click: saved; closing");
@@ -924,23 +904,22 @@ public partial class SettingsDialog : Window
         FileLog.Write($"[SettingsDialog] ApplyClaudePresetToRunningOptions: defaultArgs='{args}'");
     }
 
-    /// <summary>Reveal or mask the OpenAI key text. Default masked; "Show" reveals it for verification.</summary>
-    private void ShowKeyCheck_Changed(object? sender, RoutedEventArgs e)
-    {
-        OpenAiKeyBox.RevealPassword = ShowKeyCheck.IsChecked == true;
-    }
-
     /// <summary>
-    /// Push the entered OpenAI key onto the running AgentOptions so the voice mode and the
-    /// dictation pipeline pick it up immediately, without restarting the Director. An empty
-    /// box clears the key (the pipeline then falls back to the OPENAI_API_KEY environment
-    /// variable via <see cref="AgentOptions.ResolveOpenAiKey"/>).
+    /// Open the CC Director config.json in the OS default handler. If the file does not exist
+    /// yet (nothing has been saved on this machine), report it clearly instead of crashing.
     /// </summary>
-    private static void ApplyOpenAiKeyToRunningOptions(string openAiKey)
+    private void BtnOpenConfig_Click(object? sender, RoutedEventArgs e)
     {
-        FileLog.Write($"[SettingsDialog] ApplyOpenAiKeyToRunningOptions: key={(string.IsNullOrWhiteSpace(openAiKey) ? "<cleared>" : "<set>")}");
-        var options = CurrentOptions();
-        options.OpenAiKey = string.IsNullOrWhiteSpace(openAiKey) ? null : openAiKey;
+        var path = CcStorage.ConfigJson();
+        FileLog.Write($"[SettingsDialog] BtnOpenConfig_Click: {path}");
+        if (!File.Exists(path))
+        {
+            StatusText.Text = $"config.json not found yet at {path} - save a setting first to create it.";
+            return;
+        }
+
+        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(path)
+            { UseShellExecute = true });
     }
 
     /// <summary>The alpha-gated wake-word section follows the checkbox live (before Save).</summary>


### PR DESCRIPTION
Folds together this session's desktop UI cleanup, in three logical commits:

1. **Desktop chrome cleanup** - Home becomes a status screen in the content cell (chrome kept, gateway light in the rail, quiet-when-healthy, recent/quick-actions removed, View > Status); menu bar slimmed with experimental items alpha-gated + File > Settings; chevron panel toggles with a collapsed dot rail; right-panel toggle moved into the panel header (no dead middle column).
2. **feat(#439)** - Settings slimmed to four tabs (Gateway, Agents, Directories, Features), Voice + Advanced removed, Files renamed to Directories, Open config.json link. Closes #439.
3. **docs** - status-screen redesign before/after mockup.

Verified: full solution builds Release 0 warnings / 0 errors; live-checked on slot 5.