### PR TITLE
fix(desktop): move Director address to the app toolbar, out of the session header

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -75,9 +75,37 @@
                 BorderBrush="#3C3C3C" BorderThickness="0,0,0,1"
                 Padding="8,4">
             <DockPanel>
-                <!-- Right group: global destinations + Settings -->
+                <!-- Right group: this Director's identity + global destinations + Settings -->
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal"
                             Spacing="2" VerticalAlignment="Center">
+                    <!-- Director connection info (machine name + port + copy for agents).
+                         This identifies the WHOLE application's Director (its Control API
+                         address), so it belongs on the app-wide toolbar, not in the
+                         per-session blue header. Always visible, even with no session. -->
+                    <StackPanel x:Name="DirectorInfoPanel" Orientation="Horizontal"
+                                VerticalAlignment="Center" Margin="0,0,4,0">
+                        <TextBlock x:Name="DirectorInfoText"
+                                   Text="..."
+                                   Foreground="#CCCCCC"
+                                   FontSize="11"
+                                   FontFamily="Cascadia Mono,Consolas,monospace"
+                                   VerticalAlignment="Center" />
+                        <Button x:Name="BtnCopyDirectorInfo"
+                                Content="Copy"
+                                Click="BtnCopyDirectorInfo_Click"
+                                Margin="8,0,0,0"
+                                Padding="6,2"
+                                FontSize="11"
+                                Background="#2D2D30"
+                                Foreground="White"
+                                BorderThickness="0"
+                                Cursor="Hand"
+                                ToolTip.Tip="Copy Control API URL so other agents can reach this Director" />
+                    </StackPanel>
+
+                    <Border Width="1" Height="18" Background="#3C3C3C"
+                            Margin="6,0" VerticalAlignment="Center" />
+
                     <!-- Tools catalog -->
                     <Button x:Name="BtnTools" Classes="toolbarBtn"
                             Click="BtnTools_Click"
@@ -584,9 +612,11 @@
                      the window menu bar and toolbar. This bar now carries only the
                      per-session identity. -->
 
-                <!-- Per-session identity (fill). Toggled via SessionHeaderBanner in code. -->
+                <!-- Per-session identity (fill). Toggled via SessionHeaderBanner in code.
+                     The Director address moved to the app-wide toolbar (it identifies the
+                     whole application, not the selected session). -->
                 <Grid x:Name="SessionHeaderBanner"
-                      RowDefinitions="Auto,Auto,Auto"
+                      RowDefinitions="Auto,Auto"
                       IsVisible="False">
                 <!-- Row 0: Session name + badges + buttons -->
                 <DockPanel Grid.Row="0">
@@ -625,32 +655,8 @@
                     </Border>
                 </DockPanel>
 
-                <!-- Row 1: Director connection info (machine name + port + copy for agents) -->
-                <StackPanel x:Name="DirectorInfoPanel" Grid.Row="1"
-                            Orientation="Horizontal"
-                            HorizontalAlignment="Right"
-                            Margin="0,4,0,0">
-                    <TextBlock x:Name="DirectorInfoText"
-                               Text="..."
-                               Foreground="White"
-                               FontSize="10"
-                               FontFamily="Cascadia Mono,Consolas,monospace"
-                               VerticalAlignment="Center" />
-                    <Button x:Name="BtnCopyDirectorInfo"
-                            Content="Copy"
-                            Click="BtnCopyDirectorInfo_Click"
-                            Margin="8,0,0,0"
-                            Padding="6,2"
-                            FontSize="10"
-                            Background="#2D2D30"
-                            Foreground="White"
-                            BorderThickness="0"
-                            Cursor="Hand"
-                            ToolTip.Tip="Copy Control API URL so other agents can reach this Director" />
-                </StackPanel>
-
-                <!-- Row 2: GitHub remote links (only for GitHub Actions sessions) -->
-                <StackPanel x:Name="HeaderRemoteLinks" Grid.Row="2"
+                <!-- Row 1: GitHub remote links (only for GitHub Actions sessions) -->
+                <StackPanel x:Name="HeaderRemoteLinks" Grid.Row="1"
                             Orientation="Horizontal"
                             Margin="0,4,0,0"
                             IsVisible="False">

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -336,13 +336,48 @@ public partial class MainWindow : Window
         await dialog.ShowDialog<bool?>(this);
     }
 
