### PR TITLE
feat(launcher): ship, auto-start, and self-update cc-launcher on all machines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,41 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------
+  # Job 1c2: Build the CC Launcher tray app (Windows)
+  # ---------------------------------------------------------------
+  # The always-on Windows tray launcher (issue #250): clean process parentage + a loopback REST API,
+  # supervises the Director, and self-updates in managed mode (docs/plans/cc-launcher.md). Ships to
+  # BOTH roles. AssemblyName is "cc-launcher", so the published single file is cc-launcher.exe; the
+  # create-release job renames it to the asset name the setup engine expects
+  # (ComponentRegistry.Launcher.WindowsAsset = cc-launcher-win-x64.exe).
+  build-launcher-win:
+    name: Build CC Launcher (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Publish Launcher tray app for Windows x64
+        # Framework-dependent: requires the .NET 10 ASP.NET Core + desktop runtime on the target.
+        run: >
+          dotnet publish src/CcDirector.Launcher/CcDirector.Launcher.csproj
+          -c Release -r win-x64 --self-contained false
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+
+      - name: Upload launcher artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: launcher-win
+          path: src/CcDirector.Launcher/bin/Release/net10.0-windows/win-x64/publish/cc-launcher.exe
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------
   # Job 1d: Build the CC Cockpit web app (Windows)
   # ---------------------------------------------------------------
   # Blazor Server web UI (port 7470) supervised by the Gateway service. Unlike the
@@ -330,6 +365,7 @@ jobs:
       - build-director-win
       - build-director-mac
       - build-gateway-win
+      - build-launcher-win
       - build-cockpit-win
       - build-python-bundle-win
       - build-python-bundle-mac
@@ -379,6 +415,9 @@ jobs:
           # Windows Gateway service (publish emits devthrottle-gateway.exe)
           cp release-artifacts/gateway-win/devthrottle-gateway.exe "$RELEASE_DIR/devthrottle-gateway-win-x64.exe"
 
+          # Windows Launcher tray app (publish emits cc-launcher.exe)
+          cp release-artifacts/launcher-win/cc-launcher.exe "$RELEASE_DIR/cc-launcher-win-x64.exe"
+
           # Windows Cockpit web app (already the zip name the engine expects)
           cp release-artifacts/cockpit-win/devthrottle-cockpit-win-x64.zip "$RELEASE_DIR/devthrottle-cockpit-win-x64.zip"
 
@@ -407,6 +446,7 @@ jobs:
             cc-director-win-x64.exe
             cc-director-mac-arm64.zip
             devthrottle-gateway-win-x64.exe
+            cc-launcher-win-x64.exe
             devthrottle-cockpit-win-x64.zip
             devthrottle-setup-win-x64.exe
             devthrottle-setup-cli-win-x64.exe

--- a/src/CcDirector.Cockpit/Components/Pages/DirectorDetail.razor
+++ b/src/CcDirector.Cockpit/Components/Pages/DirectorDetail.razor
@@ -156,6 +156,21 @@
                         }
                         <dt>Started</dt><dd title="@d.StartedAt">@RelativeTime(d.StartedAt) (up @Uptime(d.StartedAt))</dd>
                         <dt>Last seen</dt><dd title="@d.LastSeen">@RelativeTime(d.LastSeen)</dd>
+                        @* Terminal stream (WebSocket UPGRADE) verification - the path the Cockpit
+                           terminal uses, proven independently of plain HTTP reachability. *@
+                        <dt>Terminal stream</dt>
+                        @if (d.StreamVerifyError is not null)
+                        {
+                            <dd class="err" title="@d.StreamVerifyError">DOWN - WebSocket stream unreachable</dd>
+                        }
+                        else if (d.StreamVerifiedAt is { } sv)
+                        {
+                            <dd class="ok" title="@sv">OK (verified @RelativeTime(sv))</dd>
+                        }
+                        else
+                        {
+                            <dd class="dim">not verified</dd>
+                        }
                     </dl>
                 </section>
             </div>

--- a/src/CcDirector.Cockpit/Components/Pages/Directors.razor
+++ b/src/CcDirector.Cockpit/Components/Pages/Directors.razor
@@ -72,6 +72,13 @@
                             {
                                 <span class="warn" title="@err.Error">UNREACHABLE</span>
                             }
+                            else if (d.StreamVerifyError is not null)
+                            {
+                                @* Reachable over plain HTTP but the WebSocket UPGRADE path the
+                                   Cockpit terminal stream depends on is dead (the cross-machine
+                                   streaming failure). Distinct from a totally-unreachable Director. *@
+                                <span class="err" title="@d.StreamVerifyError">TERMINAL STREAM DOWN</span>
+                            }
                             else
                             {
                                 <span class="ok">OK</span>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Net.WebSockets;
 using System.Text;
+using System.Text.Json;
 using CcDirector.ControlApi.Chat;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
@@ -72,6 +74,46 @@ internal static class ControlEndpoints
             Nonce = nonce,
             Known = gatewayMonitor?.RecordCallback(nonce) ?? false,
         }));
+
+        // ===== Two-way handshake callback, WEBSOCKET leg =====
+        // The Gateway dials this to prove it can complete a WebSocket UPGRADE to this Director -
+        // the exact operation the Cockpit terminal stream depends on, and the one the plain GET
+        // /verify above does NOT exercise. A Director can pass /verify (plain HTTP/1.1) while the
+        // real stream path is dead (e.g. an h2-only proxy that cannot carry the upgrade, a blocked
+        // upgrade, a missing Tailscale Serve mapping). Mirrors /verify - echoes id + nonce so a
+        // wrong-process or token mismatch fails loudly - but over a real WS so a broken stream is
+        // caught at install/connect time instead of by a user staring at "stream lost,
+        // reconnecting...". Authenticated like /verify and the live stream.
+        app.MapGet("/verify-ws/{nonce}", async (string nonce, HttpContext ctx) =>
+        {
+            if (!ctx.WebSockets.IsWebSocketRequest)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await ctx.Response.WriteAsync("expected websocket upgrade");
+                return;
+            }
+            using var ws = await ctx.WebSockets.AcceptWebSocketAsync();
+            var dto = new VerifyCallbackDto
+            {
+                DirectorId = directorId,
+                Nonce = nonce,
+                Known = gatewayMonitor?.RecordCallback(nonce) ?? false,
+            };
+            try
+            {
+                var json = JsonSerializer.SerializeToUtf8Bytes(dto);
+                await ws.SendAsync(json, WebSocketMessageType.Text, endOfMessage: true, ctx.RequestAborted);
+                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "verify-ws complete", ctx.RequestAborted);
+            }
+            catch (OperationCanceledException)
+            {
+                // Client or server going away mid-probe. Normal; the Gateway treats it as a fail.
+            }
+            catch (WebSocketException ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /verify-ws/{nonce} socket dropped: {ex.Message}");
+            }
+        });
 
         // ===== HTML pages =====
         // The cards-grid Director (manager.html) is the default UI at "/" -- the

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -533,6 +533,13 @@ public sealed class GatewayClient : IDisposable
                 result.Verified = false;
                 summary = $"The Gateway's callback was answered by something that is not this Director (at {result.CallbackEndpoint})";
             }
+            // Stream leg (the Cockpit terminal path): HTTP control can be fully verified while the
+            // WebSocket UPGRADE the terminal needs is dead. Don't flip Verified (the advertise gate
+            // is HTTP-based, issue #197) - but record it loudly. result is stored as LastResult, so
+            // any director UI reading the monitor sees StreamOk/StreamError too.
+            if (result.Verified && !result.StreamOk && result.StreamError is not null)
+                FileLog.Write($"[GatewayClient] verify: HTTP callback OK but TERMINAL STREAM leg failed: {result.StreamError}");
+
             _monitor.CompleteHandshake(nonce, result, summary);
             return result;
         }

--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -48,6 +48,7 @@ public sealed class NoCrossMachineLoopbackGuardTests
         ["src/CcDirector.GatewayApp/SettingsWindow.axaml.cs"] = "Local settings UI references.",
         ["src/CcDirector.Launcher/DirectorSupervisor.cs"] = "Supervises a local Director over loopback.",
         ["src/CcDirector.Launcher/LauncherHost.cs"] = "Local launcher loopback bind.",
+        ["src/CcDirector.Launcher/Program.cs"] = "Self-update helper POSTs /shutdown + probes /healthz on the launcher's own loopback (same machine).",
         ["src/CcDirector.Cockpit/Program.cs"] = "Cockpit child binds loopback; fronted by the Gateway.",
 
         // --- Loopback DETECTION / classification / labelling (the no-loopback policy itself) ---

--- a/src/CcDirector.Gateway.Contracts/DirectorDto.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorDto.cs
@@ -64,6 +64,24 @@ public sealed class DirectorDto
     /// </summary>
     public DateTime? TwoWayVerifiedAt { get; set; }
 
+    /// <summary>
+    /// UTC timestamp of the last PASSING stream-leg verification: the Gateway completed a real
+    /// WebSocket UPGRADE to this Director's /verify-ws callback - the same path the Cockpit
+    /// terminal stream uses. Distinct from <see cref="TwoWayVerifiedAt"/> (plain HTTP only): a
+    /// Director can pass the HTTP handshake while terminal streaming is dead (the exact remote
+    /// streaming failure). Null = stream not proven for this registration (resets on
+    /// re-register). Server-side stamp.
+    /// </summary>
+    public DateTime? StreamVerifiedAt { get; set; }
+
+    /// <summary>
+    /// Why the last stream-leg verification FAILED (WebSocket upgrade rejected, blocked, wrong
+    /// process...). Null while the stream path is proven OR while it is untested - a Director
+    /// that predates the /verify-ws endpoint leaves BOTH <see cref="StreamVerifiedAt"/> and this
+    /// null (unknown), distinct from a non-null error (a real, tested failure). Server-side stamp.
+    /// </summary>
+    public string? StreamVerifyError { get; set; }
+
     /// <summary>Value of <see cref="AdvertisedEndpointState"/> when the last probe answered as this Director.</summary>
     public const string EndpointStateOk = "ok";
 

--- a/src/CcDirector.Gateway.Contracts/DirectorVerification.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorVerification.cs
@@ -47,6 +47,24 @@ public sealed class DirectorVerifyResultDto
     /// <summary>Round-trip time of the callback leg in milliseconds.</summary>
     public long CallbackLatencyMs { get; set; }
 
+    /// <summary>
+    /// Leg 3 (stream): did a real WebSocket UPGRADE to {endpoint}/verify-ws/{nonce} succeed and
+    /// echo the right Director id? This is the path the Cockpit terminal stream uses, so it can
+    /// fail even when <see cref="CallbackOk"/> (plain HTTP) passes. False when the leg failed OR
+    /// when it was not applicable (old Director without the endpoint - see <see cref="StreamError"/>).
+    /// </summary>
+    public bool StreamOk { get; set; }
+
+    /// <summary>
+    /// Why leg 3 failed, OR a benign note that it was not tested (a Director predating /verify-ws).
+    /// Null when the stream leg passed. The Gateway only stamps <see cref="DirectorDto.StreamVerifyError"/>
+    /// for a REAL failure, never for "not applicable", so an old Director reads as unknown, not broken.
+    /// </summary>
+    public string? StreamError { get; set; }
+
+    /// <summary>Round-trip time of the stream (WebSocket upgrade) leg in milliseconds.</summary>
+    public long StreamLatencyMs { get; set; }
+
     /// <summary>Gateway UTC time the verdict was produced.</summary>
     public DateTime VerifiedAt { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/TwoWayVerifyTests.cs
+++ b/src/CcDirector.Gateway.Tests/TwoWayVerifyTests.cs
@@ -128,6 +128,74 @@ public sealed class TwoWayVerifyTests : IAsyncLifetime
         Assert.NotNull(_gateway.Registry.Get(id)!.TwoWayVerifiedAt);
     }
 
