### PR TITLE
feat(gateway): cron firing engine, run history, and guards (#483)

### DIFF
--- a/docs/cencon/proof/issue-483/qa-report.html
+++ b/docs/cencon/proof/issue-483/qa-report.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>QA Proof Report - Issue #483</title>
+<style>
+        /* Boardroom Theme - Corporate, executive style with serif fonts */
+        
+        :root {
+            /* Colors */
+            --primary: #1A365D;
+            --primary-light: #2A4A7F;
+            --accent: #D69E2E;
+            --text: #2D3748;
+            --heading: #1A365D;
+            --background: #FFFFFF;
+            --code-bg: #EDF2F7;
+            --code-text: #1A365D;
+            --border: #CBD5E0;
+            --link: #2B6CB0;
+            --blockquote-text: #4A5568;
+            --blockquote-border: #D69E2E;
+            --blockquote-bg: #FFFFFF;
+            --table-header-bg: #1A365D;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #F7FAFC;
+            --shadow-color: rgba(26, 54, 93, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Palatino Linotype", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Georgia", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Courier New", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.02em;
+            --line-height: 1.7;
+            --radius: 4px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(26, 54, 93, 0.08);
+            --shadow-md: 0 4px 12px rgba(26, 54, 93, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Boardroom: corporate authority with accent borders */
+        h1 {
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.3em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        pre::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
+            background: var(--accent);
+            border-radius: 0;
+        }
+        
+        blockquote {
+            font-style: italic;
+        }
+        
+        hr {
+            background: var(--accent);
+            max-width: none;
+            height: 2px;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>QA Proof Report - Issue #483</h1>
+<h2>Cron jobs (2/3): firing engine, run history, and guards</h2>
+<p><strong>Verifier:</strong> QA Agent (independent - own fresh build + own test run, did not trust the dev report).
+        <strong>PR:</strong> #486 (branch <code>issue-483-cron-firing-engine</code>, HEAD 03b807c).
+        <strong>Mode:</strong> standalone QA (outside the implementation-loop) -&gt; NOT merged; merge left to the human.</p>
+<h2>How I verified independently</h2>
+<ol>
+<li>Checked out the PR branch fresh and <strong>built the whole solution myself</strong>: <code>dotnet build cc-director.sln</code> -&gt; <strong>0 Warning(s), 0 Error(s)</strong>.</li>
+<li><strong>Ran the cron suite myself</strong>: <code>dotnet test --filter Cron</code> -&gt; <strong>48 Passed, 0 Failed, 0 Skipped</strong> (17 new for #483: 7 engine + 6 history + 4 real-HTTP endpoint; plus #482's 31).</li>
+<li><strong>Adversarially audited the engine</strong> (review-code lens) against the issue - focusing on the two subtle correctness points (catch-up "fire once" and overlap release) - and swept the new source for forbidden patterns.</li>
+</ol>
+<p>No live full Gateway booted: it would run the machine-global Tailscale Serve provisioner and bind :7878, colliding with the running Gateway (<a href="http://CLAUDE.md">CLAUDE.md</a> rule 0). The firing engine is proven deterministically via an injectable <code>IClock</code> (FakeClock) + fake <code>ICronSessionStarter</code>, and run-now/history over real HTTP - the equivalent running-app proof for a headless slice.</p>
+<h2>Acceptance criteria - Expected vs Actual (independently judged)</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Criterion</th>
+<th>Evidence (reproduced)</th>
+<th>Verdict</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AC1</td>
+<td>Due job fires: session started on target, run recorded</td>
+<td><code>EvaluateDue_RecurringJobDue_Fires_RecordsRun_AdvancesNextRun</code> - starter invoked, 1 run, NextRunUtc advanced to future</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC2</td>
+<td><code>POST /cron/jobs/{id}/run</code> fires immediately + records</td>
+<td><code>RunNow_FiresAndRecords_WithFullRecordShape</code> (real HTTP 200 + record)</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC3</td>
+<td><code>GET /cron/jobs/{id}/runs</code> records carry scheduled/fired/target/session/infra/task</td>
+<td><code>Runs_ReturnsHistory_AfterRunNow</code> + record-shape assertions; infra ("started") distinct from task ("unknown")</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC4</td>
+<td>Overlap: in-flight job's 2nd fire skipped, no 2nd session</td>
+<td><code>RunNow_WhilePriorRunInFlight_SecondIsSkippedAsOverlap</code> - 2nd -&gt; SkippedOverlap, starter invoked once</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC5</td>
+<td>Disabled job does not fire; enabling resumes</td>
+<td><code>EvaluateDue_DisabledJob_DoesNotFire_ThenEnablingResumes</code> - 0 while disabled, 1 after enable</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC6</td>
+<td>Missed fire fires AT MOST ONCE, not per-interval</td>
+<td><code>EvaluateDue_MissedFireWhileDown_FiresAtMostOnce_NotPerInterval</code> - 3-day downtime -&gt; exactly 1 fire, infra="catch-up", advanced</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC7</td>
+<td>One-off fires once then auto-disables</td>
+<td><code>EvaluateDue_OneOff_FiresOnce_ThenAutoDisables</code> - Enabled=false, NextRunUtc=null, no refire</td>
+<td>PASS</td>
+</tr>
+</tbody>
+</table>
+<p>Audited the code paths behind the subtle ACs: catch-up recomputes <code>ComputeNextRunUtc(job, firedUtc)</code> to the next FUTURE occurrence (no backlog replay); the overlap claim is released in a <code>finally</code>; one-off disables with a null next-run; the sweep timer is disposed in <code>StopAsync</code> and its callback owns a boundary try/catch. <code>Fire_WhenStarterReportsError_RecordsNotStarted</code> confirms a failed start still records <code>infraStatus=not-started</code> with no sessionId.</p>
+<h2>Method / regression lens</h2>
+<ul>
+<li><strong>Forbidden patterns:</strong> swept the 6 new source files for null-forgiving <code>!</code>, <code>.Result</code>, <code>.Wait()</code> -&gt; <strong>none</strong> (<code>!started</code>/<code>!isManual</code> are logical-not, allowed).</li>
+<li><strong>Catch blocks:</strong> boundary-only (sweep timer callback; engine per-job isolation at the timer boundary; history quarantine/save log-and-rethrow). No silent fallbacks.</li>
+<li><strong>Security (DT rules):</strong> no new auth surface (inherits host-wide token middleware); engine reuses the existing Director session-create path (no new Director surface); no secrets logged. No blocking rule violated.</li>
+<li><strong>Tests:</strong> present for all new behavior; warnings-as-errors clean.</li>
+</ul>
+<h3>Non-blocking observations (not defects)</h3>
+<ol>
+<li><code>RunNowAsync</code> fires even a disabled job (no enabled-check on the manual path). Not constrained by any AC; a reasonable manual-override semantic. Flagged for awareness.</li>
+<li><code>architecture_manifest.yaml</code> does not yet list the cron firing components - same deferral as #482; recommend Support records the full set when #484 lands. No security-posture change.</li>
+</ol>
+<h2>Verdict</h2>
+<p><strong>VERIFIED - all 7 acceptance criteria met.</strong> Build clean, 48/48 cron tests pass on an independent build, no forbidden patterns, no security drift, catch-up/overlap/one-off logic audited correct. Standalone QA does not merge; <strong>PR #486 is ready for the human to merge.</strong></p>
+</article>
+</body>
+</html>

--- a/docs/cencon/proof/issue-483/qa-report.md
+++ b/docs/cencon/proof/issue-483/qa-report.md
@@ -1,0 +1,43 @@
+# QA Proof Report - Issue #483
+
+## Cron jobs (2/3): firing engine, run history, and guards
+
+**Verifier:** QA Agent (independent - own fresh build + own test run, did not trust the dev report).
+**PR:** #486 (branch `issue-483-cron-firing-engine`, HEAD 03b807c).
+**Mode:** standalone QA (outside the implementation-loop) -> NOT merged; merge left to the human.
+
+## How I verified independently
+
+1. Checked out the PR branch fresh and **built the whole solution myself**: `dotnet build cc-director.sln` -> **0 Warning(s), 0 Error(s)**.
+2. **Ran the cron suite myself**: `dotnet test --filter Cron` -> **48 Passed, 0 Failed, 0 Skipped** (17 new for #483: 7 engine + 6 history + 4 real-HTTP endpoint; plus #482's 31).
+3. **Adversarially audited the engine** (review-code lens) against the issue - focusing on the two subtle correctness points (catch-up "fire once" and overlap release) - and swept the new source for forbidden patterns.
+
+No live full Gateway booted: it would run the machine-global Tailscale Serve provisioner and bind :7878, colliding with the running Gateway (CLAUDE.md rule 0). The firing engine is proven deterministically via an injectable `IClock` (FakeClock) + fake `ICronSessionStarter`, and run-now/history over real HTTP - the equivalent running-app proof for a headless slice.
+
+## Acceptance criteria - Expected vs Actual (independently judged)
+
+| # | Criterion | Evidence (reproduced) | Verdict |
+|---|-----------|-----------------------|---------|
+| AC1 | Due job fires: session started on target, run recorded | `EvaluateDue_RecurringJobDue_Fires_RecordsRun_AdvancesNextRun` - starter invoked, 1 run, NextRunUtc advanced to future | PASS |
+| AC2 | `POST /cron/jobs/{id}/run` fires immediately + records | `RunNow_FiresAndRecords_WithFullRecordShape` (real HTTP 200 + record) | PASS |
+| AC3 | `GET /cron/jobs/{id}/runs` records carry scheduled/fired/target/session/infra/task | `Runs_ReturnsHistory_AfterRunNow` + record-shape assertions; infra ("started") distinct from task ("unknown") | PASS |
+| AC4 | Overlap: in-flight job's 2nd fire skipped, no 2nd session | `RunNow_WhilePriorRunInFlight_SecondIsSkippedAsOverlap` - 2nd -> SkippedOverlap, starter invoked once | PASS |
+| AC5 | Disabled job does not fire; enabling resumes | `EvaluateDue_DisabledJob_DoesNotFire_ThenEnablingResumes` - 0 while disabled, 1 after enable | PASS |
+| AC6 | Missed fire fires AT MOST ONCE, not per-interval | `EvaluateDue_MissedFireWhileDown_FiresAtMostOnce_NotPerInterval` - 3-day downtime -> exactly 1 fire, infra="catch-up", advanced | PASS |
+| AC7 | One-off fires once then auto-disables | `EvaluateDue_OneOff_FiresOnce_ThenAutoDisables` - Enabled=false, NextRunUtc=null, no refire | PASS |
+
+Audited the code paths behind the subtle ACs: catch-up recomputes `ComputeNextRunUtc(job, firedUtc)` to the next FUTURE occurrence (no backlog replay); the overlap claim is released in a `finally`; one-off disables with a null next-run; the sweep timer is disposed in `StopAsync` and its callback owns a boundary try/catch. `Fire_WhenStarterReportsError_RecordsNotStarted` confirms a failed start still records `infraStatus=not-started` with no sessionId.
+
+## Method / regression lens
+- **Forbidden patterns:** swept the 6 new source files for null-forgiving `!`, `.Result`, `.Wait()` -> **none** (`!started`/`!isManual` are logical-not, allowed).
+- **Catch blocks:** boundary-only (sweep timer callback; engine per-job isolation at the timer boundary; history quarantine/save log-and-rethrow). No silent fallbacks.
+- **Security (DT rules):** no new auth surface (inherits host-wide token middleware); engine reuses the existing Director session-create path (no new Director surface); no secrets logged. No blocking rule violated.
+- **Tests:** present for all new behavior; warnings-as-errors clean.
+
+### Non-blocking observations (not defects)
+1. `RunNowAsync` fires even a disabled job (no enabled-check on the manual path). Not constrained by any AC; a reasonable manual-override semantic. Flagged for awareness.
+2. `architecture_manifest.yaml` does not yet list the cron firing components - same deferral as #482; recommend Support records the full set when #484 lands. No security-posture change.
+
+## Verdict
+
+**VERIFIED - all 7 acceptance criteria met.** Build clean, 48/48 cron tests pass on an independent build, no forbidden patterns, no security drift, catch-up/overlap/one-off logic audited correct. Standalone QA does not merge; **PR #486 is ready for the human to merge.**

--- a/docs/cencon/proof/issue-483/report.html
+++ b/docs/cencon/proof/issue-483/report.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Proof Report - Issue #483</title>
+<style>
+        /* Boardroom Theme - Corporate, executive style with serif fonts */
+        
+        :root {
+            /* Colors */
+            --primary: #1A365D;
+            --primary-light: #2A4A7F;
+            --accent: #D69E2E;
+            --text: #2D3748;
+            --heading: #1A365D;
+            --background: #FFFFFF;
+            --code-bg: #EDF2F7;
+            --code-text: #1A365D;
+            --border: #CBD5E0;
+            --link: #2B6CB0;
+            --blockquote-text: #4A5568;
+            --blockquote-border: #D69E2E;
+            --blockquote-bg: #FFFFFF;
+            --table-header-bg: #1A365D;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #F7FAFC;
+            --shadow-color: rgba(26, 54, 93, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Palatino Linotype", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Georgia", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Courier New", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.02em;
+            --line-height: 1.7;
+            --radius: 4px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(26, 54, 93, 0.08);
+            --shadow-md: 0 4px 12px rgba(26, 54, 93, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Boardroom: corporate authority with accent borders */
+        h1 {
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.3em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        pre::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
+            background: var(--accent);
+            border-radius: 0;
+        }
+        
+        blockquote {
+            font-style: italic;
+        }
+        
+        hr {
+            background: var(--accent);
+            max-width: none;
+            height: 2px;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>Proof Report - Issue #483</h1>
+<h2>Cron jobs (2/3): firing engine, run history, and guards</h2>
+<p><strong>Part 2 of 3 of epic #479.</strong> Makes cron jobs actually fire, on top of the merged #482 store/CRUD.</p>
+<p><strong>Branch/PR:</strong> issue-483-cron-firing-engine (PR #486)
+        <strong>Build:</strong> <code>dotnet build cc-director.sln</code> -&gt; <strong>Build succeeded, 0 Warning(s), 0 Error(s)</strong>.
+        <strong>Tests:</strong> <code>dotnet test --filter Cron</code> -&gt; <strong>48 Passed, 0 Failed, 0 Skipped</strong> (17 new for #483 + 31 from #482).</p>
+<h2>How this slice is proven</h2>
+<p>The firing engine is made deterministically testable with two seams: an injectable <code>IClock</code> (a <code>FakeClock</code> makes a job "due" without waiting on the wall clock) and an injectable <code>ICronSessionStarter</code> (a fake stands in for a live Director). So every guard is proven without a running Director. The run-now + history REST surface is proven over <strong>real HTTP</strong> (<code>CronRunEndpointsTests</code> boots the actual <code>CronRunEndpoints</code> on a loopback port). No live full Gateway is booted (it would run the machine-global Tailscale Serve provisioner and bind :7878, colliding with the running Gateway - <a href="http://CLAUDE.md">CLAUDE.md</a> rule 0); the engine + real-HTTP tests are the equivalent running-app proof for this headless slice.</p>
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Criterion</th>
+<th>Proof (test)</th>
+<th>Expected</th>
+<th>Actual</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AC1</td>
+<td>A due job fires: session started on target Director, run recorded</td>
+<td><code>CronEngineTests.EvaluateDue_RecurringJobDue_Fires_RecordsRun_AdvancesNextRun</code></td>
+<td>starter invoked with the job, 1 run recorded, NextRunUtc advanced to future</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC2</td>
+<td><code>POST /cron/jobs/{id}/run</code> fires immediately + records</td>
+<td><code>CronRunEndpointsTests.RunNow_FiresAndRecords_WithFullRecordShape</code></td>
+<td>200 + CronRunRecord</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC3</td>
+<td><code>GET /cron/jobs/{id}/runs</code> returns records with scheduledUtc/firedUtc/targetDirectorId/sessionId/infraStatus/taskStatus</td>
+<td><code>CronRunEndpointsTests.RunNow_FiresAndRecords...</code>, <code>.Runs_ReturnsHistory...</code></td>
+<td>all six fields; infra ("started") distinct from task ("unknown")</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC4</td>
+<td>Overlap: in-flight job's second fire skipped, no 2nd session</td>
+<td><code>CronEngineTests.RunNow_WhilePriorRunInFlight_SecondIsSkippedAsOverlap</code></td>
+<td>2nd run -&gt; SkippedOverlap, starter invoked once</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC5</td>
+<td>Disabled job does not fire; enabling resumes</td>
+<td><code>CronEngineTests.EvaluateDue_DisabledJob_DoesNotFire_ThenEnablingResumes</code></td>
+<td>0 fires while disabled; 1 after enable</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC6</td>
+<td>Missed fire fires AT MOST ONCE on recovery, not per-interval</td>
+<td><code>CronEngineTests.EvaluateDue_MissedFireWhileDown_FiresAtMostOnce_NotPerInterval</code></td>
+<td>3-day downtime -&gt; exactly 1 fire, infra="catch-up", NextRunUtc advanced</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC7</td>
+<td>One-off fires once then auto-disables</td>
+<td><code>CronEngineTests.EvaluateDue_OneOff_FiresOnce_ThenAutoDisables</code></td>
+<td>Enabled=false, NextRunUtc=null, no refire</td>
+<td>PASS</td>
+</tr>
+</tbody>
+</table>
+<p>Supporting: <code>Fire_WhenStarterReportsError_RecordsNotStarted</code> proves a failed session-start still records a run with <code>infraStatus=not-started</code> and no sessionId (infra-vs-task honesty). <code>CronRunHistoryStoreTests</code> proves newest-first order, the per-job cap, persistence round-trip, and corrupt-file quarantine.</p>
+<h2>CenCon impact</h2>
+<p>Adds the firing engine, run-history store, and run endpoints to the <code>gateway</code> container, plus a background sweep timer on <code>GatewayHost</code>. No security-posture change: routes inherit the host-wide token middleware; the engine reuses the existing Director session-create path (no new Director surface); no secrets logged. Recommend the Support Agent record the full cron component set in <code>architecture_manifest.yaml</code> when part 3 (#484) lands.</p>
+<h2>Statement</h2>
+<p>I believe this slice (#483) is finished: cron jobs fire on a background sweep, run history is recorded and served, and every guard (disabled, overlap, one-off, catch-up) is proven by a passing deterministic test. The solution builds clean with zero warnings. The named-work-list use case is intentionally out of scope and lands in #484.</p>
+</article>
+</body>
+</html>

--- a/docs/cencon/proof/issue-483/report.md
+++ b/docs/cencon/proof/issue-483/report.md
@@ -1,0 +1,35 @@
+# Proof Report - Issue #483
+
+## Cron jobs (2/3): firing engine, run history, and guards
+
+**Part 2 of 3 of epic #479.** Makes cron jobs actually fire, on top of the merged #482 store/CRUD.
+
+**Branch/PR:** issue-483-cron-firing-engine (PR #486)
+**Build:** `dotnet build cc-director.sln` -> **Build succeeded, 0 Warning(s), 0 Error(s)**.
+**Tests:** `dotnet test --filter Cron` -> **48 Passed, 0 Failed, 0 Skipped** (17 new for #483 + 31 from #482).
+
+## How this slice is proven
+
+The firing engine is made deterministically testable with two seams: an injectable `IClock` (a `FakeClock` makes a job "due" without waiting on the wall clock) and an injectable `ICronSessionStarter` (a fake stands in for a live Director). So every guard is proven without a running Director. The run-now + history REST surface is proven over **real HTTP** (`CronRunEndpointsTests` boots the actual `CronRunEndpoints` on a loopback port). No live full Gateway is booted (it would run the machine-global Tailscale Serve provisioner and bind :7878, colliding with the running Gateway - CLAUDE.md rule 0); the engine + real-HTTP tests are the equivalent running-app proof for this headless slice.
+
+## Acceptance criteria - Expected vs Actual
+
+| # | Criterion | Proof (test) | Expected | Actual |
+|---|-----------|--------------|----------|--------|
+| AC1 | A due job fires: session started on target Director, run recorded | `CronEngineTests.EvaluateDue_RecurringJobDue_Fires_RecordsRun_AdvancesNextRun` | starter invoked with the job, 1 run recorded, NextRunUtc advanced to future | PASS |
+| AC2 | `POST /cron/jobs/{id}/run` fires immediately + records | `CronRunEndpointsTests.RunNow_FiresAndRecords_WithFullRecordShape` | 200 + CronRunRecord | PASS |
+| AC3 | `GET /cron/jobs/{id}/runs` returns records with scheduledUtc/firedUtc/targetDirectorId/sessionId/infraStatus/taskStatus | `CronRunEndpointsTests.RunNow_FiresAndRecords...`, `.Runs_ReturnsHistory...` | all six fields; infra ("started") distinct from task ("unknown") | PASS |
+| AC4 | Overlap: in-flight job's second fire skipped, no 2nd session | `CronEngineTests.RunNow_WhilePriorRunInFlight_SecondIsSkippedAsOverlap` | 2nd run -> SkippedOverlap, starter invoked once | PASS |
+| AC5 | Disabled job does not fire; enabling resumes | `CronEngineTests.EvaluateDue_DisabledJob_DoesNotFire_ThenEnablingResumes` | 0 fires while disabled; 1 after enable | PASS |
+| AC6 | Missed fire fires AT MOST ONCE on recovery, not per-interval | `CronEngineTests.EvaluateDue_MissedFireWhileDown_FiresAtMostOnce_NotPerInterval` | 3-day downtime -> exactly 1 fire, infra="catch-up", NextRunUtc advanced | PASS |
+| AC7 | One-off fires once then auto-disables | `CronEngineTests.EvaluateDue_OneOff_FiresOnce_ThenAutoDisables` | Enabled=false, NextRunUtc=null, no refire | PASS |
+
+Supporting: `Fire_WhenStarterReportsError_RecordsNotStarted` proves a failed session-start still records a run with `infraStatus=not-started` and no sessionId (infra-vs-task honesty). `CronRunHistoryStoreTests` proves newest-first order, the per-job cap, persistence round-trip, and corrupt-file quarantine.
+
+## CenCon impact
+
+Adds the firing engine, run-history store, and run endpoints to the `gateway` container, plus a background sweep timer on `GatewayHost`. No security-posture change: routes inherit the host-wide token middleware; the engine reuses the existing Director session-create path (no new Director surface); no secrets logged. Recommend the Support Agent record the full cron component set in `architecture_manifest.yaml` when part 3 (#484) lands.
+
+## Statement
+
+I believe this slice (#483) is finished: cron jobs fire on a background sweep, run history is recorded and served, and every guard (disabled, overlap, one-off, catch-up) is proven by a passing deterministic test. The solution builds clean with zero warnings. The named-work-list use case is intentionally out of scope and lands in #484.

--- a/src/CcDirector.Gateway.Tests/CronEngineTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronEngineTests.cs
@@ -1,0 +1,231 @@
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="CronEngine"/> (epic #479, #483). A <see cref="FakeClock"/> makes jobs
+/// due without waiting on the wall clock and a fake <see cref="ICronSessionStarter"/> stands in for a
+/// live Director, so the firing logic and every guard (overlap, disabled, one-off, catch-up) is
+/// verified deterministically. Covers AC1, AC4, AC5, AC6, AC7 here; AC2/AC3 (run-now + history shape)
+/// are covered by <see cref="CronRunEndpointsTests"/> and <see cref="CronRunHistoryStoreTests"/>.
+/// </summary>
+public sealed class CronEngineTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-cronengine-tests-" + Guid.NewGuid().ToString("N"));
+
+    private CronJobStore NewJobStore() => new(Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".json"));
+    private CronRunHistoryStore NewHistory() => new(Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".runs.json"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private static CronJobDto Recurring(string name = "nightly", bool enabled = true) => new()
+    {
+        Name = name,
+        Enabled = enabled,
+        ScheduleKind = CronSchedule.KindRecurring,
+        CronExpression = "0 0 * * *",
+        TimeZoneId = "America/Chicago",
+        Target = new CronJobTarget { DirectorId = "workstation-A" },
+        Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "/work-list run Tonight" },
+    };
+
+    private static CronJobDto OneOff(DateTime runAtLocal) => new()
+    {
+        Name = "once",
+        ScheduleKind = CronSchedule.KindOneOff,
+        RunAt = runAtLocal.ToString("yyyy-MM-ddTHH:mm:ss"),
+        TimeZoneId = "America/Chicago",
+        Target = new CronJobTarget { DirectorId = "workstation-A" },
+        Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "/help" },
+    };
+
+    [Fact]
+    public async Task EvaluateDue_RecurringJobDue_Fires_RecordsRun_AdvancesNextRun()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var starter = new RecordingStarter();
+        var created = store.Create(Recurring());
+        Assert.NotNull(created.NextRunUtc);
+
+        var clock = new FakeClock(created.NextRunUtc.Value.AddMinutes(1));
+        var engine = new CronEngine(store, history, starter, clock);
+
+        var fired = await engine.EvaluateDueAsync(CancellationToken.None);
+
+        Assert.Single(fired);                                     // AC1: it fired
+        Assert.Equal(1, starter.StartCount);                       // a session start was attempted
+        Assert.Equal("workstation-A", starter.LastJob?.Target.DirectorId);
+        Assert.Single(history.List(created.Id));                   // a run was recorded
+        var after = store.Get(created.Id);
+        Assert.NotNull(after);
+        Assert.NotNull(after.LastFiredUtc);
+        Assert.NotNull(after.NextRunUtc);
+        Assert.True(after.NextRunUtc.Value > clock.UtcNow);        // schedule advanced into the future
+    }
+
+    [Fact]
+    public async Task EvaluateDue_DisabledJob_DoesNotFire_ThenEnablingResumes()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var starter = new RecordingStarter();
+        var created = store.Create(Recurring(enabled: false));
+        var clock = new FakeClock((created.NextRunUtc ?? DateTime.UtcNow).AddDays(1));
+        var engine = new CronEngine(store, history, starter, clock);
+
+        var firedWhileDisabled = await engine.EvaluateDueAsync(CancellationToken.None);
+        Assert.Empty(firedWhileDisabled);                          // AC5: disabled never fires
+        Assert.Equal(0, starter.StartCount);
+
+        // Enable it and re-evaluate -> it fires.
+        var enabled = Recurring(enabled: true);
+        store.Update(created.Id, enabled);
+        var fired = await engine.EvaluateDueAsync(CancellationToken.None);
+        Assert.Single(fired);
+        Assert.Equal(1, starter.StartCount);
+    }
+
+    [Fact]
+    public async Task EvaluateDue_MissedFireWhileDown_FiresAtMostOnce_NotPerInterval()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var starter = new RecordingStarter();
+        var created = store.Create(Recurring());                   // daily; NextRunUtc = next midnight
+
+        // The Gateway was "down" for ~3 days: now is far past the due time, spanning several missed
+        // daily occurrences.
+        var clock = new FakeClock(created.NextRunUtc!.Value.AddDays(3).AddHours(2));
+        var engine = new CronEngine(store, history, starter, clock);
+
+        await engine.EvaluateDueAsync(CancellationToken.None);
+        await engine.EvaluateDueAsync(CancellationToken.None);     // a second sweep at the same instant
+
+        Assert.Equal(1, starter.StartCount);                        // AC6: exactly one catch-up fire
+        Assert.Single(history.List(created.Id));
+        var after = store.Get(created.Id);
+        Assert.NotNull(after);
+        Assert.True(after.NextRunUtc!.Value > clock.UtcNow);        // advanced to the next FUTURE occurrence
+        Assert.Equal("catch-up", history.List(created.Id)[0].InfraStatus);
+    }
+
+    [Fact]
+    public async Task EvaluateDue_OneOff_FiresOnce_ThenAutoDisables()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var starter = new RecordingStarter();
+        var created = store.Create(OneOff(DateTime.Now.Date.AddDays(1)));
+        var clock = new FakeClock(created.NextRunUtc!.Value.AddMinutes(1));
+        var engine = new CronEngine(store, history, starter, clock);
+
+        await engine.EvaluateDueAsync(CancellationToken.None);
+        var after = store.Get(created.Id);
+        Assert.NotNull(after);
+        Assert.False(after.Enabled);                                // AC7: one-off auto-disables
+        Assert.Null(after.NextRunUtc);
+
+        // A later sweep does not fire it again.
+        var clock2Engine = new CronEngine(store, history, starter, new FakeClock(clock.UtcNow.AddDays(1)));
+        var firedAgain = await clock2Engine.EvaluateDueAsync(CancellationToken.None);
+        Assert.Empty(firedAgain);
+        Assert.Equal(1, starter.StartCount);
+    }
+
+    [Fact]
+    public async Task RunNow_WhilePriorRunInFlight_SecondIsSkippedAsOverlap()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var blocking = new BlockingStarter();
+        var created = store.Create(Recurring());                   // PreventOverlap defaults true
+        var engine = new CronEngine(store, history, blocking, new FakeClock(DateTime.UtcNow));
+
+        // Start the first run; it blocks inside the starter.
+        var firstRun = engine.RunNowAsync(created.Id, CancellationToken.None);
+        await blocking.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // A second run-now while the first is in flight is skipped.
+        var second = await engine.RunNowAsync(created.Id, CancellationToken.None);
+        Assert.Equal(CronFireOutcome.SkippedOverlap, second.Outcome);   // AC4
+
+        blocking.Release.TrySetResult();
+        var first = await firstRun;
+        Assert.Equal(CronFireOutcome.Fired, first.Outcome);
+        Assert.Equal(1, blocking.StartCount);                            // only one session ever started
+    }
+
+    [Fact]
+    public async Task RunNow_NoSuchJob_ReturnsNoSuchJob()
+    {
+        var engine = new CronEngine(NewJobStore(), NewHistory(), new RecordingStarter(), new FakeClock(DateTime.UtcNow));
+        var result = await engine.RunNowAsync("cj_nope", CancellationToken.None);
+        Assert.Equal(CronFireOutcome.NoSuchJob, result.Outcome);
+    }
+
+    [Fact]
+    public async Task Fire_WhenStarterReportsError_RecordsNotStarted()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var created = store.Create(Recurring());
+        var engine = new CronEngine(store, history, new FailingStarter(), new FakeClock(DateTime.UtcNow));
+
+        var result = await engine.RunNowAsync(created.Id, CancellationToken.None);
+
+        Assert.Equal(CronFireOutcome.Fired, result.Outcome);     // a run is still recorded
+        Assert.NotNull(result.Record);
+        Assert.Equal("not-started", result.Record.InfraStatus);
+        Assert.Null(result.Record.SessionId);
+    }
+
+    // ---- fakes -------------------------------------------------------------------------------
+
+    private sealed class FakeClock : IClock
+    {
+        public FakeClock(DateTime utcNow) => UtcNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+        public DateTime UtcNow { get; set; }
+    }
+
+    private sealed class RecordingStarter : ICronSessionStarter
+    {
+        public int StartCount { get; private set; }
+        public CronJobDto? LastJob { get; private set; }
+
+        public Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct)
+        {
+            StartCount++;
+            LastJob = job;
+            return Task.FromResult<(string?, string?)>(($"sid-{StartCount}", null));
+        }
+    }
+
+    private sealed class FailingStarter : ICronSessionStarter
+    {
+        public Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct) =>
+            Task.FromResult<(string?, string?)>((null, "target director not registered"));
+    }
+
+    private sealed class BlockingStarter : ICronSessionStarter
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int StartCount { get; private set; }
+
+        public async Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct)
+        {
+            StartCount++;
+            Entered.TrySetResult();
+            await Release.Task;
+            return ($"sid-{StartCount}", null);
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CronRunEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronRunEndpointsTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Text.Json;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// HTTP wire tests for the cron run-now + run-history endpoints (epic #479, #483). Boots
+/// <see cref="CronRunEndpoints"/> on an ephemeral loopback port over a real <see cref="CronEngine"/>
+/// with a fake session starter (no live Director), and drives run-now + history over real HTTP -
+/// the running-app proof for AC2 (run-now fires + records) and AC3 (the run-record shape).
+/// </summary>
+public sealed class CronRunEndpointsTests : IAsyncLifetime
+{
+    private readonly string _jobsPath = Path.Combine(
+        Path.GetTempPath(), "cc-cronrun-ep-jobs-" + Guid.NewGuid().ToString("N") + ".json");
+    private readonly string _runsPath = Path.Combine(
+        Path.GetTempPath(), "cc-cronrun-ep-runs-" + Guid.NewGuid().ToString("N") + ".json");
+
+    private WebApplication _app = null!;  // built in InitializeAsync (xUnit lifecycle)
+    private HttpClient _http = null!;     // built in InitializeAsync (xUnit lifecycle)
+    private CronJobStore _store = null!;  // built in InitializeAsync (xUnit lifecycle)
+
+    public async Task InitializeAsync()
+    {
+        var port = AllocateFreePort();
+        var baseUrl = $"http://127.0.0.1:{port}";
+
+        _store = new CronJobStore(_jobsPath);
+        var history = new CronRunHistoryStore(_runsPath);
+        var engine = new CronEngine(_store, history, new FakeStarter(), new SystemClock());
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        _app = builder.Build();
+        _app.Urls.Add(baseUrl);
+        CronRunEndpoints.Map(_app, engine, history);
+        await _app.StartAsync();
+
+        _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _app.DisposeAsync();
+        foreach (var p in new[] { _jobsPath, _runsPath })
+            if (File.Exists(p)) File.Delete(p);
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    private CronJobDto SeedJob() => _store.Create(new CronJobDto
+    {
+        Name = "nightly",
+        ScheduleKind = CronSchedule.KindRecurring,
+        CronExpression = "0 0 * * *",
+        TimeZoneId = "America/Chicago",
+        Target = new CronJobTarget { DirectorId = "workstation-A" },
+        Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "/work-list run Tonight" },
+    });
+
+    [Fact]
+    public async Task RunNow_FiresAndRecords_WithFullRecordShape()
+    {
+        var job = SeedJob();
+
+        var resp = await _http.PostAsync($"/cron/jobs/{job.Id}/run", content: null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var record = JsonSerializer.Deserialize<CronRunRecord>(await resp.Content.ReadAsStringAsync(), JsonOpts);
+        Assert.NotNull(record);                              // AC2: run-now produced a record
+        Assert.Equal("workstation-A", record.TargetDirectorId);
+        Assert.Equal("fake-sid", record.SessionId);
+        Assert.Equal("started", record.InfraStatus);         // AC3: infra status present
+        Assert.Equal("unknown", record.TaskStatus);          // AC3: task status separate from infra
+        Assert.NotEqual(default, record.FiredUtc);
+    }
+
+    [Fact]
+    public async Task Runs_ReturnsHistory_AfterRunNow()
+    {
+        var job = SeedJob();
+        await _http.PostAsync($"/cron/jobs/{job.Id}/run", content: null);
+
+        var resp = await _http.GetAsync($"/cron/jobs/{job.Id}/runs");
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal(job.Id, doc.RootElement.GetProperty("jobId").GetString());
+        var runs = doc.RootElement.GetProperty("runs");
+        Assert.Equal(1, runs.GetArrayLength());
+        Assert.Equal("workstation-A", runs[0].GetProperty("targetDirectorId").GetString());
+    }
+
+    [Fact]
+    public async Task RunNow_NoSuchJob_Returns404()
+    {
+        var resp = await _http.PostAsync("/cron/jobs/cj_nope/run", content: null);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Runs_NoSuchJob_ReturnsEmptyList()
+    {
+        var resp = await _http.GetAsync("/cron/jobs/cj_nope/runs");
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal(0, doc.RootElement.GetProperty("runs").GetArrayLength());
+    }
+
+    private sealed class FakeStarter : ICronSessionStarter
+    {
+        public Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct) =>
+            Task.FromResult<(string?, string?)>(("fake-sid", null));
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CronRunHistoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronRunHistoryStoreTests.cs
@@ -1,0 +1,98 @@
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="CronRunHistoryStore"/> (epic #479, #483): newest-first ordering, the
+/// per-job cap, persistence round-trip, and corrupt-file quarantine (the store precedent).
+/// </summary>
+public sealed class CronRunHistoryStoreTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-cronruns-tests-" + Guid.NewGuid().ToString("N"));
+
+    private string NewPath() => Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".json");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private static CronRunRecord Run(string sid, string infra = "started") => new()
+    {
+        ScheduledUtc = new DateTime(2026, 6, 17, 5, 0, 0, DateTimeKind.Utc),
+        FiredUtc = new DateTime(2026, 6, 17, 5, 0, 3, DateTimeKind.Utc),
+        TargetDirectorId = "workstation-A",
+        SessionId = sid,
+        InfraStatus = infra,
+        TaskStatus = "unknown",
+    };
+
+    [Fact]
+    public void Append_ThenList_ReturnsNewestFirst()
+    {
+        var store = new CronRunHistoryStore(NewPath());
+        store.Append("cj_1", Run("sid-a"));
+        store.Append("cj_1", Run("sid-b"));
+
+        var runs = store.List("cj_1");
+        Assert.Equal(2, runs.Count);
+        Assert.Equal("sid-b", runs[0].SessionId); // newest first
+        Assert.Equal("sid-a", runs[1].SessionId);
+    }
+
+    [Fact]
+    public void Append_BeyondCap_PrunesOldest()
+    {
+        var store = new CronRunHistoryStore(NewPath());
+        for (var i = 0; i < CronRunHistoryStore.MaxRecordsPerJob + 10; i++)
+            store.Append("cj_1", Run("sid-" + i));
+
+        var runs = store.List("cj_1");
+        Assert.Equal(CronRunHistoryStore.MaxRecordsPerJob, runs.Count);
+        // newest (highest i) retained, oldest pruned
+        Assert.Equal("sid-" + (CronRunHistoryStore.MaxRecordsPerJob + 9), runs[0].SessionId);
+    }
+
+    [Fact]
+    public void Persistence_RoundTrip_SurvivesReload()
+    {
+        var path = NewPath();
+        var store = new CronRunHistoryStore(path);
+        store.Append("cj_1", Run("sid-a"));
+        store.Append("cj_2", Run("sid-c"));
+
+        var reloaded = new CronRunHistoryStore(path);
+        Assert.Single(reloaded.List("cj_1"));
+        Assert.Single(reloaded.List("cj_2"));
+        Assert.Equal("sid-a", reloaded.List("cj_1")[0].SessionId);
+    }
+
+    [Fact]
+    public void List_NoRuns_ReturnsEmpty()
+    {
+        var store = new CronRunHistoryStore(NewPath());
+        Assert.Empty(store.List("cj_unknown"));
+    }
+
+    [Fact]
+    public void CorruptFile_IsQuarantined_StoreStartsEmpty()
+    {
+        var path = NewPath();
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(path, "{ not json !!!");
+
+        var store = new CronRunHistoryStore(path);
+
+        Assert.Empty(store.List("cj_1"));
+        Assert.Single(Directory.GetFiles(_dir, Path.GetFileName(path) + ".corrupt-*"));
+    }
+
+    [Fact]
+    public void Constructor_EmptyPath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new CronRunHistoryStore(" "));
+    }
+}

--- a/src/CcDirector.Gateway/Api/CronRunEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/CronRunEndpoints.cs
@@ -1,0 +1,40 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Running;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The cron firing surface (epic #479, part 2 = #483): run-now and run-history, sitting on the
+/// <see cref="CronEngine"/> and <see cref="CronRunHistoryStore"/>. The scheduled firing happens on
+/// the Gateway's background timer; these routes let a caller fire immediately and read past runs.
+///
+///   POST /cron/jobs/{id}/run    -> 200 CronRunRecord | 409 (overlap) | 404
+///   GET  /cron/jobs/{id}/runs   -> { jobId, runs: [ CronRunRecord ] }
+/// </summary>
+internal static class CronRunEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app, CronEngine engine, CronRunHistoryStore history)
+    {
+        app.MapPost("/cron/jobs/{id}/run", async (string id, HttpContext ctx) =>
+        {
+            var result = await engine.RunNowAsync(id, ctx.RequestAborted);
+            return result.Outcome switch
+            {
+                CronFireOutcome.Fired => Results.Json(result.Record),
+                CronFireOutcome.SkippedOverlap =>
+                    Results.Conflict(new { error = "a prior run of this job is still in flight", id }),
+                CronFireOutcome.NoSuchJob =>
+                    Results.NotFound(new { error = "no such cron job", id }),
+                _ => throw new InvalidOperationException($"unhandled fire outcome: {result.Outcome}"),
+            };
+        });
+
+        app.MapGet("/cron/jobs/{id}/runs", (string id) =>
+            Results.Json(new { jobId = id, runs = history.List(id) }));
+
+        FileLog.Write("[CronRunEndpoints] mapped /cron/jobs/{id}/run + /runs routes");
+    }
+}

--- a/src/CcDirector.Gateway/CronJobStore.cs
+++ b/src/CcDirector.Gateway/CronJobStore.cs
@@ -162,6 +162,37 @@ public sealed class CronJobStore
         }
     }
 
+    /// <summary>
+    /// Record a fire's outcome on a job (epic #479, #483): the firing engine is the writer of the
+    /// run metadata that <see cref="Update"/> deliberately preserves. Sets <see cref="CronJobDto.LastFiredUtc"/>,
+    /// <see cref="CronJobDto.LastStatus"/>, <see cref="CronJobDto.NextRunUtc"/>, and
+    /// <see cref="CronJobDto.Enabled"/> (a one-off fire disables itself with a null next-run), then
+    /// persists. Returns the updated copy, or null if no job with that id exists.
+    /// </summary>
+    public CronJobDto? MarkFired(string id, DateTime lastFiredUtc, string lastStatus, DateTime? nextRunUtc, bool enabled)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+
+        lock (_gate)
+        {
+            if (!_jobs.TryGetValue(id, out var existing))
+            {
+                FileLog.Write($"[CronJobStore] MarkFired: no such job id={id}");
+                return null;
+            }
+
+            existing.LastFiredUtc = lastFiredUtc;
+            existing.LastStatus = lastStatus;
+            existing.NextRunUtc = nextRunUtc;
+            existing.Enabled = enabled;
+
+            Save();
+            FileLog.Write($"[CronJobStore] MarkFired: id={id}, status={lastStatus}, enabled={enabled}, nextRunUtc={nextRunUtc:o}");
+            return Copy(existing);
+        }
+    }
+
     /// <summary>Mint an id not already in use. Short and human-quotable, like the design report's <c>cj_7fa3b1</c>.</summary>
     private string NewId()
     {

--- a/src/CcDirector.Gateway/CronRunHistoryStore.cs
+++ b/src/CcDirector.Gateway/CronRunHistoryStore.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway;
+
+/// <summary>
+/// The run-history store for cron jobs (epic #479, #483): one <see cref="CronRunRecord"/> per fire,
+/// keyed by job id, newest-first, capped per job. Persisted to <c>cronruns.json</c> with the same
+/// atomic write-through + corrupt-file quarantine contract as <see cref="CronJobStore"/> /
+/// <see cref="WorkListStore"/>, so a crash mid-write never half-truncates the file and an unreadable
+/// file is preserved rather than silently overwritten.
+/// </summary>
+public sealed class CronRunHistoryStore
+{
+    /// <summary>Max records retained per job; older runs are pruned (keeps the file bounded).</summary>
+    public const int MaxRecordsPerJob = 50;
+
+    private readonly object _gate = new();
+    private readonly string _path;
+
+    // Job id -> runs, newest first.
+    private readonly Dictionary<string, List<CronRunRecord>> _runs = new(StringComparer.Ordinal);
+
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    /// <param name="path">The JSON file the store persists to. REQUIRED (no silent default).</param>
+    /// <exception cref="ArgumentException">The path is null/empty/whitespace.</exception>
+    public CronRunHistoryStore(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("store path is required", nameof(path));
+        _path = path;
+        Load();
+    }
+
+    /// <summary>
+    /// Record one run for a job (newest first), pruning to <see cref="MaxRecordsPerJob"/>, and persist.
+    /// </summary>
+    /// <exception cref="ArgumentException">The job id is null/empty/whitespace.</exception>
+    /// <exception cref="ArgumentNullException">The record is null.</exception>
+    public void Append(string jobId, CronRunRecord record)
+    {
+        if (string.IsNullOrWhiteSpace(jobId))
+            throw new ArgumentException("job id is required", nameof(jobId));
+        if (record is null)
+            throw new ArgumentNullException(nameof(record));
+
+        lock (_gate)
+        {
+            if (!_runs.TryGetValue(jobId, out var list))
+            {
+                list = new List<CronRunRecord>();
+                _runs[jobId] = list;
+            }
+
+            list.Insert(0, Copy(record));
+            if (list.Count > MaxRecordsPerJob)
+                list.RemoveRange(MaxRecordsPerJob, list.Count - MaxRecordsPerJob);
+
+            Save();
+            FileLog.Write($"[CronRunHistoryStore] Append: job={jobId}, firedUtc={record.FiredUtc:o}, infra={record.InfraStatus}, task={record.TaskStatus}, count={list.Count}");
+        }
+    }
+
+    /// <summary>One job's runs as defensive copies, newest first; empty when the job has no runs.</summary>
+    public IReadOnlyList<CronRunRecord> List(string jobId)
+    {
+        if (string.IsNullOrWhiteSpace(jobId))
+            return Array.Empty<CronRunRecord>();
+
+        lock (_gate)
+            return _runs.TryGetValue(jobId, out var list)
+                ? list.Select(Copy).ToList()
+                : Array.Empty<CronRunRecord>();
+    }
+
+    private static CronRunRecord Copy(CronRunRecord r) => new()
+    {
+        ScheduledUtc = r.ScheduledUtc,
+        FiredUtc = r.FiredUtc,
+        TargetDirectorId = r.TargetDirectorId,
+        SessionId = r.SessionId,
+        InfraStatus = r.InfraStatus,
+        TaskStatus = r.TaskStatus,
+    };
+
+    // ---- persistence (CronJobStore / WorkListStore precedent) --------------------------------
+
+    private sealed class StoreFile
+    {
+        public Dictionary<string, List<CronRunRecord>> Runs { get; set; } = new(StringComparer.Ordinal);
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[CronRunHistoryStore] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        foreach (var (jobId, list) in parsed.Runs)
+        {
+            if (string.IsNullOrWhiteSpace(jobId))
+                continue;
+            _runs[jobId] = list ?? new List<CronRunRecord>();
+        }
+
+        FileLog.Write($"[CronRunHistoryStore] Load: restored runs for {_runs.Count} job(s) from {_path}");
+    }
+
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[CronRunHistoryStore] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty.");
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile { Runs = _runs };
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[CronRunHistoryStore] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -84,6 +84,12 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly KeyVault _keyVault;
     private readonly WorkListStore _workLists;
     private readonly CronJobStore _cronJobs;
+    private readonly CronRunHistoryStore _cronRuns;
+    private readonly Running.CronEngine _cronEngine;
+    // The cron firing sweep (epic #479, #483): wakes ~every minute and fires due jobs. Created in
+    // StartAsync, disposed in StopAsync.
+    private System.Threading.Timer? _cronTimer;
+    private static readonly TimeSpan CronSweepInterval = TimeSpan.FromMinutes(1);
     private readonly Running.WorkListRunnerManager _runnerManager = new();
     private readonly SessionAssessments _assessments = new();
     // Issue #218: Gateway-owned clock for when each session entered the red / NEEDS-YOU state.
@@ -118,7 +124,11 @@ public sealed class GatewayHost : IAsyncDisposable
     /// Override the cron-job store file (epic #479, #482). Tests pass an isolated temp path;
     /// production omits it for the shared default at <c>%LOCALAPPDATA%\cc-director\cronjobs.json</c>.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool authEnabled = false, string? instancesDirectory = null, int? cockpitProxyPort = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null)
+    /// <param name="cronRunsPath">
+    /// Override the cron run-history store file (epic #479, #483). Tests pass an isolated temp path;
+    /// production omits it for the shared default at <c>%LOCALAPPDATA%\cc-director\cronruns.json</c>.
+    /// </param>
+    public GatewayHost(int port = DefaultPort, string? token = null, bool authEnabled = false, string? instancesDirectory = null, int? cockpitProxyPort = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
@@ -163,6 +173,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // mutation - the WorkListStore precedent. Tests MUST pass an isolated path so they never
         // touch the real store.
         _cronJobs = new CronJobStore(cronJobsPath ?? Path.Combine(CcStorage.Root(), "cronjobs.json"));
+        // Cron run history + the firing engine (epic #479, #483). The engine resolves each due job's
+        // target Director from the registry and starts a session over the shared client (the same
+        // path the work-list runner uses). The background sweep timer is started in StartAsync.
+        _cronRuns = new CronRunHistoryStore(cronRunsPath ?? Path.Combine(CcStorage.Root(), "cronruns.json"));
+        _cronEngine = new Running.CronEngine(
+            _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(Registry, _client), new Running.SystemClock());
     }
 
     /// <summary>
@@ -456,6 +472,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // next-run recompute). Inherits the host-wide token middleware above.
         CronJobEndpoints.Map(_app, _cronJobs);
 
+        // Cron firing surface (epic #479, part 2 = #483): run-now and run-history over the engine.
+        // Scheduled firing runs on the background sweep timer started below in StartAsync.
+        CronRunEndpoints.Map(_app, _cronEngine, _cronRuns);
+
         // The queue runner (issue #274, child 3 of #270): the thin orchestration that turns a named
         // work list into unattended, ordered runs - one implementation session per github item,
         // watched to its IMPL-LOOP-TERMINAL sentinel (child 1, #272) before advancing. All runner
@@ -525,6 +545,27 @@ public sealed class GatewayHost : IAsyncDisposable
 
         await _app.StartAsync();
         FileLog.Write($"[GatewayHost] listening on http://127.0.0.1:{Port} (version {version})");
+
+        // Cron firing sweep (epic #479, #483): wake ~every minute and fire due jobs. The first tick
+        // also catches up a fire that came due while the Gateway was down (at most once per job).
+        _cronTimer = new System.Threading.Timer(_ => SweepCron(), null, CronSweepInterval, CronSweepInterval);
+        FileLog.Write($"[GatewayHost] cron sweep started: every {CronSweepInterval.TotalSeconds:0}s");
+    }
+
+    /// <summary>
+    /// The cron sweep timer callback (a boundary - it owns the try/catch so a sweep failure never
+    /// crashes the timer thread). Fires due jobs; per-job failures are isolated inside the engine.
+    /// </summary>
+    private void SweepCron()
+    {
+        try
+        {
+            _ = _cronEngine.EvaluateDueAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayHost] cron sweep FAILED: {ex.Message}");
+        }
     }
 
     public async Task StopAsync()
@@ -532,6 +573,9 @@ public sealed class GatewayHost : IAsyncDisposable
         if (_stopped) return;
         _stopped = true;
         FileLog.Write($"[GatewayHost] StopAsync");
+
+        try { _cronTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] cron timer dispose error: {ex.Message}"); }
+        _cronTimer = null;
 
         try { _endpointMonitor?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] endpoint monitor dispose error: {ex.Message}"); }
         _endpointMonitor = null;

--- a/src/CcDirector.Gateway/Running/CronEngine.cs
+++ b/src/CcDirector.Gateway/Running/CronEngine.cs
@@ -1,0 +1,188 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>The outcome of a fire attempt (scheduled sweep or run-now).</summary>
+public enum CronFireOutcome
+{
+    /// <summary>A session start was attempted and a run was recorded (start may have failed - see the record's InfraStatus).</summary>
+    Fired,
+
+    /// <summary>Skipped because a prior run of the same job is still in flight and the job forbids overlap.</summary>
+    SkippedOverlap,
+
+    /// <summary>No job with the requested id exists (run-now only).</summary>
+    NoSuchJob,
+}
+
+/// <summary>The result of <see cref="CronEngine.RunNowAsync"/>.</summary>
+public sealed record CronRunNowResult(CronFireOutcome Outcome, CronRunRecord? Record);
+
+/// <summary>
+/// The cron firing engine (epic #479, part 2 = #483). On each <see cref="EvaluateDueAsync"/> sweep it
+/// fires every enabled job whose <see cref="CronJobDto.NextRunUtc"/> is due (per the injected
+/// <see cref="IClock"/>), starts a session on the job's target Director via
+/// <see cref="ICronSessionStarter"/>, records a <see cref="CronRunRecord"/>, and advances the
+/// schedule. The guards:
+///   - DISABLED jobs are never fired.
+///   - OVERLAP: a job already in flight is skipped (when <see cref="CronJobDto.PreventOverlap"/>).
+///   - CATCH-UP: a fire missed while the Gateway was down fires AT MOST ONCE on the next sweep - the
+///     schedule is recomputed from "now" to the next FUTURE occurrence, never replaying the backlog.
+///   - ONE-OFF: a one-off job fires once and then auto-disables.
+/// The engine watches nothing to completion (that is the work-list runner's job); it fires and
+/// records, leaving <see cref="CronRunRecord.TaskStatus"/> as <c>unknown</c>.
+/// </summary>
+public sealed class CronEngine
+{
+    private const string TaskStatusUnknown = "unknown";
+
+    private readonly CronJobStore _store;
+    private readonly CronRunHistoryStore _history;
+    private readonly ICronSessionStarter _starter;
+    private readonly IClock _clock;
+    private readonly TimeSpan _catchUpThreshold;
+
+    private readonly object _inFlightGate = new();
+    private readonly HashSet<string> _inFlight = new(StringComparer.Ordinal);
+
+    /// <param name="catchUpThreshold">
+    /// How far past its due time a scheduled fire must be to be labeled a catch-up (default 2 min).
+    /// Purely cosmetic on the run record; it does not change whether the job fires.
+    /// </param>
+    public CronEngine(
+        CronJobStore store,
+        CronRunHistoryStore history,
+        ICronSessionStarter starter,
+        IClock clock,
+        TimeSpan? catchUpThreshold = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _history = history ?? throw new ArgumentNullException(nameof(history));
+        _starter = starter ?? throw new ArgumentNullException(nameof(starter));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _catchUpThreshold = catchUpThreshold ?? TimeSpan.FromMinutes(2);
+    }
+
+    /// <summary>
+    /// Fire every enabled job that is due as of <see cref="IClock.UtcNow"/>, advancing each schedule.
+    /// Returns the records produced this sweep. A single job's failure is logged and isolated (this is
+    /// the timer boundary) so one bad job never aborts the sweep.
+    /// </summary>
+    public async Task<IReadOnlyList<CronRunRecord>> EvaluateDueAsync(CancellationToken ct)
+    {
+        var now = _clock.UtcNow;
+        var due = _store.ListAll()
+            .Where(j => j.Enabled && j.NextRunUtc is not null && j.NextRunUtc.Value <= now)
+            .ToList();
+
+        var fired = new List<CronRunRecord>();
+        foreach (var job in due)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var result = await FireAsync(job, job.NextRunUtc ?? now, isManual: false, ct);
+                if (result.Record is not null)
+                    fired.Add(result.Record);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Timer boundary: isolate one job's failure so the sweep continues for the rest.
+                FileLog.Write($"[CronEngine] EvaluateDueAsync job FAILED: id={job.Id}: {ex.Message}");
+            }
+        }
+
+        if (fired.Count > 0)
+            FileLog.Write($"[CronEngine] EvaluateDueAsync: fired {fired.Count} job(s) at {now:o}");
+        return fired;
+    }
+
+    /// <summary>
+    /// Fire a job immediately, independent of its schedule (the run-now surface). Records a run and
+    /// updates the job's last-run metadata, but does NOT advance the schedule or disable a one-off -
+    /// a manual run is out-of-band. Returns <see cref="CronFireOutcome.NoSuchJob"/> if the id is unknown.
+    /// </summary>
+    public async Task<CronRunNowResult> RunNowAsync(string id, CancellationToken ct)
+    {
+        var job = _store.Get(id);
+        if (job is null)
+            return new CronRunNowResult(CronFireOutcome.NoSuchJob, null);
+
+        return await FireAsync(job, _clock.UtcNow, isManual: true, ct);
+    }
+
+    private async Task<CronRunNowResult> FireAsync(CronJobDto job, DateTime scheduledUtc, bool isManual, CancellationToken ct)
+    {
+        if (job.PreventOverlap && !TryEnterFlight(job.Id))
+        {
+            FileLog.Write($"[CronEngine] skip overlap: job={job.Id} (a prior run is still in flight)");
+            return new CronRunNowResult(CronFireOutcome.SkippedOverlap, null);
+        }
+
+        try
+        {
+            var (sessionId, error) = await _starter.StartAsync(job, ct);
+            var firedUtc = _clock.UtcNow;
+            var started = sessionId is not null;
+            var isCatchUp = !isManual && started && (firedUtc - scheduledUtc) > _catchUpThreshold;
+
+            var infraStatus = !started ? "not-started" : isCatchUp ? "catch-up" : "started";
+            var record = new CronRunRecord
+            {
+                ScheduledUtc = scheduledUtc,
+                FiredUtc = firedUtc,
+                TargetDirectorId = job.Target.DirectorId,
+                SessionId = sessionId,
+                InfraStatus = infraStatus,
+                TaskStatus = TaskStatusUnknown,
+            };
+            _history.Append(job.Id, record);
+
+            if (isManual)
+            {
+                // Run-now is out-of-band: record the fire, refresh last-run metadata, leave the
+                // schedule and enabled-state untouched.
+                _store.MarkFired(job.Id, firedUtc, infraStatus, job.NextRunUtc, job.Enabled);
+            }
+            else if (CronSchedule.KindOneOff.Equals(job.ScheduleKind?.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                // A one-off fires once, then auto-disables (no next run).
+                _store.MarkFired(job.Id, firedUtc, infraStatus, nextRunUtc: null, enabled: false);
+            }
+            else
+            {
+                // Recurring: advance to the next FUTURE occurrence from now - this is what makes a
+                // missed fire a single catch-up rather than a replay of every missed interval.
+                var next = CronSchedule.ComputeNextRunUtc(job, firedUtc);
+                _store.MarkFired(job.Id, firedUtc, infraStatus, next, enabled: true);
+            }
+
+            if (error is not null)
+                FileLog.Write($"[CronEngine] fire start error: job={job.Id}: {error}");
+            FileLog.Write($"[CronEngine] fired: job={job.Id}, manual={isManual}, infra={infraStatus}, sid={sessionId}");
+            return new CronRunNowResult(CronFireOutcome.Fired, record);
+        }
+        finally
+        {
+            if (job.PreventOverlap)
+                ExitFlight(job.Id);
+        }
+    }
+
+    private bool TryEnterFlight(string id)
+    {
+        lock (_inFlightGate)
+            return _inFlight.Add(id);
+    }
+
+    private void ExitFlight(string id)
+    {
+        lock (_inFlightGate)
+            _inFlight.Remove(id);
+    }
+}

--- a/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
@@ -1,0 +1,59 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// Production <see cref="ICronSessionStarter"/> (epic #479, #483). Resolves the job's target Director
+/// from the <see cref="DirectorRegistry"/> and starts a session over the Gateway's existing
+/// <see cref="DirectorEndpointClient"/> using the SAME session-create + seed-prompt path the Cockpit
+/// and the work-list runner use (<see cref="NewSessionRequest.PrePrompt"/> is the seed channel). No
+/// new Director surface is introduced; an unknown/offline target is reported as an error, not thrown.
+/// </summary>
+public sealed class DirectorCronSessionStarter : ICronSessionStarter
+{
+    private readonly DirectorRegistry _registry;
+    private readonly DirectorEndpointClient _client;
+
+    public DirectorCronSessionStarter(DirectorRegistry registry, DirectorEndpointClient client)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    public async Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct)
+    {
+        if (job is null)
+            throw new ArgumentNullException(nameof(job));
+
+        var directorId = job.Target.DirectorId;
+        var director = _registry.Get(directorId);
+        if (director is null)
+        {
+            FileLog.Write($"[DirectorCronSessionStarter] start FAILED: job={job.Id}, no such director={directorId}");
+            return (null, $"target director not registered: {directorId}");
+        }
+
+        var endpoint = director.ControlEndpoint.TrimEnd('/');
+        FileLog.Write($"[DirectorCronSessionStarter] start: job={job.Id}, director={directorId}, endpoint={endpoint}, seed={job.Action.Seed}");
+
+        var req = new NewSessionRequest
+        {
+            RepoPath = job.Action.RepoPath,
+            Agent = "ClaudeCode",
+            Type = "Implement",
+            PrePrompt = job.Action.Seed,
+        };
+
+        var (ok, body, error) = await _client.CreateSessionAsync(endpoint, req, ct);
+        if (!ok || body is null || string.IsNullOrEmpty(body.SessionId))
+        {
+            FileLog.Write($"[DirectorCronSessionStarter] start FAILED: job={job.Id}, error={error}");
+            return (null, error ?? "director did not return a session id");
+        }
+
+        FileLog.Write($"[DirectorCronSessionStarter] started: job={job.Id}, sid={body.SessionId}");
+        return (body.SessionId, null);
+    }
+}

--- a/src/CcDirector.Gateway/Running/IClock.cs
+++ b/src/CcDirector.Gateway/Running/IClock.cs
@@ -1,0 +1,18 @@
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// The current UTC instant, behind an interface so the cron firing engine (epic #479, #483) is
+/// deterministically testable - tests inject a fake clock to make a job "due" without waiting for
+/// the wall clock. Production uses <see cref="SystemClock"/>.
+/// </summary>
+public interface IClock
+{
+    /// <summary>The current instant in UTC.</summary>
+    DateTime UtcNow { get; }
+}
+
+/// <summary>The production clock: <see cref="DateTime.UtcNow"/>.</summary>
+public sealed class SystemClock : IClock
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/src/CcDirector.Gateway/Running/ICronSessionStarter.cs
+++ b/src/CcDirector.Gateway/Running/ICronSessionStarter.cs
@@ -1,0 +1,21 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// The seam the cron firing engine (epic #479, #483) uses to START a session for a due job on its
+/// target Director. Mirrors <see cref="IImplSessionDriver"/> (issue #274): production resolves the
+/// Director and uses the existing session-create + seed-prompt path; tests inject a fake so the
+/// engine's scheduling logic is verified without a live Director.
+/// </summary>
+public interface ICronSessionStarter
+{
+    /// <summary>
+    /// Start a session for <paramref name="job"/> on its <see cref="CronJobTarget.DirectorId"/>,
+    /// seeded with <see cref="CronJobAction.Seed"/> in <see cref="CronJobAction.RepoPath"/>. Returns
+    /// the new session id, or a non-null error string when no session started (e.g. the target
+    /// Director is unknown/offline). Does not throw for an expected "could not start" - it reports
+    /// the error so the engine records a not-started run.
+    /// </summary>
+    Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct);
+}


### PR DESCRIPTION
Implements **#483** - part 2 of 3 of epic #479. Builds on the merged #482 store/CRUD to make cron jobs actually fire.

## Release Notes
The always-on Gateway now fires due cron jobs on a 1-minute background sweep: it starts a session on the job's target Director, records the run, and advances the schedule. Run-now (`POST /cron/jobs/{id}/run`) and run history (`GET /cron/jobs/{id}/runs`) are exposed. Guards cover disabled jobs, overlap, one-off auto-disable, and single catch-up after downtime.

## Changes
- **`CronEngine`** - due-evaluation + run-now; guards: disabled-skip, overlap (in-flight set), one-off auto-disable, catch-up fire-once (recompute to next future occurrence, no backlog replay).
- **`IClock`/`SystemClock`** - injectable clock for deterministic firing tests.
- **`ICronSessionStarter` + `DirectorCronSessionStarter`** - resolve the target Director from the registry, reuse the existing CreateSession + seed-prompt path.
- **`CronRunHistoryStore`** - `cronruns.json`, newest-first, per-job cap, atomic write-through + quarantine.
- **`CronJobStore.MarkFired`** - the engine's writer for last-run metadata + schedule advance.
- **`CronRunEndpoints`** - run-now (409 overlap / 404 missing) + history.
- **`GatewayHost`** - engine + history wired; 1-minute sweep timer started/stopped with the host.

## How to Test
`dotnet build cc-director.sln` (clean), then `dotnet test src/CcDirector.Gateway.Tests --filter Cron`.

## Expected Result
**48 cron tests pass** (engine + history + real-HTTP run/runs, plus #482's 31). Build: 0 warnings / 0 errors.

## Acceptance criteria
- AC1 due job fires + records (`EvaluateDue_RecurringJobDue_Fires...`); AC2 run-now fires+records (`RunNow_FiresAndRecords...`); AC3 history shape incl. infra-vs-task status (`Runs_ReturnsHistory...`); AC4 overlap skip (`RunNow_WhilePriorRunInFlight...`); AC5 disabled no-fire + resume (`EvaluateDue_DisabledJob...`); AC6 single catch-up (`EvaluateDue_MissedFireWhileDown...`); AC7 one-off auto-disable (`EvaluateDue_OneOff...`).
- Proof report committed under `docs/cencon/proof/issue-483/`.

Refs #483, #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)