### PR TITLE
feat(settings): Advanced tab with grouped cards and one-click firewall-prompt fix

### DIFF
--- a/src/CcDirector.Avalonia/SettingsDialog.axaml
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml
@@ -45,6 +45,14 @@
             <Setter Property="FontFamily" Value="Cascadia Mono, Consolas, Courier New" />
             <Setter Property="FontSize" Value="12" />
         </Style>
+        <!-- Rounded "card" container that groups related settings on the Advanced tab. -->
+        <Style Selector="Border.card">
+            <Setter Property="Background" Value="#1E1E1E" />
+            <Setter Property="BorderBrush" Value="#3C3C3C" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="Padding" Value="16" />
+        </Style>
         <Style Selector="Button.dialogButton">
             <Setter Property="Height" Value="30" />
             <Setter Property="MinWidth" Value="76" />
@@ -265,28 +273,53 @@
                 </ScrollViewer>
             </TabItem>
 
-            <TabItem Header="Features">
+            <TabItem Header="Advanced">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,14,0">
-                    <StackPanel Spacing="8" Margin="0,4,0,0">
-                        <TextBlock Classes="sectionTitle" Text="Alpha Features" />
-                        <TextBlock Classes="hint" Text="Unfinished features we are still testing. They may break, change, or disappear without notice, and no support is provided while they are in alpha." />
-                        <CheckBox x:Name="AlphaFeaturesCheck"
-                                  Content="Enable alpha features"
-                                  IsChecked="False"
-                                  Foreground="#CCCCCC" FontSize="13"
-                                  Margin="0,4,0,0"
-                                  IsCheckedChanged="AlphaCheck_Changed"
-                                  ToolTip.Tip="Default: off. Shows untested features - no guarantees they work." />
-                        <TextBlock Classes="hint" Margin="24,0,0,0"
-                                   Text="When enabled you get: unverified coding agents, session handover, FIFO voice mode, GitHub remote sessions, Assistant/Coach quick-launch, and the wake-word test below. Claude Code and Pi have verified drivers and are always available." />
+                    <StackPanel Spacing="12" Margin="0,4,0,0">
 