+    // ===== Stream leg (the Cockpit terminal WebSocket path) =====
+
+    [Fact]
+    public async Task Verify_HappyPath_AlsoStampsStreamVerifiedAt()
+    {
+        // The whole point of the fix: the WebSocket UPGRADE leg is verified end to end, not just
+        // plain HTTP. A Director that can complete the upgrade stamps StreamVerifiedAt.
+        var id = Guid.NewGuid().ToString();
+        var monitor = new GatewayConnectionMonitor();
+        await using var callback = new CallbackHost(id, monitor, StreamLeg.Echo);
+        await callback.StartAsync();
+        await RegisterDirectorAsync(callback.BaseUrl, id);
+
+        var resp = await _http.PostAsJsonAsync($"directors/{id}/verify", new DirectorVerifyRequest { Nonce = "n-stream-ok" });
+        var verdict = await resp.Content.ReadFromJsonAsync<DirectorVerifyResultDto>();
+
+        Assert.NotNull(verdict);
+        Assert.True(verdict!.Verified);
+        Assert.True(verdict.StreamOk);
+        Assert.Null(verdict.StreamError);
+        Assert.NotNull(_gateway.Registry.Get(id)!.StreamVerifiedAt);
+        Assert.Null(_gateway.Registry.Get(id)!.StreamVerifyError);
+    }
+
+    [Fact]
+    public async Task Verify_HttpOkButStreamRejected_StampsStreamError_NotGreen()
+    {
+        // The exact remote-streaming failure mode: plain HTTP verifies, but the WebSocket UPGRADE
+        // the terminal needs fails. The HTTP verdict stays true (control still works) but the
+        // stream leg is recorded as a REAL failure so the Cockpit can paint TERMINAL STREAM DOWN.
+        var id = Guid.NewGuid().ToString();
+        var monitor = new GatewayConnectionMonitor();
+        await using var callback = new CallbackHost(id, monitor, StreamLeg.Reject);
+        await callback.StartAsync();
+        await RegisterDirectorAsync(callback.BaseUrl, id);
+
+        var resp = await _http.PostAsJsonAsync($"directors/{id}/verify", new DirectorVerifyRequest { Nonce = "n-stream-bad" });
+        var verdict = await resp.Content.ReadFromJsonAsync<DirectorVerifyResultDto>();
+
+        Assert.NotNull(verdict);
+        Assert.True(verdict!.Verified);        // HTTP control leg is fine
+        Assert.False(verdict.StreamOk);        // but the terminal stream is not
+        Assert.NotNull(verdict.StreamError);
+        Assert.NotNull(_gateway.Registry.Get(id)!.StreamVerifyError);
+        Assert.Null(_gateway.Registry.Get(id)!.StreamVerifiedAt);
+    }
+
+    [Fact]
+    public async Task Verify_OldDirectorWithoutStreamEndpoint_StaysUnknown_NotBroken()
+    {
+        // A Director predating /verify-ws answers 404 on the upgrade. That is "untestable", NOT a
+        // failure - both stream fields stay null so the UI shows unknown, never a false red.
+        var id = Guid.NewGuid().ToString();
+        var monitor = new GatewayConnectionMonitor();
+        await using var callback = new CallbackHost(id, monitor, StreamLeg.Missing);
+        await callback.StartAsync();
+        await RegisterDirectorAsync(callback.BaseUrl, id);
+
+        var resp = await _http.PostAsJsonAsync($"directors/{id}/verify", new DirectorVerifyRequest { Nonce = "n-stream-old" });
+        var verdict = await resp.Content.ReadFromJsonAsync<DirectorVerifyResultDto>();
+
+        Assert.NotNull(verdict);
+        Assert.True(verdict!.Verified);
+        Assert.False(verdict.StreamOk);
+        Assert.Null(_gateway.Registry.Get(id)!.StreamVerifiedAt);
+        Assert.Null(_gateway.Registry.Get(id)!.StreamVerifyError); // untested != failed
+    }
+
     // ===== Full client loop: register -> automatic handshake -> monitor verdict =====
 
     [Fact]
@@ -235,13 +303,15 @@ public sealed class TwoWayVerifyTests : IAsyncLifetime
     {
         private readonly string _directorId;
         private readonly GatewayConnectionMonitor _monitor;
+        private readonly StreamLeg _streamLeg;
         private WebApplication? _app;
         public string BaseUrl { get; private set; } = "";
 
-        public CallbackHost(string directorId, GatewayConnectionMonitor monitor)
+        public CallbackHost(string directorId, GatewayConnectionMonitor monitor, StreamLeg streamLeg = StreamLeg.Echo)
         {
             _directorId = directorId;
             _monitor = monitor;
+            _streamLeg = streamLeg;
         }
 
         public async Task StartAsync()
@@ -253,12 +323,37 @@ public sealed class TwoWayVerifyTests : IAsyncLifetime
             builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, port));
             builder.Logging.ClearProviders();
             _app = builder.Build();
+            _app.UseWebSockets();
             _app.MapGet("/verify/{nonce}", (string nonce) => Results.Json(new VerifyCallbackDto
             {
                 DirectorId = _directorId,
                 Nonce = nonce,
                 Known = _monitor.RecordCallback(nonce),
             }));
+
+            // Mirror ControlEndpoints' /verify-ws WS echo so the Gateway's stream-leg probe has a
+            // real upgrade to complete. StreamLeg controls the failure shape under test:
+            //   Echo    - accept the WS, echo id+nonce (the fixed, working stream path)
+            //   Missing - no route at all -> 404 (an OLD Director without the endpoint: "untestable")
+            //   Reject  - route exists but refuses the upgrade with 500 (a real, tested stream failure)
+            if (_streamLeg == StreamLeg.Echo)
+            {
+                _app.MapGet("/verify-ws/{nonce}", async (string nonce, HttpContext ctx) =>
+                {
+                    if (!ctx.WebSockets.IsWebSocketRequest) { ctx.Response.StatusCode = 400; return; }
+                    using var ws = await ctx.WebSockets.AcceptWebSocketAsync();
+                    var dto = new VerifyCallbackDto { DirectorId = _directorId, Nonce = nonce, Known = _monitor.RecordCallback(nonce) };
+                    var json = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(dto);
+                    await ws.SendAsync(json, System.Net.WebSockets.WebSocketMessageType.Text, endOfMessage: true, ctx.RequestAborted);
+                    await ws.CloseAsync(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, "done", ctx.RequestAborted);
+                });
+            }
+            else if (_streamLeg == StreamLeg.Reject)
+            {
+                _app.MapGet("/verify-ws/{nonce}", () => Results.StatusCode(StatusCodes.Status500InternalServerError));
+            }
+            // StreamLeg.Missing: deliberately map nothing -> the upgrade gets a 404.
+
             await _app.StartAsync();
         }
 
@@ -267,6 +362,9 @@ public sealed class TwoWayVerifyTests : IAsyncLifetime
             if (_app is not null) await _app.DisposeAsync();
         }
     }
+
+    /// <summary>How a <see cref="CallbackHost"/> answers the stream-leg (/verify-ws) probe.</summary>
+    private enum StreamLeg { Echo, Missing, Reject }
 
     /// <summary>
     /// A gateway that accepts registration and FABRICATES a passing verify verdict

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -313,6 +313,24 @@ internal static class GatewayEndpoints
             var (ok, error) = await client.VerifyCallbackAsync(endpoint, id, req.Nonce, ct);
             sw.Stop();
 
+            // Leg 3 (stream): prove the WebSocket UPGRADE path the Cockpit terminal stream uses -
+            // the leg that was silently broken cross-machine while plain HTTP verify stayed green.
+            // Only run it when the HTTP callback already reached the right Director: if leg 2
+            // failed the endpoint is unreachable anyway, so leg 2's reason stands and we skip the
+            // extra round-trip.
+            bool streamOk = false; string? streamError = null; long streamMs = 0; bool streamApplicable = false;
+            if (ok)
+            {
+                var swStream = System.Diagnostics.Stopwatch.StartNew();
+                (streamOk, streamError, streamApplicable) = await client.VerifyStreamCallbackAsync(endpoint, id, req.Nonce, ct);
+                swStream.Stop();
+                streamMs = swStream.ElapsedMilliseconds;
+                // Only stamp a verdict when the leg was applicable; an old Director (no /verify-ws)
+                // stays "unknown" (both stream fields null) rather than reading as broken.
+                if (streamApplicable)
+                    registry.MarkStreamVerified(id, streamOk, streamError);
+            }
+
             if (ok)
             {
                 registry.MarkTwoWayVerified(id);
@@ -321,7 +339,7 @@ internal static class GatewayEndpoints
                 // for the next fleet poll to coincide with a closed breaker.
                 registry.RecordReachable(id);
             }
