### PR TITLE
feat(gateway): cron work-list use case (#484)

### DIFF
--- a/docs/cencon/proof/issue-484/qa-report.html
+++ b/docs/cencon/proof/issue-484/qa-report.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>QA Proof Report - Issue #484</title>
+<style>
+        /* Boardroom Theme - Corporate, executive style with serif fonts */
+        
+        :root {
+            /* Colors */
+            --primary: #1A365D;
+            --primary-light: #2A4A7F;
+            --accent: #D69E2E;
+            --text: #2D3748;
+            --heading: #1A365D;
+            --background: #FFFFFF;
+            --code-bg: #EDF2F7;
+            --code-text: #1A365D;
+            --border: #CBD5E0;
+            --link: #2B6CB0;
+            --blockquote-text: #4A5568;
+            --blockquote-border: #D69E2E;
+            --blockquote-bg: #FFFFFF;
+            --table-header-bg: #1A365D;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #F7FAFC;
+            --shadow-color: rgba(26, 54, 93, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Palatino Linotype", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Georgia", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Courier New", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.02em;
+            --line-height: 1.7;
+            --radius: 4px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(26, 54, 93, 0.08);
+            --shadow-md: 0 4px 12px rgba(26, 54, 93, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Boardroom: corporate authority with accent borders */
+        h1 {
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.3em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        pre::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
+            background: var(--accent);
+            border-radius: 0;
+        }
+        
+        blockquote {
+            font-style: italic;
+        }
+        
+        hr {
+            background: var(--accent);
+            max-width: none;
+            height: 2px;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>QA Proof Report - Issue #484</h1>
+<h2>Cron jobs (3/3): named-work-list use case</h2>
+<p><strong>Verifier:</strong> QA Agent (independent - own fresh build + own test run; did not trust the dev report).
+        <strong>PR:</strong> #487 (branch <code>issue-484-cron-worklist-usecase</code>, HEAD cc32a67).
+        <strong>Mode:</strong> standalone QA -&gt; NOT merged; merge left to the human.</p>
+<h2>How I verified independently</h2>
+<ol>
+<li>Checked out the PR branch fresh and <strong>built the whole solution myself</strong>: <code>dotnet build cc-director.sln</code> -&gt; <strong>0 Warning(s), 0 Error(s)</strong>.</li>
+<li><strong>Ran the cron suite myself</strong>: <code>dotnet test --filter Cron</code> -&gt; <strong>61 Passed, 0 Failed, 0 Skipped</strong> (13 new for #484: 7 trigger + 4 engine-dispatch + 2 validation; plus 48 from #482/#483).</li>
+<li><strong>Adversarially audited</strong> the new code: dispatch-by-action-type, the pre-check ordering (no duplicate claim), the background drain + machine-slot release, and the validation change for regressions.</li>
+</ol>
+<p>No live full Gateway booted (Tailscale provisioner + :7878 bind would collide with the running Gateway). The integration is proven without a Director via the three seams; the launcher test drives a REAL <code>WorkListRunner</code> through the new path with a fake <code>IImplSessionDriver</code>.</p>
+<h2>Acceptance criteria - Expected vs Actual (independently judged)</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Criterion</th>
+<th>Evidence (reproduced)</th>
+<th>Verdict</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AC1</td>
+<td>A work-list cron job, when fired, causes the #274 runner to CLAIM the list + start processing</td>
+<td><code>DrainLauncher_ClaimsList_AndDrainsItemsInOrder</code> (claim taken via the real runner; items started) + <code>WorkListJob_Dispatches_ToWorkListRunner_RecordsWorklistStarted_NoSession</code> (engine routes a work-list job to the runner, records <code>worklist-started</code>, null sessionId)</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC2</td>
+<td>Items processed in list order</td>
+<td><code>DrainLauncher_ClaimsList_AndDrainsItemsInOrder</code> - start order 101,102,103 through the shipped #274 <code>WorkListRunner</code></td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC3</td>
+<td>Empty / already-claimed / no-director / machine-busy handled cleanly, no crash, no duplicate claim</td>
+<td><code>Trigger_EmptyList...</code>, <code>Trigger_AlreadyClaimedList_ReturnsAlreadyClaimed_NoDuplicateClaim</code> (launcher never invoked; original claim untouched), <code>Trigger_NoSuchList...</code>, <code>Trigger_NoSuchDirector...</code>, <code>Trigger_MachineBusy...</code></td>
+<td>PASS</td>
+</tr>
+</tbody>
+</table>
+<p>Audited supporting behavior: the engine dispatches by action type (<code>SeedJob_Dispatches_ToSessionStarter_NotWorkListRunner</code> proves seed jobs are unaffected); a work-list job advances its schedule (<code>WorkListJob_Recurring_Due_Fires_AndAdvancesSchedule</code>); the Started path launches the drain in the BACKGROUND with a <code>cron:&lt;jobId&gt;:</code> consumer and releases the machine slot in a <code>finally</code> (<code>Trigger_Started_LaunchesDrain...</code>); validation accepts a work-list action without a seed and rejects neither-present (<code>Validate_WorkListAction_NoSeed_Ok</code> / <code>Validate_NeitherSeedNorWorkList_Fails</code>).</p>
+<h2>Method / regression lens</h2>
+<ul>
+<li><strong>Forbidden patterns:</strong> swept the 4 new source files for null-forgiving <code>!</code>, <code>.Result</code>, <code>.Wait()</code> -&gt; <strong>none</strong>.</li>
+<li><strong>Background task:</strong> the detached drain owns its try/catch and releases the machine slot in <code>finally</code> - no unobserved exception, no leaked slot.</li>
+<li><strong>Regression:</strong> the <code>Validate</code> change (seed OR workListName) did not break prior behavior - all 48 #482/#483 tests still pass; seed-only jobs remain valid; neither-present still fails.</li>
+<li><strong>Security (DT rules):</strong> no new auth surface (inherits host-wide token middleware); reuses the shipped #274 drain path (no new Director surface); no secrets logged. No blocking rule violated.</li>
+</ul>
+<h3>Non-blocking observations (not defects)</h3>
+<ol>
+<li><code>architecture_manifest.yaml</code> does not yet list the cron components. The feature is COMPLETE after this slice (#482+#483+#484); recommend the Support Agent record the full set (store, engine, run history, work-list trigger, Cronos dep) now. No security-posture change.</li>
+<li>(Carried from #483) run-now fires even a disabled job - not constrained by any AC; reasonable manual override.</li>
+</ol>
+<h2>Verdict</h2>
+<p><strong>VERIFIED - all 3 acceptance criteria met.</strong> Build clean, 61/61 cron tests pass on an independent build, no forbidden patterns, no regression from the validation change, no security drift; the launch path claims + drains in order through the shipped runner and every edge is handled cleanly with no duplicate claim. Standalone QA does not merge; <strong>PR #487 is ready for the human to merge</strong> - the final slice of epic #479.</p>
+</article>
+</body>
+</html>

--- a/docs/cencon/proof/issue-484/qa-report.md
+++ b/docs/cencon/proof/issue-484/qa-report.md
@@ -1,0 +1,39 @@
+# QA Proof Report - Issue #484
+
+## Cron jobs (3/3): named-work-list use case
+
+**Verifier:** QA Agent (independent - own fresh build + own test run; did not trust the dev report).
+**PR:** #487 (branch `issue-484-cron-worklist-usecase`, HEAD cc32a67).
+**Mode:** standalone QA -> NOT merged; merge left to the human.
+
+## How I verified independently
+
+1. Checked out the PR branch fresh and **built the whole solution myself**: `dotnet build cc-director.sln` -> **0 Warning(s), 0 Error(s)**.
+2. **Ran the cron suite myself**: `dotnet test --filter Cron` -> **61 Passed, 0 Failed, 0 Skipped** (13 new for #484: 7 trigger + 4 engine-dispatch + 2 validation; plus 48 from #482/#483).
+3. **Adversarially audited** the new code: dispatch-by-action-type, the pre-check ordering (no duplicate claim), the background drain + machine-slot release, and the validation change for regressions.
+
+No live full Gateway booted (Tailscale provisioner + :7878 bind would collide with the running Gateway). The integration is proven without a Director via the three seams; the launcher test drives a REAL `WorkListRunner` through the new path with a fake `IImplSessionDriver`.
+
+## Acceptance criteria - Expected vs Actual (independently judged)
+
+| # | Criterion | Evidence (reproduced) | Verdict |
+|---|-----------|-----------------------|---------|
+| AC1 | A work-list cron job, when fired, causes the #274 runner to CLAIM the list + start processing | `DrainLauncher_ClaimsList_AndDrainsItemsInOrder` (claim taken via the real runner; items started) + `WorkListJob_Dispatches_ToWorkListRunner_RecordsWorklistStarted_NoSession` (engine routes a work-list job to the runner, records `worklist-started`, null sessionId) | PASS |
+| AC2 | Items processed in list order | `DrainLauncher_ClaimsList_AndDrainsItemsInOrder` - start order 101,102,103 through the shipped #274 `WorkListRunner` | PASS |
+| AC3 | Empty / already-claimed / no-director / machine-busy handled cleanly, no crash, no duplicate claim | `Trigger_EmptyList...`, `Trigger_AlreadyClaimedList_ReturnsAlreadyClaimed_NoDuplicateClaim` (launcher never invoked; original claim untouched), `Trigger_NoSuchList...`, `Trigger_NoSuchDirector...`, `Trigger_MachineBusy...` | PASS |
+
+Audited supporting behavior: the engine dispatches by action type (`SeedJob_Dispatches_ToSessionStarter_NotWorkListRunner` proves seed jobs are unaffected); a work-list job advances its schedule (`WorkListJob_Recurring_Due_Fires_AndAdvancesSchedule`); the Started path launches the drain in the BACKGROUND with a `cron:<jobId>:` consumer and releases the machine slot in a `finally` (`Trigger_Started_LaunchesDrain...`); validation accepts a work-list action without a seed and rejects neither-present (`Validate_WorkListAction_NoSeed_Ok` / `Validate_NeitherSeedNorWorkList_Fails`).
+
+## Method / regression lens
+- **Forbidden patterns:** swept the 4 new source files for null-forgiving `!`, `.Result`, `.Wait()` -> **none**.
+- **Background task:** the detached drain owns its try/catch and releases the machine slot in `finally` - no unobserved exception, no leaked slot.
+- **Regression:** the `Validate` change (seed OR workListName) did not break prior behavior - all 48 #482/#483 tests still pass; seed-only jobs remain valid; neither-present still fails.
+- **Security (DT rules):** no new auth surface (inherits host-wide token middleware); reuses the shipped #274 drain path (no new Director surface); no secrets logged. No blocking rule violated.
+
+### Non-blocking observations (not defects)
+1. `architecture_manifest.yaml` does not yet list the cron components. The feature is COMPLETE after this slice (#482+#483+#484); recommend the Support Agent record the full set (store, engine, run history, work-list trigger, Cronos dep) now. No security-posture change.
+2. (Carried from #483) run-now fires even a disabled job - not constrained by any AC; reasonable manual override.
+
+## Verdict
+
+**VERIFIED - all 3 acceptance criteria met.** Build clean, 61/61 cron tests pass on an independent build, no forbidden patterns, no regression from the validation change, no security drift; the launch path claims + drains in order through the shipped runner and every edge is handled cleanly with no duplicate claim. Standalone QA does not merge; **PR #487 is ready for the human to merge** - the final slice of epic #479.

--- a/docs/cencon/proof/issue-484/report.html
+++ b/docs/cencon/proof/issue-484/report.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Proof Report - Issue #484</title>
+<style>
+        /* Boardroom Theme - Corporate, executive style with serif fonts */
+        
+        :root {
+            /* Colors */
+            --primary: #1A365D;
+            --primary-light: #2A4A7F;
+            --accent: #D69E2E;
+            --text: #2D3748;
+            --heading: #1A365D;
+            --background: #FFFFFF;
+            --code-bg: #EDF2F7;
+            --code-text: #1A365D;
+            --border: #CBD5E0;
+            --link: #2B6CB0;
+            --blockquote-text: #4A5568;
+            --blockquote-border: #D69E2E;
+            --blockquote-bg: #FFFFFF;
+            --table-header-bg: #1A365D;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #F7FAFC;
+            --shadow-color: rgba(26, 54, 93, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Palatino Linotype", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Georgia", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Courier New", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.02em;
+            --line-height: 1.7;
+            --radius: 4px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(26, 54, 93, 0.08);
+            --shadow-md: 0 4px 12px rgba(26, 54, 93, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Boardroom: corporate authority with accent borders */
+        h1 {
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.3em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        pre::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
+            background: var(--accent);
+            border-radius: 0;
+        }
+        
+        blockquote {
+            font-style: italic;
+        }
+        
+        hr {
+            background: var(--accent);
+            max-width: none;
+            height: 2px;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>Proof Report - Issue #484</h1>
+<h2>Cron jobs (3/3): named-work-list use case</h2>
+<p><strong>Part 3 of 3 of epic #479</strong> - the headline "midnight, run the loop over a list of work items" use case, on top of the merged #482 (store/CRUD) and #483 (firing engine).</p>
+<p><strong>Branch/PR:</strong> issue-484-cron-worklist-usecase (PR #487)
+        <strong>Build:</strong> <code>dotnet build cc-director.sln</code> -&gt; <strong>0 Warning(s), 0 Error(s)</strong>.
+        <strong>Tests:</strong> <code>dotnet test --filter Cron</code> -&gt; <strong>61 Passed, 0 Failed, 0 Skipped</strong> (13 new for #484 + 48 from #482/#483).</p>
+<h2>How this slice is proven</h2>
+<p>A cron job's action gains an optional <code>workListName</code>. When set, the fire triggers the shipped #274 work-list runner to drain that list on the target Director instead of starting a single seeded session. The integration is proven without a live Director via three seams: <code>ICronWorkListRunner</code> (engine dispatch), <code>ICronDirectorResolver</code> (Director lookup), and <code>ICronWorkListDrainLauncher</code> (the actual drain) - the launcher's driver is injectable so a real <code>WorkListRunner.DrainAsync</code> is driven with a fake <code>IImplSessionDriver</code>, proving the claim + ordered drain through the new path.</p>
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Criterion</th>
+<th>Proof (test)</th>
+<th>Expected</th>
+<th>Actual</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AC1</td>
+<td>A work-list cron job, when fired, causes the #274 runner to CLAIM the list and start processing</td>
+<td><code>CronWorkListTriggerTests.DrainLauncher_ClaimsList_AndDrainsItemsInOrder</code> (list claimed, items started) + <code>CronEngineWorkListTests.WorkListJob_Dispatches_ToWorkListRunner_RecordsWorklistStarted_NoSession</code> (engine routes the job to the runner, records <code>worklist-started</code>)</td>
+<td>claim taken; runner invoked</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC2</td>
+<td>Items processed in list order, advancing per terminal signal</td>
+<td><code>DrainLauncher_ClaimsList_AndDrainsItemsInOrder</code> - start order = 101,102,103 through the shipped #274 <code>WorkListRunner</code></td>
+<td>in order</td>
+<td>PASS</td>
+</tr>
+<tr>
+<td>AC3</td>
+<td>Empty / already-claimed / no-director / machine-busy handled cleanly, no crash, no duplicate claim</td>
+<td><code>Trigger_EmptyList...</code>, <code>Trigger_AlreadyClaimedList_ReturnsAlreadyClaimed_NoDuplicateClaim</code> (original claim untouched, launcher never invoked), <code>Trigger_NoSuchList...</code>, <code>Trigger_NoSuchDirector...</code>, <code>Trigger_MachineBusy...</code></td>
+<td>each a clean outcome, no launch</td>
+<td>PASS</td>
+</tr>
+</tbody>
+</table>
+<p>Supporting: <code>WorkListJob_Dispatches...</code> / <code>SeedJob_Dispatches_ToSessionStarter_NotWorkListRunner</code> prove the engine routes by action type (work-list vs seed); <code>WorkListJob_Recurring_Due_Fires_AndAdvancesSchedule</code> proves the schedule advances for a work-list job; <code>Trigger_Started_LaunchesDrain...</code> proves the background drain is launched with the list + a <code>cron:&lt;jobId&gt;:</code> consumer and the machine slot is held during and released after the drain; <code>CronScheduleTests.Validate_WorkListAction_NoSeed_Ok</code> / <code>Validate_NeitherSeedNorWorkList_Fails</code> cover validation.</p>
+<p>Note on AC1/AC2 scope: the per-item ordering and terminal-signal advancement are the shipped #274 <code>WorkListRunner</code>'s behavior (already covered by <code>WorkListRunnerTests</code>). This slice's new code is the GLUE (cron job -&gt; trigger that runner); the launcher test drives a real <code>WorkListRunner</code> through that glue to prove the claim + order end-to-end without a live Director.</p>
+<h2>CenCon impact</h2>
+<p>Adds the work-list trigger components to the <code>gateway</code> container and the <code>workListName</code> field to <code>gateway_contracts</code>. No security-posture change (reuses the shipped #274 drain path and the host-wide token middleware; no new Director surface; no secrets logged). With this slice the cron feature is complete; the Support Agent should now record the full cron component set (store, engine, run history, work-list trigger, Cronos dep) in <code>architecture_manifest.yaml</code>.</p>
+<h2>Statement</h2>
+<p>I believe this slice (#484) is finished: a cron job can drain a named work list on a schedule, the engine dispatches correctly by action type, the pre-check guards handle every edge cleanly with no duplicate claim, and the launch path claims + drains in order through the shipped runner. The solution builds clean with zero warnings. With #482 + #483 + #484 merged, the original request - "at midnight, run the implementation loop over a list of work items" - is functional end to end.</p>
+</article>
+</body>
+</html>

--- a/docs/cencon/proof/issue-484/report.md
+++ b/docs/cencon/proof/issue-484/report.md
@@ -1,0 +1,33 @@
+# Proof Report - Issue #484
+
+## Cron jobs (3/3): named-work-list use case
+
+**Part 3 of 3 of epic #479** - the headline "midnight, run the loop over a list of work items" use case, on top of the merged #482 (store/CRUD) and #483 (firing engine).
+
+**Branch/PR:** issue-484-cron-worklist-usecase (PR #487)
+**Build:** `dotnet build cc-director.sln` -> **0 Warning(s), 0 Error(s)**.
+**Tests:** `dotnet test --filter Cron` -> **61 Passed, 0 Failed, 0 Skipped** (13 new for #484 + 48 from #482/#483).
+
+## How this slice is proven
+
+A cron job's action gains an optional `workListName`. When set, the fire triggers the shipped #274 work-list runner to drain that list on the target Director instead of starting a single seeded session. The integration is proven without a live Director via three seams: `ICronWorkListRunner` (engine dispatch), `ICronDirectorResolver` (Director lookup), and `ICronWorkListDrainLauncher` (the actual drain) - the launcher's driver is injectable so a real `WorkListRunner.DrainAsync` is driven with a fake `IImplSessionDriver`, proving the claim + ordered drain through the new path.
+
+## Acceptance criteria - Expected vs Actual
+
+| # | Criterion | Proof (test) | Expected | Actual |
+|---|-----------|--------------|----------|--------|
+| AC1 | A work-list cron job, when fired, causes the #274 runner to CLAIM the list and start processing | `CronWorkListTriggerTests.DrainLauncher_ClaimsList_AndDrainsItemsInOrder` (list claimed, items started) + `CronEngineWorkListTests.WorkListJob_Dispatches_ToWorkListRunner_RecordsWorklistStarted_NoSession` (engine routes the job to the runner, records `worklist-started`) | claim taken; runner invoked | PASS |
+| AC2 | Items processed in list order, advancing per terminal signal | `DrainLauncher_ClaimsList_AndDrainsItemsInOrder` - start order = 101,102,103 through the shipped #274 `WorkListRunner` | in order | PASS |
+| AC3 | Empty / already-claimed / no-director / machine-busy handled cleanly, no crash, no duplicate claim | `Trigger_EmptyList...`, `Trigger_AlreadyClaimedList_ReturnsAlreadyClaimed_NoDuplicateClaim` (original claim untouched, launcher never invoked), `Trigger_NoSuchList...`, `Trigger_NoSuchDirector...`, `Trigger_MachineBusy...` | each a clean outcome, no launch | PASS |
+
+Supporting: `WorkListJob_Dispatches...` / `SeedJob_Dispatches_ToSessionStarter_NotWorkListRunner` prove the engine routes by action type (work-list vs seed); `WorkListJob_Recurring_Due_Fires_AndAdvancesSchedule` proves the schedule advances for a work-list job; `Trigger_Started_LaunchesDrain...` proves the background drain is launched with the list + a `cron:<jobId>:` consumer and the machine slot is held during and released after the drain; `CronScheduleTests.Validate_WorkListAction_NoSeed_Ok` / `Validate_NeitherSeedNorWorkList_Fails` cover validation.
+
+Note on AC1/AC2 scope: the per-item ordering and terminal-signal advancement are the shipped #274 `WorkListRunner`'s behavior (already covered by `WorkListRunnerTests`). This slice's new code is the GLUE (cron job -> trigger that runner); the launcher test drives a real `WorkListRunner` through that glue to prove the claim + order end-to-end without a live Director.
+
+## CenCon impact
+
+Adds the work-list trigger components to the `gateway` container and the `workListName` field to `gateway_contracts`. No security-posture change (reuses the shipped #274 drain path and the host-wide token middleware; no new Director surface; no secrets logged). With this slice the cron feature is complete; the Support Agent should now record the full cron component set (store, engine, run history, work-list trigger, Cronos dep) in `architecture_manifest.yaml`.
+
+## Statement
+
+I believe this slice (#484) is finished: a cron job can drain a named work list on a schedule, the engine dispatches correctly by action type, the pre-check guards handle every edge cleanly with no duplicate claim, and the launch path claims + drains in order through the shipped runner. The solution builds clean with zero warnings. With #482 + #483 + #484 merged, the original request - "at midnight, run the implementation loop over a list of work items" - is functional end to end.

--- a/src/CcDirector.Gateway.Contracts/CronJobDto.cs
+++ b/src/CcDirector.Gateway.Contracts/CronJobDto.cs
@@ -72,12 +72,25 @@ public sealed class CronJobTarget
     public string DirectorId { get; set; } = "";
 }
 
-/// <summary>What a cron job runs when it fires (epic #479).</summary>
+/// <summary>
+/// What a cron job runs when it fires (epic #479). Two action shapes:
+///   - SEED (parts 1-2): start one session on the target Director seeded with <see cref="Seed"/>.
+///   - WORK LIST (part 3, #484): when <see cref="WorkListName"/> is set, the fire instead triggers
+///     the named-work-list runner (#274) to drain that list on the target Director - the headline
+///     "midnight, run the loop over a list of work items" use case.
+/// A job sets one or the other; <see cref="WorkListName"/> takes precedence when both are present.
+/// </summary>
 public sealed class CronJobAction
 {
-    /// <summary>Working directory for the session the fire starts.</summary>
+    /// <summary>Working directory for the session(s) the fire starts.</summary>
     public string RepoPath { get; set; } = "";
 
-    /// <summary>The skill or prompt text the session runs (e.g. <c>/work-list run Tonight</c>).</summary>
+    /// <summary>The skill or prompt text a seed-action session runs (e.g. <c>/help</c>). Optional when <see cref="WorkListName"/> is set.</summary>
     public string Seed { get; set; } = "";
+
+    /// <summary>
+    /// When set, the fire drains this named work list (#274) on the target Director instead of
+    /// starting a single seeded session. Null/empty = a seed action.
+    /// </summary>
+    public string? WorkListName { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/CronEngineTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronEngineTests.cs
@@ -25,6 +25,17 @@ public sealed class CronEngineTests : IDisposable
         if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
     }
 
+    // All tests in this file exercise SEED jobs, so the work-list runner is never invoked; this
+    // helper supplies a stub for the #484 constructor parameter without changing any test.
+    private static CronEngine Engine(CronJobStore store, CronRunHistoryStore history, ICronSessionStarter starter, IClock clock) =>
+        new(store, history, starter, new UnusedWorkListRunner(), clock);
+
+    private sealed class UnusedWorkListRunner : ICronWorkListRunner
+    {
+        public Task<CronWorkListOutcome> TriggerAsync(CronJobDto job, CancellationToken ct) =>
+            throw new InvalidOperationException("a seed-job test must not trigger the work-list runner");
+    }
+
     private static CronJobDto Recurring(string name = "nightly", bool enabled = true) => new()
     {
         Name = name,
@@ -56,7 +67,7 @@ public sealed class CronEngineTests : IDisposable
         Assert.NotNull(created.NextRunUtc);
 
         var clock = new FakeClock(created.NextRunUtc.Value.AddMinutes(1));
-        var engine = new CronEngine(store, history, starter, clock);
+        var engine = Engine(store, history, starter, clock);
 
         var fired = await engine.EvaluateDueAsync(CancellationToken.None);
 
@@ -79,7 +90,7 @@ public sealed class CronEngineTests : IDisposable
         var starter = new RecordingStarter();
         var created = store.Create(Recurring(enabled: false));
         var clock = new FakeClock((created.NextRunUtc ?? DateTime.UtcNow).AddDays(1));
-        var engine = new CronEngine(store, history, starter, clock);
+        var engine = Engine(store, history, starter, clock);
 
         var firedWhileDisabled = await engine.EvaluateDueAsync(CancellationToken.None);
         Assert.Empty(firedWhileDisabled);                          // AC5: disabled never fires
@@ -104,7 +115,7 @@ public sealed class CronEngineTests : IDisposable
         // The Gateway was "down" for ~3 days: now is far past the due time, spanning several missed
         // daily occurrences.
         var clock = new FakeClock(created.NextRunUtc!.Value.AddDays(3).AddHours(2));
-        var engine = new CronEngine(store, history, starter, clock);
+        var engine = Engine(store, history, starter, clock);
 
         await engine.EvaluateDueAsync(CancellationToken.None);
         await engine.EvaluateDueAsync(CancellationToken.None);     // a second sweep at the same instant
@@ -125,7 +136,7 @@ public sealed class CronEngineTests : IDisposable
         var starter = new RecordingStarter();
         var created = store.Create(OneOff(DateTime.Now.Date.AddDays(1)));
         var clock = new FakeClock(created.NextRunUtc!.Value.AddMinutes(1));
-        var engine = new CronEngine(store, history, starter, clock);
+        var engine = Engine(store, history, starter, clock);
 
         await engine.EvaluateDueAsync(CancellationToken.None);
         var after = store.Get(created.Id);
@@ -134,7 +145,7 @@ public sealed class CronEngineTests : IDisposable
         Assert.Null(after.NextRunUtc);
 
         // A later sweep does not fire it again.
-        var clock2Engine = new CronEngine(store, history, starter, new FakeClock(clock.UtcNow.AddDays(1)));
+        var clock2Engine = Engine(store, history, starter, new FakeClock(clock.UtcNow.AddDays(1)));
         var firedAgain = await clock2Engine.EvaluateDueAsync(CancellationToken.None);
         Assert.Empty(firedAgain);
         Assert.Equal(1, starter.StartCount);
@@ -147,7 +158,7 @@ public sealed class CronEngineTests : IDisposable
         var history = NewHistory();
         var blocking = new BlockingStarter();
         var created = store.Create(Recurring());                   // PreventOverlap defaults true
-        var engine = new CronEngine(store, history, blocking, new FakeClock(DateTime.UtcNow));
+        var engine = Engine(store, history, blocking, new FakeClock(DateTime.UtcNow));
 
         // Start the first run; it blocks inside the starter.
         var firstRun = engine.RunNowAsync(created.Id, CancellationToken.None);
@@ -166,7 +177,7 @@ public sealed class CronEngineTests : IDisposable
     [Fact]
     public async Task RunNow_NoSuchJob_ReturnsNoSuchJob()
     {
-        var engine = new CronEngine(NewJobStore(), NewHistory(), new RecordingStarter(), new FakeClock(DateTime.UtcNow));
+        var engine = Engine(NewJobStore(), NewHistory(), new RecordingStarter(), new FakeClock(DateTime.UtcNow));
         var result = await engine.RunNowAsync("cj_nope", CancellationToken.None);
         Assert.Equal(CronFireOutcome.NoSuchJob, result.Outcome);
     }
@@ -177,7 +188,7 @@ public sealed class CronEngineTests : IDisposable
         var store = NewJobStore();
         var history = NewHistory();
         var created = store.Create(Recurring());
-        var engine = new CronEngine(store, history, new FailingStarter(), new FakeClock(DateTime.UtcNow));
+        var engine = Engine(store, history, new FailingStarter(), new FakeClock(DateTime.UtcNow));
 
         var result = await engine.RunNowAsync(created.Id, CancellationToken.None);
 

--- a/src/CcDirector.Gateway.Tests/CronEngineWorkListTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronEngineWorkListTests.cs
@@ -1,0 +1,157 @@
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests that the <see cref="CronEngine"/> DISPATCHES correctly by action type (epic #479, #484): a
+/// work-list job goes to the <see cref="ICronWorkListRunner"/> (and records a worklist-* run), a seed
+/// job goes to the <see cref="ICronSessionStarter"/>, and a recurring work-list job still advances
+/// its schedule.
+/// </summary>
+public sealed class CronEngineWorkListTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-croneng-wl-tests-" + Guid.NewGuid().ToString("N"));
+
+    private CronJobStore NewJobStore() => new(Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".json"));
+    private CronRunHistoryStore NewHistory() => new(Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".runs.json"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private static CronJobDto WorkListJob() => new()
+    {
+        Name = "drain",
+        ScheduleKind = CronSchedule.KindRecurring,
+        CronExpression = "0 0 * * *",
+        TimeZoneId = "America/Chicago",
+        Target = new CronJobTarget { DirectorId = "workstation-A" },
+        Action = new CronJobAction { RepoPath = @"D:\repo", WorkListName = "Tonight" },
+    };
+
+    private static CronJobDto SeedJob() => new()
+    {
+        Name = "seed",
+        ScheduleKind = CronSchedule.KindRecurring,
+        CronExpression = "0 0 * * *",
+        TimeZoneId = "America/Chicago",
+        Target = new CronJobTarget { DirectorId = "workstation-A" },
+        Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "/help" },
+    };
+
+    [Fact]
+    public async Task WorkListJob_Dispatches_ToWorkListRunner_RecordsWorklistStarted_NoSession()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var runner = new RecordingWorkListRunner(CronWorkListOutcome.Started);
+        var starter = new ThrowingStarter();
+        var created = store.Create(WorkListJob());
+        var engine = new CronEngine(store, history, starter, runner, new FakeClock(DateTime.UtcNow));
+
+        var result = await engine.RunNowAsync(created.Id, CancellationToken.None);
+
+        Assert.Equal(CronFireOutcome.Fired, result.Outcome);
+        Assert.Equal(1, runner.TriggerCount);                 // routed to the work-list runner
+        Assert.NotNull(result.Record);
+        Assert.Equal("worklist-started", result.Record.InfraStatus);
+        Assert.Null(result.Record.SessionId);                 // a drain starts many sessions, not one
+        Assert.Single(history.List(created.Id));
+    }
+
+    [Fact]
+    public async Task SeedJob_Dispatches_ToSessionStarter_NotWorkListRunner()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var runner = new RecordingWorkListRunner(CronWorkListOutcome.Started);
+        var starter = new RecordingStarter();
+        var created = store.Create(SeedJob());
+        var engine = new CronEngine(store, history, starter, runner, new FakeClock(DateTime.UtcNow));
+
+        var result = await engine.RunNowAsync(created.Id, CancellationToken.None);
+
+        Assert.Equal(CronFireOutcome.Fired, result.Outcome);
+        Assert.Equal(1, starter.StartCount);                  // routed to the session starter
+        Assert.Equal(0, runner.TriggerCount);
+        Assert.NotNull(result.Record);
+        Assert.Equal("started", result.Record.InfraStatus);
+        Assert.Equal("sid-1", result.Record.SessionId);
+    }
+
+    [Fact]
+    public async Task WorkListJob_EmptyList_RecordsWorklistEmpty()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var runner = new RecordingWorkListRunner(CronWorkListOutcome.EmptyList);
+        var created = store.Create(WorkListJob());
+        var engine = new CronEngine(store, history, new ThrowingStarter(), runner, new FakeClock(DateTime.UtcNow));
+
+        var result = await engine.RunNowAsync(created.Id, CancellationToken.None);
+
+        Assert.NotNull(result.Record);
+        Assert.Equal("worklist-empty", result.Record.InfraStatus);
+    }
+
+    [Fact]
+    public async Task WorkListJob_Recurring_Due_Fires_AndAdvancesSchedule()
+    {
+        var store = NewJobStore();
+        var history = NewHistory();
+        var runner = new RecordingWorkListRunner(CronWorkListOutcome.Started);
+        var created = store.Create(WorkListJob());
+        var clock = new FakeClock(created.NextRunUtc!.Value.AddMinutes(1));
+        var engine = new CronEngine(store, history, new ThrowingStarter(), runner, clock);
+
+        var fired = await engine.EvaluateDueAsync(CancellationToken.None);
+
+        Assert.Single(fired);
+        Assert.Equal(1, runner.TriggerCount);
+        var after = store.Get(created.Id);
+        Assert.NotNull(after);
+        Assert.True(after.NextRunUtc!.Value > clock.UtcNow);  // schedule advanced
+    }
+
+    // ---- fakes -------------------------------------------------------------------------------
+
+    private sealed class FakeClock : IClock
+    {
+        public FakeClock(DateTime utcNow) => UtcNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+        public DateTime UtcNow { get; }
+    }
+
+    private sealed class RecordingWorkListRunner : ICronWorkListRunner
+    {
+        private readonly CronWorkListOutcome _outcome;
+        public int TriggerCount { get; private set; }
+        public RecordingWorkListRunner(CronWorkListOutcome outcome) => _outcome = outcome;
+
+        public Task<CronWorkListOutcome> TriggerAsync(CronJobDto job, CancellationToken ct)
+        {
+            TriggerCount++;
+            return Task.FromResult(_outcome);
+        }
+    }
+
+    private sealed class RecordingStarter : ICronSessionStarter
+    {
+        public int StartCount { get; private set; }
+        public Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct)
+        {
+            StartCount++;
+            return Task.FromResult<(string?, string?)>(($"sid-{StartCount}", null));
+        }
+    }
+
+    private sealed class ThrowingStarter : ICronSessionStarter
+    {
+        public Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct) =>
+            throw new InvalidOperationException("a work-list-job test must not start a single session");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CronRunEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronRunEndpointsTests.cs
@@ -34,7 +34,7 @@ public sealed class CronRunEndpointsTests : IAsyncLifetime
 
         _store = new CronJobStore(_jobsPath);
         var history = new CronRunHistoryStore(_runsPath);
-        var engine = new CronEngine(_store, history, new FakeStarter(), new SystemClock());
+        var engine = new CronEngine(_store, history, new FakeStarter(), new UnusedWorkListRunner(), new SystemClock());
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
@@ -118,6 +118,12 @@ public sealed class CronRunEndpointsTests : IAsyncLifetime
     {
         public Task<(string? sessionId, string? error)> StartAsync(CronJobDto job, CancellationToken ct) =>
             Task.FromResult<(string?, string?)>(("fake-sid", null));
+    }
+
+    private sealed class UnusedWorkListRunner : ICronWorkListRunner
+    {
+        public Task<CronWorkListOutcome> TriggerAsync(CronJobDto job, CancellationToken ct) =>
+            throw new InvalidOperationException("seed-job endpoint test must not trigger the work-list runner");
     }
 
     private static int AllocateFreePort()

--- a/src/CcDirector.Gateway.Tests/CronScheduleTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronScheduleTests.cs
@@ -43,6 +43,28 @@ public sealed class CronScheduleTests
     }
 
     [Fact]
+    public void Validate_WorkListAction_NoSeed_Ok()
+    {
+        // A work-list job (#484) may omit the seed; the work-list name is the action.
+        var job = ValidRecurring();
+        job.Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "", WorkListName = "Tonight" };
+
+        var (ok, error) = CronSchedule.Validate(job);
+        Assert.True(ok);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void Validate_NeitherSeedNorWorkList_Fails()
+    {
+        var job = ValidRecurring();
+        job.Action = new CronJobAction { RepoPath = @"D:\repo", Seed = "", WorkListName = null };
+
+        var (ok, _) = CronSchedule.Validate(job);
+        Assert.False(ok);
+    }
+
+    [Fact]
     public void Validate_InvalidCronExpression_Fails()
     {
         var job = ValidRecurring();

--- a/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
@@ -1,0 +1,201 @@
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for the cron work-list use case (epic #479, #484): the <see cref="DirectorCronWorkListRunner"/>
+/// pre-check outcomes (AC3 - no list / empty / already-claimed / no director / machine busy handled
+/// cleanly, no duplicate claim) and the <see cref="DirectorWorkListDrainLauncher"/> proving that the
+/// launch path CLAIMS the list and drains it IN ORDER through the shipped #274 runner (AC1/AC2).
+/// Schedule validation of a work-list action is covered too.
+/// </summary>
+public sealed class CronWorkListTriggerTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-cronwl-tests-" + Guid.NewGuid().ToString("N"));
+
+    private WorkListStore NewListStore() => new(Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".json"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private static CronJobDto WorkListJob(string listName = "Tonight") => new()
+    {
+        Id = "cj_test",
+        Name = "drain",
+        ScheduleKind = CronSchedule.KindRecurring,
+        CronExpression = "0 0 * * *",
+        TimeZoneId = "America/Chicago",
+        Target = new CronJobTarget { DirectorId = "workstation-A" },
+        Action = new CronJobAction { RepoPath = @"D:\repo", WorkListName = listName },
+    };
+
+    private static DirectorCronWorkListRunner Trigger(
+        WorkListStore store, ICronDirectorResolver resolver, WorkListRunnerManager manager, ICronWorkListDrainLauncher launcher) =>
+        new(store, resolver, manager, launcher);
+
+    [Fact]
+    public async Task Trigger_NoSuchList_ReturnsNoSuchList()
+    {
+        var store = NewListStore();
+        var t = Trigger(store, new FakeResolver("http://d", "machineA"), new WorkListRunnerManager(), new FakeLauncher());
+        Assert.Equal(CronWorkListOutcome.NoSuchList, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Trigger_EmptyList_ReturnsEmptyList()
+    {
+        var store = NewListStore();
+        store.Create("Tonight"); // exists but no items
+        var t = Trigger(store, new FakeResolver("http://d", "machineA"), new WorkListRunnerManager(), new FakeLauncher());
+        Assert.Equal(CronWorkListOutcome.EmptyList, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Trigger_AlreadyClaimedList_ReturnsAlreadyClaimed_NoDuplicateClaim()
+    {
+        var store = NewListStore();
+        store.Create("Tonight");
+        store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "312" });
+        Assert.Equal(WorkListStore.ClaimResult.Granted, store.Claim("Tonight", "someone-else"));
+
+        var launcher = new FakeLauncher();
+        var t = Trigger(store, new FakeResolver("http://d", "machineA"), new WorkListRunnerManager(), launcher);
+
+        Assert.Equal(CronWorkListOutcome.AlreadyClaimed, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
+        Assert.Equal(0, launcher.LaunchCount);                 // never launched -> no duplicate claim
+        Assert.Equal("someone-else", store.Get("Tonight")!.Consumer); // original claim untouched
+    }
+
+    [Fact]
+    public async Task Trigger_NoSuchDirector_ReturnsNoSuchDirector()
+    {
+        var store = NewListStore();
+        store.Create("Tonight");
+        store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "312" });
+        var t = Trigger(store, new FakeResolver(null, null), new WorkListRunnerManager(), new FakeLauncher());
+        Assert.Equal(CronWorkListOutcome.NoSuchDirector, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Trigger_MachineBusy_ReturnsMachineBusy()
+    {
+        var store = NewListStore();
+        store.Create("Tonight");
+        store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "312" });
+        var manager = new WorkListRunnerManager();
+        Assert.Equal(WorkListRunnerManager.AdmitResult.Admitted, manager.TryAdmit("machineA", "OtherList"));
+
+        var t = Trigger(store, new FakeResolver("http://d", "machineA"), manager, new FakeLauncher());
+        Assert.Equal(CronWorkListOutcome.MachineBusy, await t.TriggerAsync(WorkListJob(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Trigger_Started_LaunchesDrain_WithListAndCronConsumer_ThenReleasesMachine()
+    {
+        var store = NewListStore();
+        store.Create("Tonight");
+        store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "312" });
+        var manager = new WorkListRunnerManager();
+        var launcher = new FakeLauncher();
+        var t = Trigger(store, new FakeResolver("http://d", "machineA"), manager, launcher);
+
+        var outcome = await t.TriggerAsync(WorkListJob(), CancellationToken.None);
+        Assert.Equal(CronWorkListOutcome.Started, outcome);
+
+        // The drain runs in the background; wait until the launcher is invoked.
+        await launcher.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal("Tonight", launcher.LastListName);
+        Assert.StartsWith("cron:cj_test:", launcher.LastConsumer);
+        Assert.Equal("Tonight", manager.ActiveList("machineA")); // machineA's slot holds the "Tonight" drain
+
+        launcher.Release.TrySetResult();
+        await launcher.Completed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // The machine slot is released after the drain completes (poll briefly for the finally).
+        await WaitUntilAsync(() => manager.ActiveList("machineA") is null, TimeSpan.FromSeconds(10));
+        Assert.Null(manager.ActiveList("machineA"));
+    }
+
+    [Fact]
+    public async Task DrainLauncher_ClaimsList_AndDrainsItemsInOrder()
+    {
+        // The production launcher with a FAKE driver factory: proves that going through the launcher
+        // CLAIMS the list and drives the shipped WorkListRunner over the items in order (AC1/AC2).
+        var store = NewListStore();
+        store.Create("Tonight");
+        store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "101" });
+        store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "102" });
+        store.AppendItem("Tonight", new WorkListItemRef { Source = "github", Id = "103" });
+
+        var driver = new OrderRecordingDriver();
+        var launcher = new DirectorWorkListDrainLauncher(store, client: null, driverFactory: (_, _) => driver);
+
+        await launcher.LaunchAsync("http://d", @"D:\repo", "Tonight", "cron:cj_test:abc", CancellationToken.None);
+
+        Assert.Equal(new[] { "101", "102", "103" }, driver.StartOrder.ToArray()); // in list order
+        Assert.Null(store.Get("Tonight")!.Consumer);                               // claim released after drain
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+    }
+
+    // ---- fakes -------------------------------------------------------------------------------
+
+    private sealed class FakeResolver : ICronDirectorResolver
+    {
+        private readonly string? _endpoint;
+        private readonly string? _machine;
+        public FakeResolver(string? endpoint, string? machine) { _endpoint = endpoint; _machine = machine; }
+        public (string? endpoint, string? machineName) Resolve(string directorId) => (_endpoint, _machine);
+    }
+
+    private sealed class FakeLauncher : ICronWorkListDrainLauncher
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Completed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int LaunchCount { get; private set; }
+        public string? LastListName { get; private set; }
+        public string LastConsumer { get; private set; } = "";
+
+        public async Task LaunchAsync(string endpoint, string repoPath, string listName, string consumer, CancellationToken ct)
+        {
+            LaunchCount++;
+            LastListName = listName;
+            LastConsumer = consumer;
+            Entered.TrySetResult();
+            await Release.Task;
+            Completed.TrySetResult();
+        }
+    }
+
+    private sealed class OrderRecordingDriver : IImplSessionDriver
+    {
+        public List<string> StartOrder { get; } = new();
+
+        public Task<(string? sessionId, string? error)> StartImplementationSessionAsync(string itemId, string seedPrompt, CancellationToken ct)
+        {
+            StartOrder.Add(itemId);
+            return Task.FromResult<(string?, string?)>(($"sid-{itemId}", null));
+        }
+
+        public Task<string?> ReadTranscriptAsync(string sessionId, CancellationToken ct)
+        {
+            var issueId = sessionId["sid-".Length..];
+            return Task.FromResult<string?>(
+                $"IMPL-LOOP-TERMINAL\nissue: {issueId}\nsignal: done\npr: none\nmerged: yes\nreason: test\n");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/CronJobStore.cs
+++ b/src/CcDirector.Gateway/CronJobStore.cs
@@ -130,7 +130,7 @@ public sealed class CronJobStore
             existing.RunAt = incoming.RunAt;
             existing.TimeZoneId = incoming.TimeZoneId;
             existing.Target = new CronJobTarget { DirectorId = incoming.Target.DirectorId };
-            existing.Action = new CronJobAction { RepoPath = incoming.Action.RepoPath, Seed = incoming.Action.Seed };
+            existing.Action = new CronJobAction { RepoPath = incoming.Action.RepoPath, Seed = incoming.Action.Seed, WorkListName = incoming.Action.WorkListName };
             existing.PreventOverlap = incoming.PreventOverlap;
             existing.NextRunUtc = CronSchedule.ComputeNextRunUtc(existing, DateTime.UtcNow);
 
@@ -215,7 +215,7 @@ public sealed class CronJobStore
         RunAt = job.RunAt,
         TimeZoneId = job.TimeZoneId,
         Target = new CronJobTarget { DirectorId = job.Target.DirectorId },
-        Action = new CronJobAction { RepoPath = job.Action.RepoPath, Seed = job.Action.Seed },
+        Action = new CronJobAction { RepoPath = job.Action.RepoPath, Seed = job.Action.Seed, WorkListName = job.Action.WorkListName },
         PreventOverlap = job.PreventOverlap,
         CreatedUtc = job.CreatedUtc,
         LastFiredUtc = job.LastFiredUtc,

--- a/src/CcDirector.Gateway/CronSchedule.cs
+++ b/src/CcDirector.Gateway/CronSchedule.cs
@@ -38,8 +38,10 @@ public static class CronSchedule
             return (false, "target.directorId is required");
         if (job.Action is null || string.IsNullOrWhiteSpace(job.Action.RepoPath))
             return (false, "action.repoPath is required");
-        if (job.Action is null || string.IsNullOrWhiteSpace(job.Action.Seed))
-            return (false, "action.seed is required");
+        // The action is EITHER a seed (a prompt/skill) OR a work-list drain (#484). At least one is
+        // required; a work-list job may omit the seed.
+        if (string.IsNullOrWhiteSpace(job.Action.Seed) && string.IsNullOrWhiteSpace(job.Action.WorkListName))
+            return (false, "action requires either a seed or a workListName");
 
         if (IsRecurring(job.ScheduleKind))
         {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -177,8 +177,16 @@ public sealed class GatewayHost : IAsyncDisposable
         // target Director from the registry and starts a session over the shared client (the same
         // path the work-list runner uses). The background sweep timer is started in StartAsync.
         _cronRuns = new CronRunHistoryStore(cronRunsPath ?? Path.Combine(CcStorage.Root(), "cronruns.json"));
+        // A work-list cron job (#484) drains a named list via the shipped #274 runner: resolve the
+        // target Director, then launch the drain in the background on the shared runner manager.
+        var cronWorkListRunner = new Running.DirectorCronWorkListRunner(
+            _workLists,
+            new Running.RegistryDirectorResolver(Registry),
+            _runnerManager,
+            new Running.DirectorWorkListDrainLauncher(_workLists, _client));
         _cronEngine = new Running.CronEngine(
-            _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(Registry, _client), new Running.SystemClock());
+            _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(Registry, _client),
+            cronWorkListRunner, new Running.SystemClock());
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Running/CronEngine.cs
+++ b/src/CcDirector.Gateway/Running/CronEngine.cs
@@ -40,12 +40,15 @@ public sealed class CronEngine
     private readonly CronJobStore _store;
     private readonly CronRunHistoryStore _history;
     private readonly ICronSessionStarter _starter;
+    private readonly ICronWorkListRunner _workListRunner;
     private readonly IClock _clock;
     private readonly TimeSpan _catchUpThreshold;
 
     private readonly object _inFlightGate = new();
     private readonly HashSet<string> _inFlight = new(StringComparer.Ordinal);
 
+    /// <param name="starter">Starts a single seeded session for a seed-action job.</param>
+    /// <param name="workListRunner">Drains a named work list for a work-list-action job (#484).</param>
     /// <param name="catchUpThreshold">
     /// How far past its due time a scheduled fire must be to be labeled a catch-up (default 2 min).
     /// Purely cosmetic on the run record; it does not change whether the job fires.
@@ -54,12 +57,14 @@ public sealed class CronEngine
         CronJobStore store,
         CronRunHistoryStore history,
         ICronSessionStarter starter,
+        ICronWorkListRunner workListRunner,
         IClock clock,
         TimeSpan? catchUpThreshold = null)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _history = history ?? throw new ArgumentNullException(nameof(history));
         _starter = starter ?? throw new ArgumentNullException(nameof(starter));
+        _workListRunner = workListRunner ?? throw new ArgumentNullException(nameof(workListRunner));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _catchUpThreshold = catchUpThreshold ?? TimeSpan.FromMinutes(2);
     }
@@ -126,12 +131,32 @@ public sealed class CronEngine
 
         try
         {
-            var (sessionId, error) = await _starter.StartAsync(job, ct);
+            // A work-list action (#484) drains a named list via the runner; a seed action starts a
+            // single session. Either way a run is recorded and the schedule advances below.
+            var isWorkList = !string.IsNullOrWhiteSpace(job.Action.WorkListName);
+            string? sessionId;
+            string? error;
+            bool started;
+            string baseStatus;
+            if (isWorkList)
+            {
+                var outcome = await _workListRunner.TriggerAsync(job, ct);
+                sessionId = null;                                  // a drain starts many sessions, not one
+                started = outcome == CronWorkListOutcome.Started;
+                error = started ? null : outcome.ToString();
+                baseStatus = "worklist-" + WorkListStatusSuffix(outcome);
+            }
+            else
+            {
+                (sessionId, error) = await _starter.StartAsync(job, ct);
+                started = sessionId is not null;
+                baseStatus = started ? "started" : "not-started";
+            }
+
             var firedUtc = _clock.UtcNow;
-            var started = sessionId is not null;
             var isCatchUp = !isManual && started && (firedUtc - scheduledUtc) > _catchUpThreshold;
 
-            var infraStatus = !started ? "not-started" : isCatchUp ? "catch-up" : "started";
+            var infraStatus = isCatchUp ? "catch-up" : baseStatus;
             var record = new CronRunRecord
             {
                 ScheduledUtc = scheduledUtc,
@@ -173,6 +198,17 @@ public sealed class CronEngine
                 ExitFlight(job.Id);
         }
     }
+
+    private static string WorkListStatusSuffix(CronWorkListOutcome outcome) => outcome switch
+    {
+        CronWorkListOutcome.Started => "started",
+        CronWorkListOutcome.EmptyList => "empty",
+        CronWorkListOutcome.NoSuchList => "no-list",
+        CronWorkListOutcome.AlreadyClaimed => "already-claimed",
+        CronWorkListOutcome.NoSuchDirector => "no-director",
+        CronWorkListOutcome.MachineBusy => "machine-busy",
+        _ => "unknown",
+    };
 
     private bool TryEnterFlight(string id)
     {

--- a/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
@@ -1,0 +1,100 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// Production <see cref="ICronWorkListRunner"/> (epic #479, #484): when a cron job's action names a
+/// work list, this triggers the shipped #274 drain on the job's target Director. It mirrors the
+/// <c>POST /lists/{name}/run</c> endpoint's guards - synchronous pre-checks (no list / empty /
+/// already-claimed / no director / machine busy) return a clean outcome and never launch a drain -
+/// then launches the actual drain in the BACKGROUND (a cron sweep must not block for the hours a
+/// drain can take), releasing the machine's single-drain slot when it finishes.
+/// </summary>
+public sealed class DirectorCronWorkListRunner : ICronWorkListRunner
+{
+    private readonly WorkListStore _store;
+    private readonly ICronDirectorResolver _resolver;
+    private readonly WorkListRunnerManager _manager;
+    private readonly ICronWorkListDrainLauncher _launcher;
+
+    public DirectorCronWorkListRunner(
+        WorkListStore store,
+        ICronDirectorResolver resolver,
+        WorkListRunnerManager manager,
+        ICronWorkListDrainLauncher launcher)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _manager = manager ?? throw new ArgumentNullException(nameof(manager));
+        _launcher = launcher ?? throw new ArgumentNullException(nameof(launcher));
+    }
+
+    public Task<CronWorkListOutcome> TriggerAsync(CronJobDto job, CancellationToken ct)
+    {
+        if (job is null)
+            throw new ArgumentNullException(nameof(job));
+        var listName = job.Action.WorkListName;
+        if (string.IsNullOrWhiteSpace(listName))
+            throw new ArgumentException("job is not a work-list action", nameof(job));
+
+        // Synchronous pre-checks (AC3): a clean outcome, no drain launched, no duplicate claim.
+        var list = _store.Get(listName);
+        if (list is null)
+        {
+            FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: no such list={listName}");
+            return Task.FromResult(CronWorkListOutcome.NoSuchList);
+        }
+        if (list.Items.Count == 0)
+        {
+            FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: list={listName} is empty; nothing to drain");
+            return Task.FromResult(CronWorkListOutcome.EmptyList);
+        }
+        if (!string.IsNullOrEmpty(list.Consumer))
+        {
+            FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: list={listName} already claimed by {list.Consumer}");
+            return Task.FromResult(CronWorkListOutcome.AlreadyClaimed);
+        }
+
+        var (endpoint, machineName) = _resolver.Resolve(job.Target.DirectorId);
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: no such director={job.Target.DirectorId}");
+            return Task.FromResult(CronWorkListOutcome.NoSuchDirector);
+        }
+
+        var machineKey = string.IsNullOrWhiteSpace(machineName) ? job.Target.DirectorId : machineName;
+        if (_manager.TryAdmit(machineKey, listName) == WorkListRunnerManager.AdmitResult.RefusedMachineBusy)
+        {
+            FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: machine={machineKey} busy (active={_manager.ActiveList(machineKey)})");
+            return Task.FromResult(CronWorkListOutcome.MachineBusy);
+        }
+
+        // Admitted: launch the drain in the background so the cron sweep is not blocked for the
+        // hours a drain can take. The machine slot is released when the drain finishes.
+        var consumer = $"cron:{job.Id}:{Guid.NewGuid():N}";
+        var repoPath = job.Action.RepoPath;
+        FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: launching drain list={listName} on machine={machineKey}, consumer={consumer}");
+
+        _ = Task.Run(async () =>
+        {
+            // Detached background task: it owns its try/catch so a drain failure is logged, never
+            // unobserved, and the machine slot is always released.
+            try
+            {
+                await _launcher.LaunchAsync(endpoint, repoPath, listName, consumer, ct);
+                FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: drain complete list={listName}");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[DirectorCronWorkListRunner] job={job.Id}: drain FAILED list={listName}: {ex.Message}");
+            }
+            finally
+            {
+                _manager.Complete(machineKey);
+            }
+        }, CancellationToken.None);
+
+        return Task.FromResult(CronWorkListOutcome.Started);
+    }
+}

--- a/src/CcDirector.Gateway/Running/ICronDirectorResolver.cs
+++ b/src/CcDirector.Gateway/Running/ICronDirectorResolver.cs
@@ -1,0 +1,34 @@
+using CcDirector.Gateway.Discovery;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// Resolves a Director id to its control endpoint + machine name, behind an interface so the cron
+/// work-list trigger (epic #479, #484) is unit-testable without populating a real
+/// <see cref="DirectorRegistry"/>. Production is <see cref="RegistryDirectorResolver"/>.
+/// </summary>
+public interface ICronDirectorResolver
+{
+    /// <summary>
+    /// Resolve <paramref name="directorId"/>. Returns (null, null) when no such Director is
+    /// registered or it has no control endpoint.
+    /// </summary>
+    (string? endpoint, string? machineName) Resolve(string directorId);
+}
+
+/// <summary>Production resolver over the Gateway's <see cref="DirectorRegistry"/>.</summary>
+public sealed class RegistryDirectorResolver : ICronDirectorResolver
+{
+    private readonly DirectorRegistry _registry;
+
+    public RegistryDirectorResolver(DirectorRegistry registry) =>
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+
+    public (string? endpoint, string? machineName) Resolve(string directorId)
+    {
+        var director = _registry.Get(directorId);
+        if (director is null || string.IsNullOrEmpty(director.ControlEndpoint))
+            return (null, null);
+        return (director.ControlEndpoint.TrimEnd('/'), director.MachineName);
+    }
+}

--- a/src/CcDirector.Gateway/Running/ICronWorkListDrainLauncher.cs
+++ b/src/CcDirector.Gateway/Running/ICronWorkListDrainLauncher.cs
@@ -1,0 +1,58 @@
+using CcDirector.Gateway.Discovery;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// Runs the actual work-list drain once the cron trigger has decided to go (epic #479, #484).
+/// Behind an interface so <see cref="DirectorCronWorkListRunner"/>'s decision logic is unit-testable
+/// without a live Director; production is <see cref="DirectorWorkListDrainLauncher"/>, which reuses
+/// the same <see cref="DirectorImplSessionDriver"/> + <see cref="WorkListRunner"/> path the
+/// <c>/lists/{name}/run</c> endpoint uses (#274). The call completes when the whole list is drained.
+/// </summary>
+public interface ICronWorkListDrainLauncher
+{
+    /// <summary>Claim and drain <paramref name="listName"/> on the Director at
+    /// <paramref name="endpoint"/> as <paramref name="consumer"/>, opening sessions in
+    /// <paramref name="repoPath"/>.</summary>
+    Task LaunchAsync(string endpoint, string repoPath, string listName, string consumer, CancellationToken ct);
+}
+
+/// <summary>Production launcher: the shipped #274 drain path (DirectorImplSessionDriver + WorkListRunner).</summary>
+public sealed class DirectorWorkListDrainLauncher : ICronWorkListDrainLauncher
+{
+    private readonly WorkListStore _store;
+    private readonly Func<string, string, IImplSessionDriver> _driverFactory;
+
+    /// <param name="driverFactory">
+    /// Builds the per-drain session driver from (endpoint, repoPath). Defaults to the production
+    /// <see cref="DirectorImplSessionDriver"/> over the shared client; tests inject a fake so the
+    /// claim + ordered drain through this launcher is verifiable without a live Director.
+    /// </param>
+    public DirectorWorkListDrainLauncher(
+        WorkListStore store,
+        DirectorEndpointClient? client,
+        Func<string, string, IImplSessionDriver>? driverFactory = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        if (driverFactory is not null)
+        {
+            _driverFactory = driverFactory;
+        }
+        else if (client is not null)
+        {
+            // Flow analysis: client is non-null in this branch, so the captured driver build is safe.
+            _driverFactory = (endpoint, repoPath) => new DirectorImplSessionDriver(client, endpoint, repoPath);
+        }
+        else
+        {
+            throw new ArgumentException("a client or a driver factory is required", nameof(client));
+        }
+    }
+
+    public async Task LaunchAsync(string endpoint, string repoPath, string listName, string consumer, CancellationToken ct)
+    {
+        var driver = _driverFactory(endpoint, repoPath);
+        var runner = new WorkListRunner(_store, driver);
+        await runner.DrainAsync(listName, consumer, ct);
+    }
+}

--- a/src/CcDirector.Gateway/Running/ICronWorkListRunner.cs
+++ b/src/CcDirector.Gateway/Running/ICronWorkListRunner.cs
@@ -1,0 +1,41 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>The outcome of triggering a work-list drain for a fired cron job (epic #479, #484).</summary>
+public enum CronWorkListOutcome
+{
+    /// <summary>The list was claimable and a background drain was launched on the target Director.</summary>
+    Started,
+
+    /// <summary>The named list has no items - nothing to drain (skipped cleanly).</summary>
+    EmptyList,
+
+    /// <summary>No list with the job's <see cref="CronJobAction.WorkListName"/> exists.</summary>
+    NoSuchList,
+
+    /// <summary>The list already has an active draining consumer (#273) - not re-claimed.</summary>
+    AlreadyClaimed,
+
+    /// <summary>The job's target Director is not registered / has no control endpoint.</summary>
+    NoSuchDirector,
+
+    /// <summary>The target machine is already draining another list (#274 single-machine guard).</summary>
+    MachineBusy,
+}
+
+/// <summary>
+/// The seam the cron firing engine (epic #479, #484) uses to drain a named work list when a job's
+/// action is a work-list action. The production implementation triggers the existing #274 runner;
+/// tests inject a fake. It does the cheap pre-checks synchronously (so the engine gets an immediate
+/// outcome to record) and launches the actual drain in the background.
+/// </summary>
+public interface ICronWorkListRunner
+{
+    /// <summary>
+    /// Trigger a drain of <see cref="CronJobAction.WorkListName"/> on the job's target Director.
+    /// Returns the synchronous outcome; on <see cref="CronWorkListOutcome.Started"/> the drain runs
+    /// in the background.
+    /// </summary>
+    Task<CronWorkListOutcome> TriggerAsync(CronJobDto job, CancellationToken ct);
+}


### PR DESCRIPTION
Implements **#484** - part 3 of 3 of epic #479, the headline use case: a cron job can drain a named work list on a schedule ("midnight, run the implementation loop over a list of work items").

## Release Notes
A cron job whose action sets `workListName` now triggers the existing named-work-list runner (#274) to drain that list on the target Director when it fires - instead of starting a single seeded session. With #482 (store/CRUD) and #483 (firing engine), the full feature from the original request is functional.

## Changes
- **`CronJobAction.WorkListName`** - marks a work-list action (the seed is optional then).
- **`CronEngine`** dispatches by action type: work-list -> `ICronWorkListRunner`, seed -> `ICronSessionStarter`. Records a `worklist-*` run; schedule-advance + guards (overlap/one-off/catch-up) unchanged.
- **`DirectorCronWorkListRunner`** - synchronous pre-checks (no-list / empty / already-claimed / no-director / machine-busy -> clean outcome, **no duplicate claim**), then launches the real `WorkListRunner.DrainAsync` in the **background** (a sweep must not block for a drain), releasing the machine slot when done. Seams `ICronDirectorResolver` + `ICronWorkListDrainLauncher` keep it unit-testable.
- **`CronSchedule.Validate`** - action requires a seed OR a workListName.

## How to Test
`dotnet build cc-director.sln` (clean), then `dotnet test src/CcDirector.Gateway.Tests --filter Cron`.

## Expected Result
**61 cron tests pass** (13 new for #484 + 48 from #482/#483). Build 0/0.

## Acceptance criteria
- AC1 fire triggers the runner to CLAIM + start processing: `DrainLauncher_ClaimsList_AndDrainsItemsInOrder` (claim taken, items started) + `WorkListJob_Dispatches_ToWorkListRunner...` (engine routes a work-list job to the runner).
- AC2 items processed in list order: `DrainLauncher_ClaimsList_AndDrainsItemsInOrder` (101,102,103 in order via the shipped #274 runner).
- AC3 empty / already-claimed / no-director / machine-busy handled cleanly, no crash, no duplicate claim: the `Trigger_*` pre-check tests.
- Proof report under `docs/cencon/proof/issue-484/`.

Refs #484, #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)