+    private global::Avalonia.Threading.DispatcherTimer? _directorInfoTimer;
+
     private void InitDirectorInfo()
     {
         FileLog.Write("[MainWindow] InitDirectorInfo");
+        // The Director address lives on the always-visible app toolbar now, so it must
+        // resolve even though the Control API binds its port on a background task that may
+        // finish after the window loads. Set what we know now, then poll until the port is
+        // bound (it never changes once set), so the toolbar is never stuck on "...".
+        if (TrySetDirectorInfo())
+            return;
+
+        _directorInfoTimer = new global::Avalonia.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(500),
+        };
+        _directorInfoTimer.Tick += (_, _) =>
+        {
+            if (TrySetDirectorInfo())
+            {
+                _directorInfoTimer?.Stop();
+                _directorInfoTimer = null;
+            }
+        };
+        _directorInfoTimer.Start();
+    }
+
+    /// <summary>
+    /// Sets the toolbar Director address from the Control API port. Returns true once the
+    /// port is bound (a real value was written), false while it is still starting.
+    /// </summary>
+    private bool TrySetDirectorInfo()
+    {
         var app = global::Avalonia.Application.Current as App;
         var port = app?.ControlApiHost?.Port;
-        var portStr = port is > 0 ? port.Value.ToString() : "...";
-        DirectorInfoText.Text = $"{Environment.MachineName}:{portStr}";
+        if (port is > 0)
+        {
+            DirectorInfoText.Text = $"{Environment.MachineName}:{port.Value}";
+            return true;
+        }
+        DirectorInfoText.Text = $"{Environment.MachineName}:...";
+        return false;
     }
 
     private async void BtnCopyDirectorInfo_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## What

The Director's Control API address (`SOREN_NORTH:7881` + the **Copy** button) was rendered inside the **per-session blue header** (`SessionHeaderBanner` Row 1 in `MainWindow.axaml`).

That address identifies the **whole application's Director** — it's constant no matter which session you select, and the whole desktop window *is* one Director. Putting it in the session banner made it read as if it belonged to the selected session, and it disappeared entirely when no session was selected.

This moves it up to the **application-wide toolbar** (`MainToolbar`), on the right just before the `Tools | Cockpit | Settings` group, separated by a divider.

## Layout

```
Before:  [ New Session ] [ Start FIFO ] ............ [ Tools ] [ Cockpit ] | [ Settings ]
         (blue session header)  ...........  SOREN_NORTH:7881 [ Copy ]

After:   [ New Session ] [ Start FIFO ] ...  SOREN_NORTH:7881 [ Copy ] | [ Tools ] [ Cockpit ] | [ Settings ]
         (blue session header)  ...........  (session identity only)
```

## Changes

- `MainWindow.axaml`: `DirectorInfoPanel` (`DirectorInfoText` + `BtnCopyDirectorInfo`) moved from `SessionHeaderBanner` into `MainToolbar`'s right group, before `Tools`, with a divider. `SessionHeaderBanner` drops from three rows to two (name, remote links).
- `MainWindow.axaml.cs`: `InitDirectorInfo` now polls (500 ms) until the Control API port binds. The port starts on a background task, so an always-visible toolbar field would otherwise be stuck on `...`. New `TrySetDirectorInfo` helper.

Now always visible — even at zero sessions — so an agent can grab the Control API URL before any session exists.

## Verification

Built to slot 5 and launched via the `cc-director-launch` scheduled task. Captured with `PrintWindow` (the test Director was on the second monitor).

- App toolbar now shows `SOREN_NORTH:7883  Copy | Tools  Cockpit | Settings` (port 7883 = the slot-5 Control API, confirming the running binary).
- The blue session header no longer carries the address.
- `dotnet build`: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)