-            FileLog.Write($"[GatewayEndpoints] verify {id}: callbackOk={ok}, endpoint={endpoint}, {sw.ElapsedMilliseconds}ms{(ok ? "" : $", error={error}")}");
+            FileLog.Write($"[GatewayEndpoints] verify {id}: callbackOk={ok}, streamOk={streamOk} (applicable={streamApplicable}), endpoint={endpoint}, {sw.ElapsedMilliseconds}ms{(ok ? "" : $", error={error}")}{(streamApplicable && !streamOk ? $", streamError={streamError}" : "")}");
 
             return Results.Json(new DirectorVerifyResultDto
             {
@@ -331,6 +349,9 @@ internal static class GatewayEndpoints
                 CallbackError = error,
                 CallbackEndpoint = endpoint,
                 CallbackLatencyMs = sw.ElapsedMilliseconds,
+                StreamOk = streamOk,
+                StreamError = streamApplicable ? streamError : (ok ? "stream verify not supported by this Director version" : null),
+                StreamLatencyMs = streamMs,
                 VerifiedAt = DateTime.UtcNow,
             });
         });

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -49,8 +49,7 @@ internal static class SessionWsProxyEndpoints
     /// </summary>
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client, SessionOwnerCache owners, string? fleetToken = null)
     {
-        var forwarder = app.ServiceProvider.GetRequiredService<IHttpForwarder>();
-        var proxy = new SessionWsForwarder(forwarder, fleetToken);
+        var proxy = new SessionWsForwarder(fleetToken);
 
         // Live terminal stream: forward to the owning Director's /sessions/{sid}/stream .
         app.MapGet("/sessions/{sid}/stream", async (string sid, HttpContext ctx) =>
@@ -323,72 +322,164 @@ internal static class SessionWsProxyEndpoints
 
     /// <summary>
     /// Reverse-proxies a per-session request (WS upgrade or plain HTTP) to a per-request Director
-    /// destination, reusing the shared YARP <see cref="IHttpForwarder"/>. The forwarder rewrites the
-    /// request path to the Director's own endpoint path (e.g. the sid-scoped /dictate becomes the
+    /// destination at the Director's own endpoint path (e.g. the sid-scoped /dictate becomes the
     /// Director's /dictate, the sid-scoped screenshots path becomes /screenshots/file).
+    ///
+    /// Why a HAND-ROLLED proxy instead of YARP's IHttpForwarder (the remote-streaming bug): on
+    /// Windows, YARP's forwarder cannot complete the TLS handshake to a Tailscale Serve (https)
+    /// backend - every forward (WebSocket OR plain HTTP) fails with the Schannel error "The message
+    /// received was unexpected or badly formatted", while a plain HttpClient / ClientWebSocket to
+    /// the IDENTICAL url succeeds. That is exactly why remote Directors showed metadata (read with a
+    /// plain HttpClient by the aggregator) but could not stream or be driven (forwarded by YARP).
+    /// So WS legs are pumped over a <see cref="ClientWebSocket"/> and HTTP legs over an
+    /// <see cref="HttpClient"/> - the two clients proven to work against the TLS backend. The
+    /// <see cref="ForwarderError"/> return value is kept (None = ok, Request = failed) so the
+    /// caller's 404/503/closed-frame logic is unchanged.
     /// </summary>
     private sealed class SessionWsForwarder
     {
-        private readonly IHttpForwarder _forwarder;
-        private readonly HttpMessageInvoker _invoker;
         private readonly string? _fleetToken;
-
-        public SessionWsForwarder(IHttpForwarder forwarder, string? fleetToken)
+        // One pooled client for the HTTP legs. No overall Timeout: the per-call ctx.RequestAborted
+        // governs (a slow verb like recap can legitimately run minutes); a DEAD Director still fails
+        // fast via the handler's ConnectTimeout. Default ResponseContentRead - the path proven to
+        // work over the Schannel TLS backend (ResponseHeadersRead is the YARP-style path that broke).
+        private readonly HttpClient _http = new(new SocketsHttpHandler
         {
-            _forwarder = forwarder;
-            _fleetToken = fleetToken;
-            _invoker = new HttpMessageInvoker(new SocketsHttpHandler
-            {
-                UseProxy = false,
-                AllowAutoRedirect = false,
-                AutomaticDecompression = DecompressionMethods.None,
-                UseCookies = false,
-                ActivityHeadersPropagator = null,
-                ConnectTimeout = TimeSpan.FromSeconds(5),
-            });
-        }
+            UseProxy = false,
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.None,
+            UseCookies = false,
+            ConnectTimeout = TimeSpan.FromSeconds(5),
+        })
+        { Timeout = Timeout.InfiniteTimeSpan };
 
-        public async ValueTask<ForwarderError> ForwardAsync(HttpContext ctx, string destinationPrefix, string directorPath)
+        public SessionWsForwarder(string? fleetToken) => _fleetToken = fleetToken;
+
+        public ValueTask<ForwarderError> ForwardAsync(HttpContext ctx, string destinationPrefix, string directorPath)
+            => ctx.WebSockets.IsWebSocketRequest
+                ? ForwardWebSocketAsync(ctx, destinationPrefix, directorPath)
+                : ForwardHttpAsync(ctx, destinationPrefix, directorPath);
+
+        // WS leg: connect to the Director FIRST so a backend failure leaves ctx.Response unstarted
+        // and the caller can surface the real reason as a {"type":"closed"} frame (issue #457/#461).
+        // Only once the backend upgrade succeeds do we accept the browser side and pump raw frames
+        // (size header, PTY bytes, the user's keystrokes, close) verbatim in both directions.
+        private async ValueTask<ForwarderError> ForwardWebSocketAsync(HttpContext ctx, string destinationPrefix, string directorPath)
         {
-            var transformer = new RewritePathTransformer(directorPath, _fleetToken);
-            return await _forwarder.SendAsync(ctx, destinationPrefix, _invoker, ForwarderRequestConfig.Empty, transformer);
-        }
-    }
-
-    /// <summary>
-    /// Rewrites the proxied request path to the Director's own endpoint path. The Gateway path
-    /// (e.g. /sessions/{sid}/dictate) differs from the Director path (/dictate), so the default
-    /// path-copy transform would hit the wrong endpoint - we set the path explicitly.
-    /// </summary>
-    private sealed class RewritePathTransformer : HttpTransformer
-    {
-        private readonly string _directorPath;
-        private readonly string? _fleetToken;
-
-        public RewritePathTransformer(string directorPath, string? fleetToken)
-        {
-            _directorPath = directorPath;
-            _fleetToken = fleetToken;
-        }
-
-        public override async ValueTask TransformRequestAsync(
-            HttpContext ctx, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken ct)
-        {
-            await base.TransformRequestAsync(ctx, proxyRequest, destinationPrefix, ct);
-
-            // base set RequestUri to destinationPrefix + the INBOUND path+query. Replace it with
-            // the Director's own path on the same destination, carrying any query string through.
-            var prefix = destinationPrefix.TrimEnd('/');
-            var query = ctx.Request.QueryString.HasValue ? ctx.Request.QueryString.Value : "";
-            proxyRequest.RequestUri = new Uri(prefix + _directorPath + query);
-
-            // Issue #457: authenticate to the owning Director with the shared fleet token. An
-            // auth-enabled Director (LAN mode) requires it; the browser only carried the Gateway
-            // cookie, which the Director does not accept. Replace any inbound Authorization so the
-            // forward presents the fleet bearer, never the browser's gateway credential.
+            var target = ToWsUri(destinationPrefix, directorPath, ctx.Request.QueryString);
+            var upstream = new ClientWebSocket();
+            // HTTP/1.1 upgrade (matches DirectorForwarding + the verify probe). Default for
+            // ClientWebSocket, set explicitly so an env/runtime default can never flip it to h2.
+            upstream.Options.HttpVersion = DirectorForwarding.HttpVersion;
+            upstream.Options.HttpVersionPolicy = DirectorForwarding.HttpVersionPolicy;
             if (!string.IsNullOrEmpty(_fleetToken))
-                proxyRequest.Headers.Authorization =
-                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _fleetToken);
+                upstream.Options.SetRequestHeader("Authorization", "Bearer " + _fleetToken);
+            try
+            {
+                await upstream.ConnectAsync(target, ctx.RequestAborted);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[SessionWsProxy] WS upstream connect failed: {target} -> {ex.Message}");
+                upstream.Dispose();
+                return ForwarderError.Request; // caller renders the closed-reason frame
+            }
+
+            using var downstream = await ctx.WebSockets.AcceptWebSocketAsync();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            try
+            {
+                var a = PumpAsync(downstream, upstream, cts); // browser -> Director (keystrokes)
+                var b = PumpAsync(upstream, downstream, cts); // Director -> browser (PTY)
+                await Task.WhenAny(a, b);
+                cts.Cancel();
+                try { await Task.WhenAll(a, b); } catch { /* the losing pump unwinds on cancel */ }
+            }
+            finally
+            {
+                upstream.Dispose();
+            }
+            return ForwarderError.None;
+        }
+
+        // Copy frames one-for-one, preserving message type (binary PTY vs text size/closed JSON) and
+        // the fragment boundary, so xterm renders a coherent screen. A close or any socket error
+        // cancels the linked token, which tears down the paired pump.
+        private static async Task PumpAsync(WebSocket from, WebSocket to, CancellationTokenSource cts)
+        {
+            var buf = new byte[64 * 1024];
+            try
+            {
+                while (from.State == WebSocketState.Open && !cts.IsCancellationRequested)
+                {
+                    var r = await from.ReceiveAsync(buf, cts.Token);
+                    if (r.MessageType == WebSocketMessageType.Close)
+                    {
+                        try { await to.CloseAsync(WebSocketCloseStatus.NormalClosure, "peer closed", cts.Token); } catch { }
+                        break;
+                    }
+                    await to.SendAsync(new ArraySegment<byte>(buf, 0, r.Count), r.MessageType, r.EndOfMessage, cts.Token);
+                }
+            }
+            catch
+            {
+                // Socket dropped or cancelled: normal teardown. The WhenAny/WhenAll above observes it.
+            }
+            finally
+            {
+                cts.Cancel();
+            }
+        }
+
+        // HTTP leg: forward method + body + query to the Director's own path, present the fleet
+        // bearer (an auth-enabled LAN Director requires it; the browser only had a Gateway cookie),
+        // and copy status + headers + body back. ResponseContentRead (default) - the responses here
+        // (screenshots, verb JSON) are bounded, and it is the path proven to work over the TLS backend.
+        private async ValueTask<ForwarderError> ForwardHttpAsync(HttpContext ctx, string destinationPrefix, string directorPath)
+        {
+            var query = ctx.Request.QueryString.HasValue ? ctx.Request.QueryString.Value : "";
+            var url = destinationPrefix.TrimEnd('/') + directorPath + query;
+            using var req = new HttpRequestMessage(new HttpMethod(ctx.Request.Method), url);
+
+            if (ctx.Request.ContentLength is > 0 || ctx.Request.Headers.ContainsKey("Transfer-Encoding"))
+            {
+                req.Content = new StreamContent(ctx.Request.Body);
+                if (!string.IsNullOrEmpty(ctx.Request.ContentType))
+                    req.Content.Headers.TryAddWithoutValidation("Content-Type", ctx.Request.ContentType);
+            }
+            if (!string.IsNullOrEmpty(_fleetToken))
+                req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _fleetToken);
+
+            HttpResponseMessage resp;
+            try
+            {
+                resp = await _http.SendAsync(req, ctx.RequestAborted);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[SessionWsProxy] HTTP forward failed: {ctx.Request.Method} {url} -> {ex.Message}");
+                return ForwarderError.Request;
+            }
+            using (resp)
+            {
+                ctx.Response.StatusCode = (int)resp.StatusCode;
+                foreach (var h in resp.Headers) ctx.Response.Headers[h.Key] = h.Value.ToArray();
+                foreach (var h in resp.Content.Headers) ctx.Response.Headers[h.Key] = h.Value.ToArray();
+                // Kestrel sets framing for the outbound response; a copied chunked/length header
+                // would conflict with what it actually writes.
+                ctx.Response.Headers.Remove("transfer-encoding");
+                ctx.Response.Headers.Remove("content-length");
+                await resp.Content.CopyToAsync(ctx.Response.Body, ctx.RequestAborted);
+            }
+            return ForwarderError.None;
+        }
+
+        // destinationPrefix is http(s)://host:port; the Director's WS endpoints live at ws(s)://.
+        private static Uri ToWsUri(string destinationPrefix, string directorPath, QueryString qs)
+        {
+            var http = new Uri(destinationPrefix.TrimEnd('/') + directorPath + (qs.HasValue ? qs.Value : ""));
+            var scheme = http.Scheme == Uri.UriSchemeHttps ? "wss" : "ws";
+            return new UriBuilder(http) { Scheme = scheme }.Uri;
         }
     }
 }

--- a/src/CcDirector.Gateway/DirectorForwarding.cs
+++ b/src/CcDirector.Gateway/DirectorForwarding.cs
@@ -1,0 +1,29 @@
+namespace CcDirector.Gateway;
+
+/// <summary>
+/// Single source of truth for how the Gateway dials a Director's Control API when it proxies a
+/// per-session leg (the terminal stream, dictation, screenshots, per-session verbs) and when it
+/// runs the stream-leg verification probe.
+///
+/// Two decisions live here, both learned from the remote-streaming bug:
+///
+/// 1. The Gateway proxies these legs with a hand-rolled <c>HttpClient</c> / <c>ClientWebSocket</c>
+///    proxy (see SessionWsForwarder), NOT YARP's IHttpForwarder. On Windows, YARP's forwarder
+///    cannot complete the TLS handshake to a Tailscale Serve (https) backend - every forward fails
+///    with the Schannel error "The message received was unexpected or badly formatted" - while a
+///    plain HttpClient / ClientWebSocket to the identical url works. (Same-machine loopback http
+///    backends worked through YARP, which is why local Directors streamed but remote ones never did.)
+///
+/// 2. The WebSocket upgrade uses HTTP/1.1. ClientWebSocket already defaults to 1.1; pinning it here
+///    is a single source of truth so the live stream proxy and the install/connect verification
+///    probe always agree, and a runtime/env default can never flip either to HTTP/2.
+/// </summary>
+public static class DirectorForwarding
+{
+    /// <summary>HTTP version for the Director-bound WebSocket upgrade (proxy + verify probe).</summary>
+    public static readonly Version HttpVersion = System.Net.HttpVersion.Version11;
+
+    /// <summary>Exact: keep the upgrade on HTTP/1.1 regardless of any negotiated default.</summary>
+    public static readonly System.Net.Http.HttpVersionPolicy HttpVersionPolicy =
+        System.Net.Http.HttpVersionPolicy.RequestVersionExact;
+}