-                        <StackPanel x:Name="AlphaVoicePanel" Spacing="6" Margin="24,8,0,0" IsVisible="False">
-                            <TextBlock Text="Voice wake-word test" Foreground="#CCCCCC" FontSize="12" FontWeight="SemiBold" />
-                            <TextBlock Classes="hint" Text="Sandbox for tuning the hands-free wake-word grammar: say &quot;wingman&quot; to start, dictate, then &quot;wingman send&quot; or &quot;wingman cancel&quot;. Emits to an on-screen box only, never to a live session." />
-                            <Button x:Name="WakeWordTestButton" Classes="dialogButton"
-                                    Content="Open Wake-Word Test" Width="170" HorizontalAlignment="Left"
-                                    Click="BtnWakeWordTest_Click" />
-                        </StackPanel>
+                        <!-- Network and Firewall card. Lets the user turn off the Windows
+                             notification that pops up the first time each new build opens its
+                             local network port. -->
+                        <Border Classes="card">
+                            <StackPanel Spacing="8">
+                                <TextBlock Classes="sectionTitle" Margin="0" Text="Network and Firewall" />
+                                <TextBlock Classes="hint" Text="The first time you run a new build, Windows pops up a dialog asking whether to allow CC Director on public and private networks. It appears because CC Director opens a network port so its tools can reach it. CC Director only needs that port on this same computer, so the block does no harm - but the dialog interrupts testing every time the build changes." />
+                                <TextBlock Classes="hint" Text="The button below turns off that Windows notification. Windows will ask you for administrator approval once; after you approve it, the dialog stops appearing for good." />
+                                <Button x:Name="SuppressFirewallButton" Classes="dialogButton"
+                                        Content="Stop the Windows firewall pop-up"
+                                        HorizontalAlignment="Left" Margin="0,4,0,0"
+                                        ToolTip.Tip="Turns off the Windows notification that asks to allow a new app on the network. Windows will ask you for administrator approval."
+                                        Click="BtnSuppressFirewallPrompt_Click" />
+                                <TextBlock x:Name="FirewallStatus" Text="" Foreground="#888888"
+                                           FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0" IsVisible="False" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Alpha Features card. -->
+                        <Border Classes="card">
+                            <StackPanel Spacing="8">
+                                <TextBlock Classes="sectionTitle" Margin="0" Text="Alpha Features" />
+                                <TextBlock Classes="hint" Text="Unfinished features we are still testing. They may break, change, or disappear without notice, and no support is provided while they are in alpha." />
+                                <CheckBox x:Name="AlphaFeaturesCheck"
+                                          Content="Enable alpha features"
+                                          IsChecked="False"
+                                          Foreground="#CCCCCC" FontSize="13"
+                                          Margin="0,4,0,0"
+                                          IsCheckedChanged="AlphaCheck_Changed"
+                                          ToolTip.Tip="Default: off. Shows untested features - no guarantees they work." />
+                                <TextBlock Classes="hint" Margin="24,0,0,0"
+                                           Text="When enabled you get: unverified coding agents, session handover, FIFO voice mode, GitHub remote sessions, Assistant/Coach quick-launch, and the wake-word test below. Claude Code and Pi have verified drivers and are always available." />
+
+                                <StackPanel x:Name="AlphaVoicePanel" Spacing="6" Margin="24,8,0,0" IsVisible="False">
+                                    <TextBlock Text="Voice wake-word test" Foreground="#CCCCCC" FontSize="12" FontWeight="SemiBold" />
+                                    <TextBlock Classes="hint" Text="Sandbox for tuning the hands-free wake-word grammar: say &quot;wingman&quot; to start, dictate, then &quot;wingman send&quot; or &quot;wingman cancel&quot;. Emits to an on-screen box only, never to a live session." />
+                                    <Button x:Name="WakeWordTestButton" Classes="dialogButton"
+                                            Content="Open Wake-Word Test" Width="170" HorizontalAlignment="Left"
+                                            Click="BtnWakeWordTest_Click" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -686,6 +687,84 @@ public partial class SettingsDialog : Window
 
         System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(path)
             { UseShellExecute = true });
