### PR TITLE
Fix SessionStateServices decoupling tests for green-ready behavior

### DIFF
--- a/src/CcDirector.Gateway.Tests/ControlApiHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/ControlApiHostTests.cs
@@ -177,6 +177,12 @@ public sealed class SessionStateServicesDecouplingTests
             // activity handler so StatusColor tracks ActivityState.
             var session = sm.CreatePipeModeSession(Path.GetTempPath());
 
+            // Simulate a session that has already taken its first turn. A brand-new session is
+            // painted green ("ready") at a turn-end by design - it is parked at its prompt, not
+            // needing you. This test exercises the genuine "needs you" RED path, which applies
+            // only once IsBrandNew has cleared (it clears when the first prompt is submitted).
+            session.IsBrandNew = false;
+
             // Drive the activity state the way TerminalStateDetector would (byte -> Working;
             // QuietThreshold of silence -> WaitingForInput). The wingman is the sole writer of
             // StatusColor; if it is running, the badge follows -- with no Control API bound.
@@ -233,6 +239,12 @@ public sealed class SessionStateServicesDecouplingTests
             host.StartSessionStateServices();
 
             var session = sm.CreatePipeModeSession(Path.GetTempPath());
+            // Past its brand-new "ready" (green) window - see the note in the test above; this
+            // asserts the genuine "needs you" red path. A pipe session starts already in
+            // WaitingForInput, so drive Working first to guarantee a real transition back into
+            // WaitingForInput fires the wingman handler (SetActivityState ignores same-state).
+            session.IsBrandNew = false;
+            session.ApplyTerminalActivityState(ActivityState.Working);
             session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
             Assert.Equal("red", session.StatusColor);
         }


### PR DESCRIPTION
## What

Fixes the two `SessionStateServicesDecouplingTests` that are currently **red on `main`** (`StateServices_DriveBadgeColour_WithoutAnyControlApiBind` and `StartSessionStateServices_IsIdempotent` — both assert `WaitingForInput => "red"` but get `"green"`).

## Root cause

The recent commit *"fix(wingman): start a new session green (ready), not red"* added a green-ready overlay in `SessionStatusWingman.ColorFor`:

```csharp
if (session.IsBrandNew && atTurnEnd)
    return (StatusColor.Green, "ready");
```

That is **correct production behavior**. The two tests predate it: they drive `ActivityState` directly on a freshly-created pipe session without clearing `IsBrandNew`, so the overlay returns green where they asserted red. The idempotent test had a second issue — a pipe session starts already in `WaitingForInput` and `SetActivityState` ignores same-state calls, so its lone `WaitingForInput` call was a no-op.

## Why it's test-only, not a product bug

`IsBrandNew` clears only when a real prompt is submitted (`SendInput` with CR/LF, or `SendTextAsync`), and `TerminalStateDetector` suppresses the byte→`Working` flip while brand-new. So `IsBrandNew && Working` is unreachable in production — the tests manufactured an impossible state.

## The fix (test-only)

- Both tests set `IsBrandNew = false` to simulate a session past its first turn, preserving their purpose: proving the "needs you" **red** path works with no Control API bind.
- The idempotent test drives `Working` first so the transition back to `WaitingForInput` actually fires the wingman handler.

**No production code changed.**

## Verification
- 3 `SessionStateServicesDecouplingTests` pass
- full 17-test `ControlApiHostTests` group passes
- 48 Core wingman / StatusColor tests pass (green-ready behavior stays covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)