--- a/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
@@ -1,4 +1,7 @@
+using System.Net;
 using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Text.Json;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -78,6 +81,74 @@ public sealed class DirectorEndpointClient : IDisposable
         {
             FileLog.Write($"[DirectorEndpointClient] VerifyCallbackAsync FAILED: url={url}, error={ex.Message}");
             return (false, $"callback failed at {url}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Leg 3 of the handshake (remote terminal streaming fix): prove the Gateway can complete a
+    /// real WebSocket UPGRADE to the Director - the exact path the Cockpit terminal stream uses,
+    /// which the plain-HTTP <see cref="VerifyCallbackAsync"/> never exercises. Dials
+    /// ws(s)://{endpoint}/verify-ws/{nonce} with the SAME HTTP version the session forwarder uses
+    /// (<see cref="DirectorForwarding"/>) and the fleet bearer, then requires a single text frame
+    /// echoing the expected Director id + nonce.
+    ///
+    /// Returns <c>applicable=false</c> (with ok=false) when the Director predates the /verify-ws
+    /// endpoint (HTTP 404 on the upgrade), so an old Director reads as "untested" rather than
+    /// broken. Any other non-101 / wrong-process / timeout is applicable=true, ok=false - a real
+    /// stream failure the install/connect check should surface.
+    /// </summary>
+    public async Task<(bool ok, string? error, bool applicable)> VerifyStreamCallbackAsync(
+        string endpoint, string expectedDirectorId, string nonce, CancellationToken ct = default)
+    {
+        var http = new Uri(endpoint.TrimEnd('/') + "/verify-ws/" + Uri.EscapeDataString(nonce));
+        var wsUri = new UriBuilder(http) { Scheme = http.Scheme == Uri.UriSchemeHttps ? "wss" : "ws" }.Uri;
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(VerifyCallbackTimeout);
+        using var ws = new ClientWebSocket();
+        // Same version the forwarder dials with, so an accidental future bump to h2 is caught HERE
+        // (the install/connect check) instead of by a user with a dead terminal.
+        ws.Options.HttpVersion = DirectorForwarding.HttpVersion;
+        ws.Options.HttpVersionPolicy = DirectorForwarding.HttpVersionPolicy;
+        ws.Options.CollectHttpResponseDetails = true; // populates HttpStatusCode on a failed upgrade
+        if (!string.IsNullOrEmpty(_token))
+            ws.Options.SetRequestHeader("Authorization", "Bearer " + _token);
+        try
+        {
+            await ws.ConnectAsync(wsUri, cts.Token);
+            var buf = new byte[4096];
+            var frame = await ws.ReceiveAsync(buf, cts.Token);
+            if (frame.MessageType == WebSocketMessageType.Close)
+                return (false, $"stream verify: Director closed the socket without an echo at {wsUri}", true);
+
+            VerifyCallbackDto? dto = null;
+            try { dto = JsonSerializer.Deserialize<VerifyCallbackDto>(buf.AsSpan(0, frame.Count)); }
+            catch { /* dto stays null -> handled below */ }
+
+            try { await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "verify-ws done", cts.Token); }
+            catch { /* best effort: we already have the echo */ }
+
+            if (dto is null)
+                return (false, $"stream verify: upgrade ok at {wsUri} but the frame was not a verify echo", true);
+            if (!string.Equals(dto.DirectorId, expectedDirectorId, StringComparison.OrdinalIgnoreCase))
+                return (false, $"stream verify: upgrade answered by a DIFFERENT Director ({dto.DirectorId}) - the advertised URL points at the wrong process", true);
+            if (!string.Equals(dto.Nonce, nonce, StringComparison.Ordinal))
+                return (false, "stream verify: upgrade echoed a different nonce", true);
+            return (true, null, true);
+        }
+        catch (WebSocketException) when (ws.HttpStatusCode == HttpStatusCode.NotFound)
+        {
+            // Director predates /verify-ws: not a stream failure, just untestable.
+            return (false, "stream verify not supported by this Director version", false);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return (false, $"stream verify: WebSocket upgrade timed out after {VerifyCallbackTimeout.TotalSeconds:F0}s at {wsUri}", true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorEndpointClient] VerifyStreamCallbackAsync FAILED: url={wsUri}, error={ex.Message}");
+            return (false, $"stream verify failed at {wsUri}: {ex.Message}", true);
         }
     }
 

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -264,6 +264,25 @@ public sealed class DirectorRegistry : IDisposable
             d.TwoWayVerifiedAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Stamp the result of the stream-leg verification (the real WebSocket UPGRADE to
+    /// /verify-ws - the path the Cockpit terminal stream uses). <paramref name="ok"/> true ->
+    /// stamp <see cref="DirectorDto.StreamVerifiedAt"/> and clear the error; false -> clear the
+    /// stamp and record <paramref name="error"/>. Like the two-way stamp this lives on the
+    /// in-memory dto, so a re-register naturally resets it. NOT called when the leg was not
+    /// applicable (a Director predating /verify-ws), so such a Director stays "unknown" (both
+    /// fields null) rather than reading as broken.
+    /// </summary>
+    public void MarkStreamVerified(string directorId, bool ok, string? error)
+    {
+        if (string.IsNullOrEmpty(directorId)) return;
+        if (_directors.TryGetValue(directorId, out var d))
+        {
+            d.StreamVerifiedAt = ok ? DateTime.UtcNow : null;
+            d.StreamVerifyError = ok ? null : error;
+        }
+    }
+
     // ===== Advertised-endpoint re-verification state machine (issue #325) =====
 
     /// <summary>Consecutive advertised-endpoint probe failures per Director, for log throttling only

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -364,6 +364,13 @@ public sealed class GatewayHost : IAsyncDisposable
         var cockpitForwarder = new Cockpit.CockpitProxy.CockpitForwarder(_app.Services, _cockpitProxyPort);
         Cockpit.CockpitProxy.UseBrowserPageRoutes(_app, cockpitForwarder);
 
+        // Enable ASP.NET WebSocket support so the per-session proxy can recognize an inbound WS
+        // upgrade (ctx.WebSockets.IsWebSocketRequest) and accept it (AcceptWebSocketAsync) for the
+        // hand-rolled terminal/dictation stream proxy. The old YARP forwarder used the raw upgrade
+        // feature and needed no middleware; the manual proxy (SessionWsForwarder) does. Pass-through
+        // for upgrades it does not accept, so the YARP-forwarded Cockpit/Blazor circuit is unaffected.
+        _app.UseWebSockets();
+
         _app.UseRouting();
 
         // Product version stamped by Directory.Build.props; full form carries the commit SHA.

--- a/src/CcDirector.Launcher/LauncherAppOptions.cs
+++ b/src/CcDirector.Launcher/LauncherAppOptions.cs
@@ -16,7 +16,16 @@ public static class LauncherAppOptions
     /// <summary>When true, register the HKCU Run-key autostart entry on startup. --no-autostart disables.</summary>
     public static bool RegisterAutostart { get; set; } = true;
 
-    /// <summary>Parse the supported flags: --port N, --no-autostart.</summary>
+    /// <summary>
+    /// Installed mode (--managed): run the periodic self-update check. Off by default so a dev launch
+    /// never self-updates a repo build. The installer launches the shipped launcher with --managed.
+    /// </summary>
+    public static bool Managed { get; set; }
+
+    /// <summary>The arguments equivalent to the current options, for the autostart Run key.</summary>
+    public static string? AutostartArguments() => Managed ? "--managed" : null;
+
+    /// <summary>Parse the supported flags: --port N, --no-autostart, --managed.</summary>
     public static void Parse(string[] args)
     {
         for (int i = 0; i < args.Length; i++)
@@ -29,6 +38,10 @@ public static class LauncherAppOptions
             else if (args[i] == "--no-autostart")
             {
                 RegisterAutostart = false;
+            }
+            else if (args[i] == "--managed")
+            {
+                Managed = true;
             }
         }
     }

--- a/src/CcDirector.Launcher/LauncherTrayController.cs
+++ b/src/CcDirector.Launcher/LauncherTrayController.cs
@@ -6,6 +6,7 @@ using Avalonia.Platform;
 using Avalonia.Threading;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Utilities;
+using CcDirector.Setup.Engine;
 
 namespace CcDirector.Launcher;
 
@@ -21,6 +22,7 @@ public sealed class LauncherTrayController : IDisposable
 
     private readonly IClassicDesktopStyleApplicationLifetime _desktop;
     private readonly int _port;
+    private readonly CancellationTokenSource _lifetime = new();
 
     private TrayIcon? _trayIcon;
     private NativeMenuItem? _statusItem;
@@ -39,13 +41,16 @@ public sealed class LauncherTrayController : IDisposable
     /// <summary>Build the tray icon, register autostart, and start the REST host.</summary>
     public void Start()
     {
-        FileLog.Write("[LauncherTrayController] Start");
+        FileLog.Write($"[LauncherTrayController] Start (managed={LauncherAppOptions.Managed})");
 
         BuildTrayIcon();
         RegisterAutostartSafe();
 
         SetState(HostState.Starting);
         _ = StartHostAsync();
+
+        if (LauncherAppOptions.Managed)
+            _ = RunUpdateLoopAsync(_lifetime.Token);
     }
 
     private void BuildTrayIcon()
@@ -144,6 +149,7 @@ public sealed class LauncherTrayController : IDisposable
     private async Task QuitAsync()
     {
         FileLog.Write("[LauncherTrayController] QuitAsync");
+        _lifetime.Cancel();
 
         // Issue #331: unregister from the Gateway before shutting down the REST host.
         if (_gatewayClient is not null)
@@ -193,7 +199,7 @@ public sealed class LauncherTrayController : IDisposable
             {
                 var exePath = Environment.ProcessPath
                     ?? throw new InvalidOperationException("Could not resolve own exe path");
-                LauncherAutostart.EnsureRegistered(exePath);
+                LauncherAutostart.EnsureRegistered(exePath, LauncherAppOptions.AutostartArguments());
                 FileLog.Write("[LauncherTrayController] Autostart enabled by user");
             }
             UpdateAutostartMenuItem();
@@ -219,11 +225,48 @@ public sealed class LauncherTrayController : IDisposable
             var exePath = Environment.ProcessPath
                           ?? Process.GetCurrentProcess().MainModule?.FileName
                           ?? throw new InvalidOperationException("Could not resolve own exe path for autostart");
-            LauncherAutostart.EnsureRegistered(exePath);
+            LauncherAutostart.EnsureRegistered(exePath, LauncherAppOptions.AutostartArguments());
         }
         catch (Exception ex)
         {
             FileLog.Write($"[LauncherTrayController] Autostart registration FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Periodic machine-tier auto-update (managed mode only): check for a newer Launcher and, if
+    /// found, launch the detached self-update helper (it POSTs /shutdown -> swap -> relaunch ->
+    /// health -> auto-rollback). Mirrors the Gateway's update loop. Failures only log.
+    /// </summary>
+    private static async Task RunUpdateLoopAsync(CancellationToken ct)
+    {
+        var layout = InstallLayout.Default();
+        // Let the launcher settle before the first check; never compete with startup.
+        try { await Task.Delay(TimeSpan.FromMinutes(2), ct); } catch (OperationCanceledException) { return; }
+
+        while (!ct.IsCancellationRequested)
+        {
+            var cfg = AutoUpdateConfig.Load(layout);
+            if (cfg.Enabled && OperatingSystem.IsWindows())
+            {
+                try
+                {
+                    var source = new ReleaseSource();
+                    var release = await source.FetchLatestAsync(ct);
+                    var version = await new LauncherUpdater(layout).CheckStageAndLaunchAsync(release, source, ct);
+                    if (version is not null)
+                    {
+                        FileLog.Write($"[LauncherTrayController] launched Launcher self-update to {version}; this process will be asked to exit");
+                        return; // the detached helper POSTs /shutdown, swaps, and relaunches us
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[LauncherTrayController] update check failed: {ex.Message}");
+                }
+            }
+            try { await Task.Delay(cfg.Enabled ? cfg.Interval : TimeSpan.FromHours(1), ct); }
+            catch (OperationCanceledException) { break; }
         }
     }
 
@@ -285,6 +328,7 @@ public sealed class LauncherTrayController : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+        _lifetime.Cancel();
         try { _gatewayClient?.StopAsync().GetAwaiter().GetResult(); }
         catch (Exception ex) { FileLog.Write($"[LauncherTrayController] Dispose gateway client stop error: {ex.Message}"); }
         _gatewayClient = null;
@@ -292,5 +336,6 @@ public sealed class LauncherTrayController : IDisposable
         catch (Exception ex) { FileLog.Write($"[LauncherTrayController] Dispose stop error: {ex.Message}"); }
         _host = null;
         if (_trayIcon is not null) _trayIcon.IsVisible = false;
+        _lifetime.Dispose();
     }
 }

--- a/src/CcDirector.Launcher/Program.cs
+++ b/src/CcDirector.Launcher/Program.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
+using System.Net.Http;
 using Avalonia;
 using CcDirector.Core.Utilities;
+using CcDirector.Setup.Engine;
 
 namespace CcDirector.Launcher;
 
@@ -14,6 +17,14 @@ public static class Program
     public static int Main(string[] args)
     {
         FileLog.Start();
+
+        // Detached self-update helper mode: this process is a STAGED copy of the new Launcher exe.
+        // It asks the running tray app to exit (POST /shutdown), swaps itself into the installed
+        // location, relaunches, and verifies the new build is healthy - rolling back to the .old
+        // build (and pinning the bad version) if not. NEVER the normal startup path: it exits when
+        // done. Launched by LauncherUpdater.LaunchDetachedUpdater.
+        if (Array.IndexOf(args, "--apply-update") >= 0)
+            return ApplyUpdate(args);
 
         LauncherAppOptions.Parse(args);
 
@@ -41,6 +52,78 @@ public static class Program
             FileLog.Write("[Program] CC Launcher exited");
             FileLog.Stop();
         }
+    }
+
+    private static int ApplyUpdate(string[] args)
+    {
+        string Arg(string name) { var i = Array.IndexOf(args, name); return i >= 0 && i + 1 < args.Length ? args[i + 1] : ""; }
+        var target = Arg("--target");
+        var version = Arg("--new-version");
+        var port = int.TryParse(Arg("--port"), out var p) ? p : LauncherAppOptions.DefaultPort;
+        // Relaunch arguments: the installed Launcher always relaunches managed; the self-update
+        // test harness overrides this to keep its throwaway instance off the real install.
+        var relaunchArgs = Arg("--args");
+        if (relaunchArgs.Length == 0) relaunchArgs = LauncherTrayInstaller.InstalledArguments;
+        var stagedSelf = Environment.ProcessPath ?? "";
+        FileLog.Write($"[Program] --apply-update: version={version}, target={target}, port={port}, args={relaunchArgs}, staged={stagedSelf}");
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+
+        var result = new LauncherSelfUpdate().ApplyAsync(
+            target, stagedSelf, version,
+            stopLauncher: () =>
+            {
+                // Best-effort graceful exit; LauncherSelfUpdate's exe-writability wait is the real
+                // exit barrier (a single-file exe unlocks only when its process has fully exited,
+                // which also releases the single-instance mutex for the relaunch).
+                try
+                {
+                    using var resp = http.PostAsync($"http://127.0.0.1:{port}/shutdown", content: null)
+                        .GetAwaiter().GetResult();
+                    FileLog.Write($"[Program] /shutdown -> {(int)resp.StatusCode}");
+                    return resp.IsSuccessStatusCode;
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[Program] /shutdown unreachable ({ex.Message}); launcher presumably not running");
+                    return false;
+                }
+            },
+            startLauncher: () =>
+            {
+                try
+                {
+                    // UseShellExecute=true so the relaunched Launcher does NOT inherit this helper's
+                    // stdio handles - an inherited stdout pipe keeps the caller's pipe open for the
+                    // Launcher's whole lifetime (observed as a hang in any script that pipes output).
+                    var psi = new ProcessStartInfo
+                    {
+                        FileName = target,
+                        Arguments = relaunchArgs,
+                        WorkingDirectory = Path.GetDirectoryName(target) ?? Environment.CurrentDirectory,
+                        UseShellExecute = true,
+                    };
+                    using var proc = Process.Start(psi);
+                    FileLog.Write($"[Program] relaunched Launcher pid={proc?.Id}");
+                    return proc is not null;
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[Program] relaunch FAILED: {ex.Message}");
+                    return false;
+                }
+            },
+            isHealthy: async ct =>
+            {
+                try { return (await http.GetAsync($"http://127.0.0.1:{port}/healthz", ct)).IsSuccessStatusCode; }
+                catch { return false; }
+            },
+            healthTimeout: TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+
+        FileLog.Write($"[Program] self-update outcome={result.Outcome}: {result.Message}");
+        foreach (var step in result.Steps) FileLog.Write($"[Program]   {step}");
+        FileLog.Stop();
+        return result.Outcome == SelfUpdateOutcome.Updated ? 0 : 1;
     }
 
     public static AppBuilder BuildAvaloniaApp()

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -268,6 +268,27 @@ internal static class Commands
             }
         }
 