+    }
+
+    /// <summary>
+    /// Turn off the Windows notification that pops up the first time each new build opens its
+    /// local network port ("Do you want to allow ... on public and private networks?"). Changing a
+    /// firewall profile needs administrator rights, which CC Director does not have, so we launch a
+    /// short elevated PowerShell command. Windows shows one User Account Control approval prompt; if
+    /// the user declines it, the launch throws error 1223 and we say so plainly. The work runs off
+    /// the UI thread so the window stays responsive while the approval prompt is up.
+    /// </summary>
+    private async void BtnSuppressFirewallPrompt_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[SettingsDialog] BtnSuppressFirewallPrompt_Click");
+        SuppressFirewallButton.IsEnabled = false;
+        ShowFirewallStatus("Asking Windows for administrator approval...", error: false);
+        try
+        {
+            var (ok, message) = await Task.Run(RunFirewallPromptSuppression);
+            ShowFirewallStatus(message, error: !ok);
+            FileLog.Write($"[SettingsDialog] BtnSuppressFirewallPrompt_Click: ok={ok}");
+        }
+        catch (Win32Exception wex) when (wex.NativeErrorCode == 1223)
+        {
+            // 1223 = the user clicked No on the User Account Control approval prompt.
+            FileLog.Write("[SettingsDialog] BtnSuppressFirewallPrompt_Click: administrator approval declined");
+            ShowFirewallStatus("No change was made - administrator approval was declined.", error: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SettingsDialog] BtnSuppressFirewallPrompt_Click FAILED: {ex.Message}");
+            ShowFirewallStatus($"Could not change the setting: {ex.Message}", error: true);
+        }
+        finally
+        {
+            SuppressFirewallButton.IsEnabled = true;
+        }
+    }
+
+    /// <summary>
+    /// Run, with administrator rights, the PowerShell command that disables the "notify me when a new
+    /// app is blocked" firewall notification on all three profiles. Returns whether it applied and a
+    /// message to show the user. The elevated script reports success or failure through its exit code
+    /// (0 = applied, 1 = the firewall cmdlet itself failed, e.g. blocked by organization policy).
+    /// </summary>
+    private static (bool Ok, string Message) RunFirewallPromptSuppression()
+    {
+        FileLog.Write("[SettingsDialog] RunFirewallPromptSuppression: launching elevated PowerShell");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -Command " +
+                        "\"try { Set-NetFirewallProfile -Profile Domain,Public,Private -NotifyOnListen False -ErrorAction Stop; exit 0 } catch { exit 1 }\"",
+            Verb = "runas",            // Raises the Windows administrator approval prompt.
+            UseShellExecute = true,    // Required for Verb to take effect.
+            WindowStyle = ProcessWindowStyle.Hidden,
+        };
+
+        var process = Process.Start(startInfo);
+        if (process is null)
+            throw new InvalidOperationException("Windows did not start the elevated PowerShell process.");
+
+        process.WaitForExit();
+        FileLog.Write($"[SettingsDialog] RunFirewallPromptSuppression: exit code={process.ExitCode}");
+
+        if (process.ExitCode == 0)
+            return (true, "Done. Windows will no longer pop up the firewall question when a new build runs for the first time.");
+
+        return (false, "The setting could not be applied. The firewall may be controlled by your organization's policy.");
+    }
+
+    private void ShowFirewallStatus(string text, bool error)
+    {
+        FirewallStatus.Text = text;
+        FirewallStatus.IsVisible = true;
+        FirewallStatus.Foreground = error
+            ? global::Avalonia.Media.Brushes.IndianRed
+            : global::Avalonia.Media.Brushes.MediumSeaGreen;
     }
 
     /// <summary>The alpha-gated wake-word section follows the checkbox live (before Save).</summary>


### PR DESCRIPTION
## What

Renames the Settings **Features** tab to **Advanced** and reorganizes it into two rounded "card" group boxes:

1. **Network and Firewall** (new, shown first) — explains why Windows pops up the "allow this app on public and private networks?" dialog the first time each new build runs, and adds a **Stop the Windows firewall pop-up** button that turns off that notification.
2. **Alpha Features** (moved to second card) — the existing "Enable alpha features" checkbox and wake-word test panel, unchanged in behavior.

## Why

The Windows Defender Firewall notification fires every time a new build opens its local Control API port. CC Director only needs that port on the same machine, so the block is harmless, but the dialog interrupts testing on every rebuild. This gives the user a one-click way to suppress it.

## How the firewall fix works

The button launches a short elevated PowerShell command via the `runas` verb:

```
Set-NetFirewallProfile -Profile Domain,Public,Private -NotifyOnListen False
```

- Windows shows **one** administrator approval prompt (unavoidable — changing a firewall profile requires elevation by design).
- Declining the prompt throws error 1223, which is caught and reported plainly ("administrator approval was declined").
- The elevated script reports success/failure through its exit code, so the "managed by organization policy" case is surfaced as a failure rather than a false success.
- The work runs off the UI thread so the window stays responsive while the approval prompt is up.

## Testing

- `dotnet build` — succeeds, 0 warnings.
- Built to slot 5 and ran the Director; Settings → Advanced shows both cards in the correct order.

## Files

- `src/CcDirector.Avalonia/SettingsDialog.axaml` — tab rename, `Border.card` style, two cards.
- `src/CcDirector.Avalonia/SettingsDialog.axaml.cs` — `BtnSuppressFirewallPrompt_Click` handler, `RunFirewallPromptSuppression` worker, `ShowFirewallStatus` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