+        // The Launcher tray app ships to BOTH roles. The generic runner places its exe but never
+        // starts it (so a fresh install leaves it dormant and its autostart Run key unwritten). On
+        // any install, start it in managed mode and verify health + autostart - the app self-registers
+        // its Run key and runs the self-update loop. Idempotent: an already-running launcher just keeps
+        // serving. Runs last so it never blocks the core Director/tools install.
+        if (installMode && result.Failed == 0 && OperatingSystem.IsWindows())
+        {
+            var launcherInstaller = new LauncherTrayInstaller(layout);
+            var launcherTray = await launcherInstaller.InstallAsync();
+            if (json)
+                Program.WriteJson(new { launcherTray = new { success = launcherTray.Success, message = launcherTray.Message, steps = launcherTray.Steps } });
+            else
+            {
+                Console.WriteLine();
+                Console.WriteLine(launcherTray.Success ? "Launcher tray app:" : "Launcher tray app FAILED:");
+                foreach (var s in launcherTray.Steps) Console.WriteLine($"  {s}");
+                Console.WriteLine($"  {launcherTray.Message}");
+            }
+            if (!launcherTray.Success) return Error;
+        }
+
         return result.Failed > 0 ? Error : Ok;
     }
 

--- a/tools/cc-director-setup-engine.Tests/LauncherSelfUpdateTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherSelfUpdateTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+public class LauncherSelfUpdateTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly InstallLayout _layout;
+    private readonly string _target;
+    private readonly string _staged;
+
+    public LauncherSelfUpdateTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-lnsu-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _layout = new InstallLayout(Path.Combine(_dir, "local"));
+        var installedDir = Path.Combine(_dir, "installed");
+        Directory.CreateDirectory(installedDir);
+        _target = Path.Combine(installedDir, "cc-launcher.exe");
+        File.WriteAllText(_target, "launcher-OLD");
+        var stagedDir = Path.Combine(_dir, "staged");
+        Directory.CreateDirectory(stagedDir);
+        _staged = Path.Combine(stagedDir, "cc-launcher.exe");
+        File.WriteAllText(_staged, "launcher-NEW");
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Apply_HealthyNewBuild_Swaps_RecordsVersion_NoPin()
+    {
+        var stops = 0; var starts = 0;
+        var su = new LauncherSelfUpdate(_layout, unlockTimeout: TimeSpan.FromSeconds(1));
+
+        var result = await su.ApplyAsync(
+            _target, _staged, "0.4.0",
+            stopLauncher: () => { stops++; return true; },
+            startLauncher: () => { starts++; return true; },
+            isHealthy: _ => Task.FromResult(true),
+            healthTimeout: TimeSpan.FromSeconds(2));
+
+        Assert.Equal(SelfUpdateOutcome.Updated, result.Outcome);
+        Assert.Equal("launcher-NEW", File.ReadAllText(_target));            // swapped in
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target + ".old"));   // backup kept
+        Assert.Equal("0.4.0", InstalledManifest.Load(_layout).Get(ComponentRegistry.Launcher.Id));
+        Assert.False(PinStore.Load(_layout).IsPinned(ComponentRegistry.Launcher.Id, "0.4.0")); // not pinned
+        Assert.Equal(1, stops);
+        Assert.Equal(1, starts);
+    }
+
+    [Fact]
+    public async Task Apply_UnhealthyNewBuild_RollsBack_AndPins()
+    {
+        var su = new LauncherSelfUpdate(_layout, unlockTimeout: TimeSpan.FromSeconds(1));
+
+        var result = await su.ApplyAsync(
+            _target, _staged, "0.4.0",
+            stopLauncher: () => true,
+            startLauncher: () => true,
+            isHealthy: _ => Task.FromResult(false),    // new build never comes up
+            healthTimeout: TimeSpan.FromMilliseconds(200));
+
+        Assert.Equal(SelfUpdateOutcome.RolledBack, result.Outcome);
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));   // restored from .old
+        Assert.True(PinStore.Load(_layout).IsPinned(ComponentRegistry.Launcher.Id, "0.4.0")); // pinned away from the bad version
+    }
+}
+
+public class LauncherUpdaterTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _releaseDir;
+    private readonly InstallLayout _layout;
+
+    public LauncherUpdaterTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-lnupd-" + Guid.NewGuid().ToString("N"));
+        _releaseDir = Path.Combine(_dir, "release");
+        Directory.CreateDirectory(_releaseDir);
+        _layout = new InstallLayout(Path.Combine(_dir, "local"));
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private ResolvedRelease BuildRelease(string version)
+    {
+        var name = ComponentRegistry.Launcher.WindowsAsset; // cc-launcher-win-x64.exe
+        var path = Path.Combine(_releaseDir, name);
+        File.WriteAllText(path, $"launcher@{version}");
+        var manifest = new
+        {
+            version,
+            assets = new Dictionary<string, object>
+            {
+                [name] = new { version, sha256 = Hashing.Sha256OfFile(path), platform = "windows", size = new FileInfo(path).Length },
+            },
+        };
+        File.WriteAllText(Path.Combine(_releaseDir, "release-manifest.json"), JsonSerializer.Serialize(manifest));
+        return ReleaseSource.LoadLocalReleaseDir(_releaseDir);
+    }
+
+    private void InstallLauncher(string version)
+    {
+        Directory.CreateDirectory(_layout.LauncherDir);
+        var p = _layout.PathFor(ComponentRegistry.Launcher);
+        File.WriteAllText(p, $"launcher@{version}");
+        var m = InstalledManifest.Load(_layout);
+        m.Set(ComponentRegistry.Launcher.Id, version);
+        m.Save(_layout);
+    }
+
+    [Fact]
+    public void IsUpdateAvailable_TrueWhenNewer_FalseWhenCurrentOrAbsentOrPinned()
+    {
+        var release = BuildRelease("0.4.0");
+        var updater = new LauncherUpdater(_layout);
+
+        Assert.False(updater.IsUpdateAvailable(release));   // not installed -> refresh-only
+
+        InstallLauncher("0.3.6");
+        Assert.True(updater.IsUpdateAvailable(release));     // behind
+
+        InstallLauncher("0.4.0");
+        Assert.False(updater.IsUpdateAvailable(release));    // current
+
+        InstallLauncher("0.3.6");
+        var pins = new UpdatePins();
+        pins.Pin(ComponentRegistry.Launcher.Id, "0.4.0");
+        PinStore.Save(_layout, pins);
+        Assert.False(updater.IsUpdateAvailable(release));    // pinned
+    }
+
+    [Fact]
+    public async Task Stage_DownloadsVerifiedExe_ToStagingPath()
+    {
+        InstallLauncher("0.3.6");
+        var release = BuildRelease("0.4.0");
+
+        var staged = await new LauncherUpdater(_layout).StageAsync(release, new ReleaseSource());
+
+        Assert.NotNull(staged);
+        Assert.Equal("0.4.0", staged.Value.Version);
+        Assert.True(File.Exists(staged.Value.StagedPath));
+        Assert.Equal("launcher@0.4.0", File.ReadAllText(staged.Value.StagedPath));
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/UninstallerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/UninstallerTests.cs
@@ -21,16 +21,22 @@ public class UninstallerTests : IDisposable
     }
 
     [Fact]
-    public void Plan_Workstation_TargetsAppBinPathShortcut_NotGatewayOrAutostart()
+    public void Plan_Workstation_TargetsAppBinLauncherPathShortcut_NotGatewayDirsOrGatewayAutostart()
     {
         var plan = new Uninstaller(_layout).Plan(InstallRole.Workstation);
         var dirs = plan.Where(t => t.Kind == UninstallKind.Directory).Select(t => t.Path).ToList();
 
         Assert.Contains(_layout.AppDir, dirs);
         Assert.Contains(_layout.BinDir, dirs);
+        // The Launcher ships to both roles, so a Workstation uninstall removes its binaries too.
+        Assert.Contains(_layout.LauncherDir, dirs);
         Assert.DoesNotContain(_layout.GatewayDir, dirs);
         Assert.DoesNotContain(_layout.CockpitDir, dirs);
-        Assert.DoesNotContain(plan, t => t.Kind == UninstallKind.Autostart);
+        // The Gateway autostart Run key is never in a Workstation plan...
+        Assert.DoesNotContain(plan, t => t.Kind == UninstallKind.Autostart && t.Path == GatewayAutostart.ValueName);
+        // ...but the Launcher autostart Run key is (Windows), because the launcher is a Workstation component.
+        if (OperatingSystem.IsWindows())
+            Assert.Contains(plan, t => t.Kind == UninstallKind.Autostart && t.Path == LauncherAutostart.ValueName);
         Assert.Contains(plan, t => t.Kind == UninstallKind.PathEntry);
         Assert.Contains(plan, t => t.Kind == UninstallKind.Shortcut);
     }

--- a/tools/cc-director-setup-engine/LauncherAutostart.cs
+++ b/tools/cc-director-setup-engine/LauncherAutostart.cs
@@ -1,15 +1,15 @@
 using System.Runtime.Versioning;
-using CcDirector.Core.Utilities;
 using Microsoft.Win32;
 
-namespace CcDirector.Launcher;
+namespace CcDirector.Setup.Engine;
 
 /// <summary>
 /// The CC Launcher tray app's per-user autostart entry under
 /// HKCU\Software\Microsoft\Windows\CurrentVersion\Run.
 ///
-/// Per-user (HKCU) is the correct scope: the launcher only does useful work while the
-/// user is logged in. Modeled on GatewayAutostart from the setup engine.
+/// Per-user (HKCU) is the correct scope: the launcher only does useful work while the user is
+/// logged in. Lives in the engine (next to <see cref="GatewayAutostart"/>) so the installer, the
+/// uninstaller, and the tray app itself all agree on one value name and command-line format.
 /// </summary>
 public static class LauncherAutostart
 {
@@ -19,18 +19,20 @@ public static class LauncherAutostart
     public const string ValueName = "CcDirectorLauncher";
 
     /// <summary>The full command line for the Run-key value. Pure, for tests.</summary>
-    public static string CommandLine(string exePath) => $"\"{exePath}\"";
+    public static string CommandLine(string exePath, string? arguments = null) =>
+        string.IsNullOrWhiteSpace(arguments) ? $"\"{exePath}\"" : $"\"{exePath}\" {arguments}";
 
     /// <summary>
-    /// Ensure the Run-key value is exactly <see cref="CommandLine"/> for the given exe.
-    /// Idempotent: returns true if a write was performed, false if already correct.
+    /// Ensure the Run-key value is exactly <see cref="CommandLine"/> for the given exe and
+    /// arguments. Idempotent: returns true if a write was performed (first registration or
+    /// command change), false if already correct.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public static bool EnsureRegistered(string exePath)
+    public static bool EnsureRegistered(string exePath, string? arguments = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(exePath);
-        var desired = CommandLine(exePath);
-        FileLog.Write($"[LauncherAutostart] EnsureRegistered: {desired}");
+        var desired = CommandLine(exePath, arguments);
+        EngineLog.Write($"[LauncherAutostart] EnsureRegistered: {desired}");
 
         using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true)
                         ?? Registry.CurrentUser.CreateSubKey(RunKeyPath);
@@ -40,12 +42,12 @@ public static class LauncherAutostart
         var current = key.GetValue(ValueName) as string;
         if (string.Equals(current, desired, StringComparison.OrdinalIgnoreCase))
         {
-            FileLog.Write("[LauncherAutostart] EnsureRegistered: already up to date");
+            EngineLog.Write("[LauncherAutostart] EnsureRegistered: already up to date");
             return false;
         }
 
         key.SetValue(ValueName, desired, RegistryValueKind.String);
-        FileLog.Write("[LauncherAutostart] EnsureRegistered: wrote Run-key value");
+        EngineLog.Write("[LauncherAutostart] EnsureRegistered: wrote Run-key value");
         return true;
     }
 
@@ -65,7 +67,7 @@ public static class LauncherAutostart
     [SupportedOSPlatform("windows")]
     public static bool Unregister()
     {
-        FileLog.Write("[LauncherAutostart] Unregister");
+        EngineLog.Write("[LauncherAutostart] Unregister");
         using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true);
         if (key?.GetValue(ValueName) is not string) return false;
         key.DeleteValue(ValueName, throwOnMissingValue: false);

--- a/tools/cc-director-setup-engine/LauncherSelfUpdate.cs
+++ b/tools/cc-director-setup-engine/LauncherSelfUpdate.cs
@@ -1,0 +1,158 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Orchestrates the CC Launcher tray app replacing its own (file-locked) exe: stop -> swap ->
+/// relaunch -> health-check, with AUTO-ROLLBACK to the .old build + a version pin if the new build
+/// does not come up (a bricked always-on launcher with no human present is the worst failure mode).
+///
+/// Runs inside a detached helper process launched from a STAGED copy of the new exe, so the
+/// installed target is free to overwrite once the running tray app has exited. Process control and
+/// the health probe are injected as delegates so the rollback logic is unit-testable without a real
+/// Launcher. Mirrors <see cref="GatewaySelfUpdate"/> (and shares its
+/// <see cref="SelfUpdateOutcome"/>/<see cref="SelfUpdateResult"/> types).
+/// </summary>
+public sealed class LauncherSelfUpdate
+{
+    private readonly InstallLayout _layout;
+    private readonly TimeSpan _unlockTimeout;
+
+    public LauncherSelfUpdate(InstallLayout? layout = null, TimeSpan? unlockTimeout = null)
+    {
+        _layout = layout ?? InstallLayout.Default();
+        _unlockTimeout = unlockTimeout ?? TimeSpan.FromSeconds(20);
+    }
+
+    /// <summary>
+    /// Swap in <paramref name="stagedExePath"/> as the Launcher exe and verify the new build is
+    /// healthy, rolling back to .old (and pinning <paramref name="newVersion"/>) if it is not.
+    /// </summary>
+    public async Task<SelfUpdateResult> ApplyAsync(
+        string targetExePath,
+        string stagedExePath,
+        string newVersion,
+        Func<bool> stopLauncher,
+        Func<bool> startLauncher,
+        Func<CancellationToken, Task<bool>> isHealthy,
+        TimeSpan healthTimeout,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetExePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stagedExePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newVersion);
+        ArgumentNullException.ThrowIfNull(stopLauncher);
+        ArgumentNullException.ThrowIfNull(startLauncher);
+        ArgumentNullException.ThrowIfNull(isHealthy);
+
+        var steps = new List<string>();
+        var target = targetExePath;
+        EngineLog.Write($"[LauncherSelfUpdate] applying {newVersion} -> {target}");
+
+        // 1. Stop the running Launcher so its exe unlocks, then swap. The writability wait is the
+        // real exit barrier: a single-file exe stays locked until its process has fully exited
+        // (which also releases the tray app's single-instance mutex for the relaunch).
+        stopLauncher();
+        steps.Add("stopped the running Launcher");
+        if (!WaitUntilWritable(target))
+            return Fail(steps, $"Launcher exe still locked after stop ({target}); aborting swap.");
+
+        string? backup;
+        try
+        {
+            backup = InstallSwapper.Place(target, stagedExePath);
+            steps.Add($"swapped Launcher exe -> {newVersion} (backup: {backup})");
+        }
+        catch (Exception ex)
+        {
+            startLauncher(); // leave the Launcher running on the old (still-installed) exe
+            return Fail(steps, $"swap failed: {ex.Message}");
+        }
+
+        // 2. Relaunch the new build and health-check it.
+        startLauncher();
+        steps.Add("relaunched the Launcher (new build)");
+        if (await WaitHealthyAsync(isHealthy, healthTimeout, ct))
+        {
+            RecordInstalled(newVersion);
+            steps.Add($"healthy on {newVersion}");
+            EngineLog.Write($"[LauncherSelfUpdate] success: {newVersion}");
+            return new SelfUpdateResult(SelfUpdateOutcome.Updated, $"Launcher updated to {newVersion}.", steps);
+        }
+
+        // 3. The new build did not come up -> roll back to .old and pin the bad version.
+        steps.Add($"new build NOT healthy within {healthTimeout.TotalSeconds:F0}s; rolling back");
+        EngineLog.Write($"[LauncherSelfUpdate] {newVersion} unhealthy; rolling back");
+        stopLauncher();
+        WaitUntilWritable(target);
+        var restored = InstallSwapper.Rollback(target);
+        Pin(newVersion);
+        startLauncher();
+        var healthyAfter = await WaitHealthyAsync(isHealthy, healthTimeout, ct);
+        steps.Add(restored
+            ? $"rolled back to previous build (healthy={healthyAfter}); pinned away from {newVersion}"
+            : $"ROLLBACK FAILED - no .old backup; pinned away from {newVersion}");
+        return new SelfUpdateResult(
+            SelfUpdateOutcome.RolledBack,
+            $"Rolled back from bad {newVersion} (healthy after rollback={healthyAfter}).",
+            steps);
+    }
+
+    private async Task<bool> WaitHealthyAsync(Func<CancellationToken, Task<bool>> isHealthy, TimeSpan timeout, CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
+        {
+            try { if (await isHealthy(ct)) return true; }
+            catch { /* not up yet */ }
+            try { await Task.Delay(1000, ct); } catch (OperationCanceledException) { return false; }
+        }
+        return false;
+    }
+
+    /// <summary>Wait until the target exe can be opened for write (i.e. the old Launcher process exited and released it).</summary>
+    private bool WaitUntilWritable(string path)
+    {
+        if (!File.Exists(path)) return true; // nothing to unlock (fresh)
+        var deadline = DateTime.UtcNow + _unlockTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                using var fs = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                return true;
+            }
+            catch (IOException)
+            {
+                Thread.Sleep(500);
+            }
+        }
+        return false;
+    }
+
+    private void RecordInstalled(string version)
+    {
+        try
+        {
+            var m = InstalledManifest.Load(_layout);
+            m.Set(ComponentRegistry.Launcher.Id, version);
+            m.Save(_layout);
+        }
+        catch (Exception ex) { EngineLog.Write($"[LauncherSelfUpdate] record version failed: {ex.Message}"); }
+    }
+
+    private void Pin(string version)
+    {
+        try
+        {
+            var pins = PinStore.Load(_layout);
+            pins.Pin(ComponentRegistry.Launcher.Id, version);
+            PinStore.Save(_layout, pins);
+        }
+        catch (Exception ex) { EngineLog.Write($"[LauncherSelfUpdate] pin failed: {ex.Message}"); }
+    }
+
+    private static SelfUpdateResult Fail(List<string> steps, string message)
+    {
+        EngineLog.Write($"[LauncherSelfUpdate] FAILED: {message}");
+        return new SelfUpdateResult(SelfUpdateOutcome.Failed, message, steps);
+    }
+}

--- a/tools/cc-director-setup-engine/LauncherTrayInstaller.cs
+++ b/tools/cc-director-setup-engine/LauncherTrayInstaller.cs
@@ -1,0 +1,163 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Runtime.Versioning;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>The outcome of a Launcher tray-app install, with the steps taken (for logs / UI).</summary>
+public sealed record LauncherInstallResult(bool Success, string Message, IReadOnlyList<string> Steps);
+
+/// <summary>
+/// Performs the post-download step the generic <see cref="UpdateRunner"/> cannot: the runner places
+/// cc-launcher.exe but never starts it, so on a fresh install the launcher sits dormant and its
+/// autostart Run key is never written. This:
+///   1. stops any already-running installed launcher (so a fresh managed instance takes over),
+///   2. starts the launcher tray app with <c>--managed</c> (it runs the periodic self-update check
+///      and registers its own HKCU Run-key autostart on startup),
+///   3. waits for the launcher (7900) to answer /healthz,
+///   4. confirms the autostart Run key is registered.
+///
+/// The Launcher exe is already placed by the UpdateRunner at the Launcher component path before this
+/// runs. Ships to BOTH roles (it is in <see cref="ComponentRegistry.Apps"/> for Workstation and
+/// Gateway). Everything is per-user (%LOCALAPPDATA%): NO elevation, NO Windows service. Windows-only.
+/// Idempotent: starting an already-running launcher is harmless (the second instance sees the
+/// single-instance mutex held and exits). Mirrors <see cref="GatewayTrayInstaller"/>.
+/// </summary>
+public sealed class LauncherTrayInstaller
+{
+    /// <summary>The Launcher's default loopback REST port; kept here so the engine has no compile dependency on the Launcher exe.</summary>
+    public const int LauncherDefaultPort = 7900;
+
+    /// <summary>The arguments the installed tray app runs with: managed mode runs the self-update check.</summary>
+    public const string InstalledArguments = "--managed";
+
+    private readonly InstallLayout _layout;
+    private readonly HttpClient _http;
+
+    public LauncherTrayInstaller(InstallLayout layout, HttpClient? http = null)
+    {
+        _layout = layout ?? throw new ArgumentNullException(nameof(layout));
+        _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+    }
+
+    /// <summary>
+    /// Start the already-placed Launcher tray app in managed mode and verify it is healthy and
+    /// autostart-registered. The Launcher exe must already be placed (by the UpdateRunner) at
+    /// <see cref="InstallLayout.PathFor"/> for the Launcher component.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public async Task<LauncherInstallResult> InstallAsync(CancellationToken ct = default)
+    {
+        var steps = new List<string>();
+        EngineLog.Write("[LauncherTrayInstaller] InstallAsync begin");
+
+        var launcherExe = _layout.PathFor(ComponentRegistry.Launcher);
+        if (!File.Exists(launcherExe))
+            return Fail(steps, $"Launcher exe not present at {launcherExe}; the file swap must run first.");
+
+        // 1. Stop any already-running installed launcher so a fresh managed instance takes over (a
+        // re-install / repair path). Scoped to processes under the install dir only - a dev launcher
+        // running from a repo checkout is never touched.
+        StopInstalledProcesses(steps);
+
+        // 2. Start the tray app. It registers its own HKCU Run-key autostart (pointing at itself with
+        // the same arguments) on startup, so install-time registration and app self-registration can
+        // never disagree.
+        try
+        {
+            var psi = BuildTrayLaunchInfo(launcherExe, _layout.LauncherDir);
+            using var p = Process.Start(psi)
+                ?? throw new InvalidOperationException("Process.Start returned null");
+            steps.Add($"started Launcher tray app pid={p.Id} ({InstalledArguments})");
+        }
+        catch (Exception ex)
+        {
+            return Fail(steps, $"Failed to start the Launcher tray app: {ex.Message}");
+        }
+
+        // 3. Wait for health.
+        var up = await WaitForHttpAsync($"http://127.0.0.1:{LauncherDefaultPort}/healthz", TimeSpan.FromSeconds(20), ct);
+        steps.Add($"launcher healthz on {LauncherDefaultPort}: {(up ? "OK" : "no response")}");
+        if (!up)
+            return Fail(steps, $"Launcher tray app started but did not answer on {LauncherDefaultPort}. Check {_layout.LogsDir}.");
+
+        // 4. Verify the autostart Run key (written by the app on startup).
+        var registered = LauncherAutostart.IsRegistered();
+        steps.Add($"autostart Run key: {(registered ? "registered" : "NOT registered")}");
+        if (!registered)
+            return Fail(steps, "Launcher is healthy but did not register its autostart Run key; check the launcher log.");
+
+        EngineLog.Write("[LauncherTrayInstaller] InstallAsync success");
+        return new LauncherInstallResult(true, $"Launcher tray app installed and running on {LauncherDefaultPort}.", steps);
+    }
+
+    /// <summary>
+    /// Builds the <see cref="ProcessStartInfo"/> for launching the long-lived tray Launcher.
+    ///
+    /// <c>UseShellExecute=true</c> (with NO <c>RedirectStandard*</c>) so the Launcher does NOT inherit
+    /// the caller's stdout/stderr handles. An inherited stdout pipe keeps the caller's pipe open for
+    /// the Launcher's whole lifetime, so any caller that PIPES the CLI hangs forever after it exits
+    /// (the same fix as the GatewayApp relaunch path; see issue #175).
+    /// </summary>
+    public static ProcessStartInfo BuildTrayLaunchInfo(string launcherExe, string workingDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(launcherExe);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+
+        return new ProcessStartInfo
+        {
+            FileName = launcherExe,
+            Arguments = InstalledArguments,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = true,
+        };
+    }
+
+    /// <summary>
+    /// Kill installed launcher processes (image under the install dir ONLY) so its file unlocks. A dev
+    /// launcher running from a repo checkout is never touched.
+    /// </summary>
+    private void StopInstalledProcesses(List<string> steps)
+    {
+        var stopped = 0;
+        foreach (var p in Process.GetProcessesByName("cc-launcher"))
+        {
+            try
+            {
+                var path = p.MainModule?.FileName ?? "";
+                if (!path.StartsWith(_layout.LauncherDir, StringComparison.OrdinalIgnoreCase)) continue;
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(5000);
+                stopped++;
+            }
+            catch (Exception ex) { EngineLog.Write($"[LauncherTrayInstaller] stop cc-launcher pid={p.Id}: {ex.Message}"); }
+            finally { p.Dispose(); }
+        }
+        if (stopped > 0) steps.Add($"stopped {stopped} running installed Launcher process(es)");
+    }
+
+    private async Task<bool> WaitForHttpAsync(string url, TimeSpan timeout, CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
+        {
+            try
+            {
+                using var resp = await _http.GetAsync(url, ct);
+                if (resp.IsSuccessStatusCode) return true;
+            }
+            catch
+            {
+                // not up yet
+            }
+            try { await Task.Delay(1000, ct); } catch (OperationCanceledException) { return false; }
+        }
+        return false;
+    }
+
+    private static LauncherInstallResult Fail(List<string> steps, string message)
+    {
+        EngineLog.Write($"[LauncherTrayInstaller] FAILED: {message}");
+        return new LauncherInstallResult(false, message, steps);
+    }
+}

--- a/tools/cc-director-setup-engine/LauncherUpdater.cs
+++ b/tools/cc-director-setup-engine/LauncherUpdater.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Drives a CC Launcher self-update: decide if a newer Launcher exe is available, stage it (download
+/// + verify) to a stable path, and launch the detached helper (the staged exe in
+/// <c>--apply-update</c> mode) that performs the stop -> swap -> relaunch -> health -> rollback
+/// (<see cref="LauncherSelfUpdate"/>). The helper runs from the STAGED copy so the installed exe is
+/// free to overwrite once the running tray app exits. Refresh-only and pin-aware. Everything is
+/// per-user (no elevation): the Launcher is a tray app under %LOCALAPPDATA%. Mirrors
+/// <see cref="GatewayUpdater"/>.
+/// </summary>
+public sealed class LauncherUpdater
+{
+    private readonly InstallLayout _layout;
+
+    public LauncherUpdater(InstallLayout? layout = null)
+    {
+        _layout = layout ?? InstallLayout.Default();
+    }
+
+    /// <summary>The staging path the new Launcher exe is downloaded to before the swap.</summary>
+    public string StagedExePath => Path.Combine(_layout.StateDir, "staged", "cc-launcher.exe");
+
+    /// <summary>True when the release has a Launcher newer than the installed one (and it isn't pinned).</summary>
+    public bool IsUpdateAvailable(ResolvedRelease release)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+        var asset = release.Manifest.TryGetAsset(ComponentRegistry.Launcher.WindowsAsset);
+        if (asset is null) return false;
+
+        var installed = new InstalledStateReader(_layout).Read(ComponentRegistry.Launcher);
+        if (!installed.Present) return false; // refresh-only
+
+        if (PinStore.Load(_layout).IsPinned(ComponentRegistry.Launcher.Id, asset.Version)) return false;
+        return VersionUtil.IsNewer(asset.Version, installed.Version);
+    }
+
+    /// <summary>
+    /// Download + SHA-256 verify the new Launcher exe to <see cref="StagedExePath"/>. Returns the
+    /// staged path and version, or null if no update is available. Throws on a hash mismatch (never
+    /// stages a corrupt build).
+    /// </summary>
+    public async Task<(string StagedPath, string Version)?> StageAsync(ResolvedRelease release, ReleaseSource source, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+        ArgumentNullException.ThrowIfNull(source);
+        if (!IsUpdateAvailable(release)) return null;
+
+        var asset = release.Manifest.TryGetAsset(ComponentRegistry.Launcher.WindowsAsset);
+        if (asset is null) return null;
+
+        var downloaded = await source.DownloadAssetAsync(asset.Name, release.DownloadUrls, ct);
+        try
+        {
+            if (!Hashing.Sha256Matches(downloaded, asset.Sha256))
+                throw new InvalidOperationException("Launcher asset SHA-256 mismatch; not staging.");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(StagedExePath) ?? _layout.StateDir);
+            File.Copy(downloaded, StagedExePath, overwrite: true);
+            EngineLog.Write($"[LauncherUpdater] staged Launcher {asset.Version} -> {StagedExePath}");
+            return (StagedExePath, asset.Version);
+        }
+        finally
+        {
+            try { if (File.Exists(downloaded)) File.Delete(downloaded); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Launch the detached helper that applies the staged update. It runs from the staged exe (not the
+    /// installed one), so it survives the running tray app exiting and can overwrite the installed exe.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public Process LaunchDetachedUpdater(string stagedExePath, string newVersion, int port = LauncherTrayInstaller.LauncherDefaultPort)
+    {
+        var target = _layout.PathFor(ComponentRegistry.Launcher);
+        var psi = new ProcessStartInfo
+        {
+            FileName = stagedExePath,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("--apply-update");
+        psi.ArgumentList.Add("--new-version");
+        psi.ArgumentList.Add(newVersion);
+        psi.ArgumentList.Add("--target");
+        psi.ArgumentList.Add(target);
+        psi.ArgumentList.Add("--port");
+        psi.ArgumentList.Add(port.ToString());
+
+        var p = Process.Start(psi) ?? throw new InvalidOperationException("Failed to launch the Launcher self-update helper.");
+        EngineLog.Write($"[LauncherUpdater] launched detached updater pid={p.Id} for {newVersion}");
+        return p;
+    }
+
+    /// <summary>Convenience: if an update is available, stage it and launch the detached helper. Returns the staged version, or null.</summary>
+    [SupportedOSPlatform("windows")]
+    public async Task<string?> CheckStageAndLaunchAsync(ResolvedRelease release, ReleaseSource source, CancellationToken ct = default)
+    {
+        var staged = await StageAsync(release, source, ct);
+        if (staged is null) return null;
+        LaunchDetachedUpdater(staged.Value.StagedPath, staged.Value.Version);
+        return staged.Value.Version;
+    }
+}

--- a/tools/cc-director-setup-engine/Uninstaller.cs
+++ b/tools/cc-director-setup-engine/Uninstaller.cs
@@ -40,6 +40,9 @@ public sealed class Uninstaller
             ("CLI tools", _layout.BinDir),
             ("Python runtime", _layout.PythonDir),
             ("Python tools venv", _layout.PyenvDir),
+            // The Launcher tray app ships to BOTH roles (issue #250), so its binaries are removed
+            // regardless of role.
+            ("Launcher binaries", _layout.LauncherDir),
         };
         if (role == InstallRole.Gateway)
         {
@@ -67,6 +70,12 @@ public sealed class Uninstaller
             targets.Add(new UninstallTarget(
                 UninstallKind.Autostart, "Gateway autostart (HKCU Run key)",
                 GatewayAutostart.ValueName, GatewayAutostart.IsRegistered()));
+
+        // The Launcher autostart Run key exists for both roles (the launcher ships to both).
+        if (OperatingSystem.IsWindows())
+            targets.Add(new UninstallTarget(
+                UninstallKind.Autostart, "Launcher autostart (HKCU Run key)",
+                LauncherAutostart.ValueName, LauncherAutostart.IsRegistered()));
 
         foreach (var (desc, path) in Directories(role))
             targets.Add(new UninstallTarget(UninstallKind.Directory, desc, path, Directory.Exists(path)));
@@ -117,6 +126,16 @@ public sealed class Uninstaller
             // The 443 front-door Serve mapping is the Gateway's, so its teardown is Gateway-scoped.
             progress?.Report("Removing the Tailscale mapping");
             RemoveTailscaleServe(steps, errors);
+        }
+
+        // The Launcher tray app ships to both roles: stop it and remove its autostart Run key before
+        // the directory delete unlocks its exe.
+        if (OperatingSystem.IsWindows())
+        {
+            progress?.Report("Stopping the Launcher tray app");
+            StopLauncherTrayApp(steps);
+            progress?.Report("Removing the Launcher autostart");
+            RemoveLauncherAutostart(steps, errors);
         }
 
         progress?.Report("Removing the app and CLI tools");
@@ -337,6 +356,48 @@ public sealed class Uninstaller
         catch (Exception ex)
         {
             errors.Add($"autostart Run key: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Stop the INSTALLED Launcher tray app so its exe unlocks before the directory delete. Scoped
+    /// strictly to a process whose image lives under the install-owned Launcher dir - a dev launcher
+    /// running from a repo is never touched.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private void StopLauncherTrayApp(List<string> steps)
+    {
+        var stopped = 0;
+        foreach (var p in Process.GetProcessesByName("cc-launcher"))
+        {
+            try
+            {
+                var path = p.MainModule?.FileName ?? "";
+                if (!path.StartsWith(_layout.LauncherDir, StringComparison.OrdinalIgnoreCase)) continue;
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(5000);
+                stopped++;
+            }
+            catch (Exception ex) { EngineLog.Write($"[Uninstaller] stop cc-launcher pid={p.Id}: {ex.Message}"); }
+            finally { p.Dispose(); }
+        }
+        steps.Add(stopped > 0
+            ? $"stopped {stopped} installed Launcher process(es)"
+            : "Launcher tray app: not running");
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RemoveLauncherAutostart(List<string> steps, List<string> errors)
+    {
+        try
+        {
+            steps.Add(LauncherAutostart.Unregister()
+                ? $"removed autostart Run key ({LauncherAutostart.ValueName})"
+                : "Launcher autostart Run key: not present");
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Launcher autostart Run key: {ex.Message}");
         }
     }
 

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -385,8 +385,45 @@ public partial class MainWindow : Window
         if (_role == InstallRole.Gateway)
             await RunGatewayTrayInstallAsync(prep);
 
+        // Start the always-on Launcher tray app (Windows, both roles) AFTER the Gateway phase, so the
+        // order matches the CLI. Hard-fail like the CLI: if it does not come up, the install is not
+        // "done" - surface the error and offer Retry rather than reporting a clean success while the
+        // launcher is dead.
+        if (OperatingSystem.IsWindows() && !await StartLauncherAsync())
+        {
+            NextButton.Content = "Retry";
+            NextButton.IsEnabled = true;
+            return;
+        }
+
         NextButton.Content = "Next";
         NextButton.IsEnabled = true;
+    }
+
+    /// <summary>
+    /// Start the installed Launcher tray app in managed mode and verify it is healthy and
+    /// autostart-registered (the runner placed cc-launcher.exe but does not start it). Returns false
+    /// on any failure so the caller can hard-fail the install with a Retry, mirroring the CLI.
+    /// </summary>
+    private async Task<bool> StartLauncherAsync()
+    {
+        SetupLog.Write("[MainWindow] StartLauncherAsync");
+        _installStep?.SetStatus("Starting the Launcher tray app...");
+        try
+        {
+            var result = await new LauncherTrayInstaller(InstallLayout.Default()).InstallAsync();
+            foreach (var s in result.Steps) SetupLog.Write($"[MainWindow]   launcher: {s}");
+            SetupLog.Write($"[MainWindow] launcher start success={result.Success}: {result.Message}");
+            if (result.Success) return true;
+            _installStep?.SetStatus($"ERROR: Launcher tray app failed to start. {result.Message}");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            SetupLog.Write($"[MainWindow] StartLauncherAsync FAILED: {ex.Message}");
+            _installStep?.SetStatus($"ERROR: Launcher tray app failed to start. {ex.Message}");
+            return false;
+        }
     }
 
     private async Task RunGatewayTrayInstallAsync(EngineInstallRunner.Prep prep)

--- a/tools/cc-director-setup/Services/EngineInstallRunner.cs
+++ b/tools/cc-director-setup/Services/EngineInstallRunner.cs
@@ -167,6 +167,25 @@ public sealed class EngineInstallRunner
         if (File.Exists(AppExePath))
             ShortcutCreator.CreateStartMenuShortcut(AppExePath);
 
+        // Start the Launcher tray app (Windows, both roles): the runner placed cc-launcher.exe but
+        // does not start it, so without this it sits dormant and never writes its autostart Run key.
+        // Managed mode runs the self-update loop and self-registers autostart. Reported to the log
+        // and kept non-fatal (like the wizard's Gateway phase): a launcher start hiccup must not fail
+        // an otherwise-good Director/tools install, and the app re-asserts autostart on its own start.
+        if (OperatingSystem.IsWindows())
+        {
+            try
+            {
+                var launcherResult = await new LauncherTrayInstaller(_layout).InstallAsync(ct);
+                SetupLog.Write($"[EngineInstallRunner] launcher start: success={launcherResult.Success}: {launcherResult.Message}");
+                foreach (var s in launcherResult.Steps) SetupLog.Write($"[EngineInstallRunner]   launcher: {s}");
+            }
+            catch (Exception ex)
+            {
+                SetupLog.Write($"[EngineInstallRunner] launcher start FAILED: {ex.Message}");
+            }
+        }
+
         var installed = result.Installed + result.Updated + toolCount;
         var skipped = prep.Items.Count(i => i.Status is "Skipped" or "Failed");
         SetupLog.Write($"[EngineInstallRunner] ApplyAsync: installed={installed}, skipped={skipped}");

--- a/tools/cc-director-setup/Services/EngineInstallRunner.cs
+++ b/tools/cc-director-setup/Services/EngineInstallRunner.cs
@@ -167,24 +167,10 @@ public sealed class EngineInstallRunner
         if (File.Exists(AppExePath))
             ShortcutCreator.CreateStartMenuShortcut(AppExePath);
 
-        // Start the Launcher tray app (Windows, both roles): the runner placed cc-launcher.exe but
-        // does not start it, so without this it sits dormant and never writes its autostart Run key.
-        // Managed mode runs the self-update loop and self-registers autostart. Reported to the log
-        // and kept non-fatal (like the wizard's Gateway phase): a launcher start hiccup must not fail
-        // an otherwise-good Director/tools install, and the app re-asserts autostart on its own start.
-        if (OperatingSystem.IsWindows())
-        {
-            try
-            {
-                var launcherResult = await new LauncherTrayInstaller(_layout).InstallAsync(ct);
-                SetupLog.Write($"[EngineInstallRunner] launcher start: success={launcherResult.Success}: {launcherResult.Message}");
-                foreach (var s in launcherResult.Steps) SetupLog.Write($"[EngineInstallRunner]   launcher: {s}");
-            }
-            catch (Exception ex)
-            {
-                SetupLog.Write($"[EngineInstallRunner] launcher start FAILED: {ex.Message}");
-            }
-        }
+        // NOTE: the runner above PLACES cc-launcher.exe (it is an in-scope component for both roles),
+        // but STARTING it is done by MainWindow.StartLauncherAsync after the Gateway phase, so the
+        // order matches the CLI (Gateway first, then the launcher) and a launcher start failure can
+        // hard-fail the wizard with a Retry instead of being swallowed here.
 
         var installed = result.Installed + result.Updated + toolCount;
         var skipped = prep.Items.Count(i => i.Status is "Skipped" or "Failed");


### PR DESCRIPTION
## What & why

Brings the **CC Launcher** tray app to full **Gateway parity** so it installs, runs always-on, autostarts at login, and self-updates on every workstation and the Gateway box. The app was already fully built (tray icon, loopback REST API, clean-parentage launch, Director supervisor, Gateway registration) but was **never wired to ship or start** — so on a real machine it sat on disk dormant. This closes that gap.

## Before this PR

| Need | Status |
|------|--------|
| Built & shipped in a release | MISSING (no build job; asset never produced) |
| Started after install | MISSING (runner placed the exe but nothing started it) |
| Autostart at login | MISSING (Run key only written if the exe was ever run) |
| Self-update | MISSING (no updater / `--apply-update`) |

## Changes

- **Release** (`release.yml`): new `build-launcher-win` job publishes `cc-launcher-win-x64.exe`; wired into `create-release` (needs, collect, and the **required-assets** completeness check, so a missing launcher fails the release).
- **Install + start** (`LauncherTrayInstaller`, engine): after the generic runner places the exe, stop any running installed instance, start it `--managed`, wait for `/healthz` on :7900, and verify the autostart Run key.
  - CLI: `Commands.UpdateAsync` starts it (both roles), after the Gateway phase; failure returns a non-zero exit.
  - WPF wizard: `MainWindow` starts it after the Gateway phase; failure **hard-fails** the install with a Retry (same UX as a release-fetch failure) — matching the CLI.
- **Autostart**: `LauncherAutostart` moved into the engine (so the installer can verify it) and given `--managed` argument support, mirroring `GatewayAutostart`. The app self-registers `CcDirectorLauncher` on startup.
- **Self-update**: `LauncherUpdater` + `LauncherSelfUpdate` + `--apply-update` mode in `Program.cs` + a managed update loop in `LauncherTrayController` — stage -> swap -> relaunch -> health-check -> **auto-rollback + version-pin** on failure, mirroring the Gateway.
- **Uninstall**: remove the launcher dir + autostart Run key for **both** roles.

## Roll-out note

Existing fleet machines pick up the launcher the next time the installer/updater runs (the launcher only self-updates *after* it is first installed) — same model as the Gateway.

## Tests

- New `LauncherSelfUpdateTests` (healthy swap + records version/no-pin; unhealthy -> rollback + pin) and `LauncherUpdaterTests` (is-update-available matrix; stage downloads/verifies).
- Updated the workstation uninstall-plan test for the launcher's autostart + dir.
- Full local runs: engine **156/156**, launcher **22/22**, setup CLI **17/17**. CI builds + tests the whole solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
