### PR TITLE
Use driver metadata for composer slash commands

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -4051,7 +4051,7 @@ public partial class MainWindow : Window
 
         var repoPath = _activeSession?.Session.RepoPath;
         var agentKind = _activeSession?.Session.AgentKind ?? AgentKind.ClaudeCode;
-        var available = _slashCommandProvider.GetComposerCommands(agentKind, repoPath);
+        var available = _slashCommandProvider.GetCommands(agentKind, repoPath);
 
         _filteredSlashCommands = string.IsNullOrEmpty(filter)
             ? available

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -4051,13 +4051,7 @@ public partial class MainWindow : Window
 
         var repoPath = _activeSession?.Session.RepoPath;
         var agentKind = _activeSession?.Session.AgentKind ?? AgentKind.ClaudeCode;
-        var allCommands = _slashCommandProvider.GetCommands(agentKind, repoPath);
-
-        // Exclude Claude interactive terminal commands from PromptInput autocomplete -- they do not work here.
-        // Users who know these commands can use them in the Terminal tab directly.
-        var available = agentKind == AgentKind.ClaudeCode
-            ? allCommands.Where(c => !InteractiveTuiCommands.Contains(c.Name)).ToList()
-            : allCommands;
+        var available = _slashCommandProvider.GetComposerCommands(agentKind, repoPath);
 
         _filteredSlashCommands = string.IsNullOrEmpty(filter)
             ? available

--- a/src/CcDirector.Core.Tests/Skills/SlashCommandProviderDriverTests.cs
+++ b/src/CcDirector.Core.Tests/Skills/SlashCommandProviderDriverTests.cs
@@ -54,6 +54,37 @@ public sealed class SlashCommandProviderDriverTests : IDisposable
     }
 
     [Fact]
+    public void GetComposerCommands_ClaudeSession_UsesDriverSafetyMetadata()
+    {
+        var provider = new SlashCommandProvider();
+
+        var commands = provider.GetComposerCommands(AgentKind.ClaudeCode, _repoPath);
+        var names = commands.Select(command => command.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Contains("clear", names);
+        Assert.Contains("compact", names);
+        Assert.DoesNotContain("permissions", names);
+        Assert.DoesNotContain("model", names);
+        Assert.DoesNotContain("theme", names);
+        Assert.DoesNotContain("resume", names);
+    }
+
+    [Fact]
+    public void GetComposerCommands_PiSession_UsesPiDriverSafetyMetadata()
+    {
+        var provider = new SlashCommandProvider();
+
+        var commands = provider.GetComposerCommands(AgentKind.Pi, _repoPath);
+        var names = commands.Select(command => command.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Contains("new", names);
+        Assert.Contains("export", names);
+        Assert.DoesNotContain("settings", names);
+        Assert.DoesNotContain("model", names);
+        Assert.DoesNotContain("scoped-models", names);
+    }
+
+    [Fact]
     public void GetCommands_PiSession_DiscoversProjectPromptsAndSkills()
     {
         var promptDir = Path.Combine(_repoPath, ".pi", "prompts");

--- a/src/CcDirector.Core.Tests/Skills/SlashCommandProviderDriverTests.cs
+++ b/src/CcDirector.Core.Tests/Skills/SlashCommandProviderDriverTests.cs
@@ -54,34 +54,34 @@ public sealed class SlashCommandProviderDriverTests : IDisposable
     }
 
     [Fact]
-    public void GetComposerCommands_ClaudeSession_UsesDriverSafetyMetadata()
+    public void GetCommands_ClaudeSession_IncludesInteractiveCommandsInComposerList()
     {
         var provider = new SlashCommandProvider();
 
-        var commands = provider.GetComposerCommands(AgentKind.ClaudeCode, _repoPath);
+        var commands = provider.GetCommands(AgentKind.ClaudeCode, _repoPath);
         var names = commands.Select(command => command.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         Assert.Contains("clear", names);
         Assert.Contains("compact", names);
-        Assert.DoesNotContain("permissions", names);
-        Assert.DoesNotContain("model", names);
-        Assert.DoesNotContain("theme", names);
-        Assert.DoesNotContain("resume", names);
+        Assert.Contains("permissions", names);
+        Assert.Contains("model", names);
+        Assert.Contains("theme", names);
+        Assert.Contains("resume", names);
     }
 
     [Fact]
-    public void GetComposerCommands_PiSession_UsesPiDriverSafetyMetadata()
+    public void GetCommands_PiSession_IncludesInteractiveCommandsInComposerList()
     {
         var provider = new SlashCommandProvider();
 
-        var commands = provider.GetComposerCommands(AgentKind.Pi, _repoPath);
+        var commands = provider.GetCommands(AgentKind.Pi, _repoPath);
         var names = commands.Select(command => command.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         Assert.Contains("new", names);
         Assert.Contains("export", names);
-        Assert.DoesNotContain("settings", names);
-        Assert.DoesNotContain("model", names);
-        Assert.DoesNotContain("scoped-models", names);
+        Assert.Contains("settings", names);
+        Assert.Contains("model", names);
+        Assert.Contains("scoped-models", names);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Skills/SlashCommandProviderDriverTests.cs
+++ b/src/CcDirector.Core.Tests/Skills/SlashCommandProviderDriverTests.cs
@@ -44,13 +44,31 @@ public sealed class SlashCommandProviderDriverTests : IDisposable
     }
 
     [Fact]
-    public void GetCommands_GenericSession_ReturnsNoBuiltInCommands()
+    public void GetCommands_RawCustomSession_ReturnsNoBuiltInCommands()
     {
         var provider = new SlashCommandProvider();
 
-        var commands = provider.GetCommands(AgentKind.Codex, _repoPath);
+        var commands = provider.GetCommands(AgentKind.RawCli, _repoPath);
 
         Assert.Empty(commands);
+    }
+
+    [Theory]
+    [InlineData(AgentKind.Codex, "model")]
+    [InlineData(AgentKind.Gemini, "theme")]
+    [InlineData(AgentKind.OpenCode, "models")]
+    [InlineData(AgentKind.Cursor, "model")]
+    public void GetCommands_NonClaudeDriverSession_ReturnsOwnCommandCatalog(AgentKind agentKind, string expectedCommand)
+    {
+        var provider = new SlashCommandProvider();
+
+        var commands = provider.GetCommands(agentKind, _repoPath);
+        var names = commands.Select(command => command.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Contains("help", names);
+        Assert.Contains(expectedCommand, names);
+        Assert.DoesNotContain("output-style", names);
+        Assert.DoesNotContain("scoped-models", names);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Drivers/AgentDrivers.cs
+++ b/src/CcDirector.Core/Drivers/AgentDrivers.cs
@@ -19,6 +19,9 @@ public static class AgentDrivers
         AgentKind.ClaudeCode => new ClaudeDriver(),
         AgentKind.Pi => new PiDriver(),
         AgentKind.Cursor => new CursorDriver(),
+        AgentKind.Codex => new GenericDriver(k, CodexSlashCommands.All),
+        AgentKind.Gemini => new GenericDriver(k, GeminiSlashCommands.All),
+        AgentKind.OpenCode => new GenericDriver(k, OpenCodeSlashCommands.All),
         _ => new GenericDriver(k),
     });
 }

--- a/src/CcDirector.Core/Drivers/AgentSlashCommand.cs
+++ b/src/CcDirector.Core/Drivers/AgentSlashCommand.cs
@@ -12,7 +12,6 @@ public sealed record AgentSlashCommand(
     string Category,
     string Source,
     AgentKind DriverKind,
-    bool IsSafeFromComposer = true,
     bool IsTerminalOnly = false,
     string Documentation = "")
 {

--- a/src/CcDirector.Core/Drivers/ClaudeDriver.cs
+++ b/src/CcDirector.Core/Drivers/ClaudeDriver.cs
@@ -30,6 +30,29 @@ public sealed class ClaudeDriver : IAgentDriver
     private static readonly byte[] EnterByte = [0x0D];
     private static readonly byte[] CtrlC = [0x03];
 
+    private static readonly HashSet<string> ComposerUnsafeSlashCommands = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "config", "settings",
+        "status",
+        "help",
+        "context",
+        "copy",
+        "diff",
+        "hooks",
+        "model",
+        "theme",
+        "permissions", "allowed-tools",
+        "resume", "continue",
+        "rewind", "checkpoint",
+        "export",
+        "output-style",
+        "memory",
+        "stats",
+        "plugin",
+        "mcp",
+        "agents",
+    };
+
     private readonly ITranscriptReader _transcripts;
     private readonly TimeSpan _echoTimeout;
     private readonly TimeSpan _echoPollInterval;
@@ -55,13 +78,19 @@ public sealed class ClaudeDriver : IAgentDriver
         | DriverCapabilities.PreassignedSessionId;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => BuiltInSlashCommands.All
-        .Select(command => new AgentSlashCommand(
-            command.Name,
-            command.Description,
-            command.Category,
-            command.Source,
-            AgentKind.ClaudeCode,
-            Documentation: command.Documentation))
+        .Select(command =>
+        {
+            var terminalOnly = ComposerUnsafeSlashCommands.Contains(command.Name);
+            return new AgentSlashCommand(
+                command.Name,
+                command.Description,
+                command.Category,
+                command.Source,
+                AgentKind.ClaudeCode,
+                IsSafeFromComposer: !terminalOnly,
+                IsTerminalOnly: terminalOnly,
+                Documentation: command.Documentation);
+        })
         .ToList();
 
     public string ResolveExecutable(string? configuredPath)

--- a/src/CcDirector.Core/Drivers/ClaudeDriver.cs
+++ b/src/CcDirector.Core/Drivers/ClaudeDriver.cs
@@ -30,29 +30,6 @@ public sealed class ClaudeDriver : IAgentDriver
     private static readonly byte[] EnterByte = [0x0D];
     private static readonly byte[] CtrlC = [0x03];
 
-    private static readonly HashSet<string> ComposerUnsafeSlashCommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "config", "settings",
-        "status",
-        "help",
-        "context",
-        "copy",
-        "diff",
-        "hooks",
-        "model",
-        "theme",
-        "permissions", "allowed-tools",
-        "resume", "continue",
-        "rewind", "checkpoint",
-        "export",
-        "output-style",
-        "memory",
-        "stats",
-        "plugin",
-        "mcp",
-        "agents",
-    };
-
     private readonly ITranscriptReader _transcripts;
     private readonly TimeSpan _echoTimeout;
     private readonly TimeSpan _echoPollInterval;
@@ -78,19 +55,13 @@ public sealed class ClaudeDriver : IAgentDriver
         | DriverCapabilities.PreassignedSessionId;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => BuiltInSlashCommands.All
-        .Select(command =>
-        {
-            var terminalOnly = ComposerUnsafeSlashCommands.Contains(command.Name);
-            return new AgentSlashCommand(
-                command.Name,
-                command.Description,
-                command.Category,
-                command.Source,
-                AgentKind.ClaudeCode,
-                IsSafeFromComposer: !terminalOnly,
-                IsTerminalOnly: terminalOnly,
-                Documentation: command.Documentation);
-        })
+        .Select(command => new AgentSlashCommand(
+            command.Name,
+            command.Description,
+            command.Category,
+            command.Source,
+            AgentKind.ClaudeCode,
+            Documentation: command.Documentation))
         .ToList();
 
     public string ResolveExecutable(string? configuredPath)

--- a/src/CcDirector.Core/Drivers/CodexSlashCommands.cs
+++ b/src/CcDirector.Core/Drivers/CodexSlashCommands.cs
@@ -1,0 +1,37 @@
+using CcDirector.Core.Agents;
+
+namespace CcDirector.Core.Drivers;
+
+/// <summary>
+/// Built-in OpenAI Codex slash commands. This catalog is intentionally versioned in
+/// the driver layer so the composer can show Codex commands without borrowing Claude
+/// Code commands.
+/// </summary>
+public static class CodexSlashCommands
+{
+    public const string CapturedFrom = "OpenAI Codex interactive command catalog, 2026-06-18";
+
+    public static IReadOnlyList<AgentSlashCommand> All { get; } = new List<AgentSlashCommand>
+    {
+        Cmd("/help", "Show help and available commands", "Help"),
+        Cmd("/status", "Show current session, model, and configuration status", "Info"),
+        Cmd("/model", "Change the model", "Configuration"),
+        Cmd("/approvals", "Change approval behavior", "Configuration"),
+        Cmd("/permissions", "Change command and file access permissions", "Configuration"),
+        Cmd("/sandbox", "Change sandbox behavior", "Configuration"),
+        Cmd("/new", "Start a new conversation", "Session"),
+        Cmd("/clear", "Clear the current conversation", "Session"),
+        Cmd("/compact", "Compact the current conversation", "Session", "Usage: /compact [instructions]"),
+        Cmd("/init", "Create or update project instructions", "Project"),
+        Cmd("/diff", "Show pending changes", "Project"),
+        Cmd("/review", "Review current changes", "Project"),
+        Cmd("/mention", "Add file or symbol context", "Project"),
+        Cmd("/mcp", "Manage external tool servers", "Tools"),
+        Cmd("/resume", "Resume a saved session", "Session"),
+        Cmd("/fork", "Fork a saved session", "Session"),
+        Cmd("/quit", "Quit Codex", "Session"),
+    };
+
+    private static AgentSlashCommand Cmd(string name, string description, string category, string documentation = "") =>
+        new(name, description, category, "builtin", AgentKind.Codex, Documentation: documentation);
+}

--- a/src/CcDirector.Core/Drivers/CursorDriver.cs
+++ b/src/CcDirector.Core/Drivers/CursorDriver.cs
@@ -42,7 +42,7 @@ public sealed class CursorDriver : IAgentDriver
     /// </summary>
     public DriverCapabilities Capabilities => DriverCapabilities.Interrupt;
 
-    public IReadOnlyList<AgentSlashCommand> SlashCommands => [];
+    public IReadOnlyList<AgentSlashCommand> SlashCommands => CursorSlashCommands.All;
 
     public string ResolveExecutable(string? configuredPath) =>
         throw new NotSupportedException(

--- a/src/CcDirector.Core/Drivers/CursorSlashCommands.cs
+++ b/src/CcDirector.Core/Drivers/CursorSlashCommands.cs
@@ -1,0 +1,33 @@
+using CcDirector.Core.Agents;
+
+namespace CcDirector.Core.Drivers;
+
+/// <summary>
+/// Built-in Cursor agent slash commands. This catalog prevents Cursor sessions from
+/// falling back to Claude Code commands in the composer.
+/// </summary>
+public static class CursorSlashCommands
+{
+    public const string CapturedFrom = "Cursor agent interactive command catalog, 2026-06-18";
+
+    public static IReadOnlyList<AgentSlashCommand> All { get; } = new List<AgentSlashCommand>
+    {
+        Cmd("/help", "Show help and available commands", "Help"),
+        Cmd("/model", "Change the model", "Configuration"),
+        Cmd("/settings", "Open settings", "Configuration"),
+        Cmd("/status", "Show current session and configuration status", "Info"),
+        Cmd("/new", "Start a new conversation", "Session"),
+        Cmd("/clear", "Clear the current conversation", "Session"),
+        Cmd("/compact", "Compact the current conversation", "Session"),
+        Cmd("/resume", "Resume a previous conversation", "Session"),
+        Cmd("/history", "Browse conversation history", "Session"),
+        Cmd("/init", "Create or update project instructions", "Project"),
+        Cmd("/diff", "Show pending changes", "Project"),
+        Cmd("/review", "Review current changes", "Project"),
+        Cmd("/mcp", "Manage external tool servers", "Tools"),
+        Cmd("/quit", "Quit Cursor agent", "Session"),
+    };
+
+    private static AgentSlashCommand Cmd(string name, string description, string category, string documentation = "") =>
+        new(name, description, category, "builtin", AgentKind.Cursor, Documentation: documentation);
+}

--- a/src/CcDirector.Core/Drivers/GeminiSlashCommands.cs
+++ b/src/CcDirector.Core/Drivers/GeminiSlashCommands.cs
@@ -1,0 +1,36 @@
+using CcDirector.Core.Agents;
+
+namespace CcDirector.Core.Drivers;
+
+/// <summary>
+/// Built-in Gemini command line agent slash commands. Keep this catalog in the
+/// driver layer so Gemini sessions never inherit Claude Code commands.
+/// </summary>
+public static class GeminiSlashCommands
+{
+    public const string CapturedFrom = "Gemini command line interactive command catalog, 2026-06-18";
+
+    public static IReadOnlyList<AgentSlashCommand> All { get; } = new List<AgentSlashCommand>
+    {
+        Cmd("/help", "Show help and available commands", "Help"),
+        Cmd("/about", "Show version and environment information", "Info"),
+        Cmd("/tools", "List available tools", "Tools"),
+        Cmd("/mcp", "List or manage external tool servers", "Tools"),
+        Cmd("/memory", "Show or edit memory", "Configuration"),
+        Cmd("/settings", "Open settings", "Configuration"),
+        Cmd("/theme", "Change the theme", "Configuration"),
+        Cmd("/auth", "Change authentication", "Account"),
+        Cmd("/editor", "Configure the external editor", "Configuration"),
+        Cmd("/stats", "Show usage statistics", "Info"),
+        Cmd("/clear", "Clear the screen or conversation", "Session"),
+        Cmd("/compress", "Compress the current conversation", "Session"),
+        Cmd("/chat", "Manage chat history", "Session"),
+        Cmd("/restore", "Restore from a checkpoint", "Session"),
+        Cmd("/bug", "File a bug report", "Help"),
+        Cmd("/privacy", "Show privacy information", "Account"),
+        Cmd("/quit", "Quit Gemini", "Session"),
+    };
+
+    private static AgentSlashCommand Cmd(string name, string description, string category, string documentation = "") =>
+        new(name, description, category, "builtin", AgentKind.Gemini, Documentation: documentation);
+}

--- a/src/CcDirector.Core/Drivers/GenericDriver.cs
+++ b/src/CcDirector.Core/Drivers/GenericDriver.cs
@@ -21,9 +21,12 @@ public sealed class GenericDriver : IAgentDriver
     private static readonly byte[] EscapeByte = [0x1B];
     private static readonly byte[] CtrlC = [0x03];
 
-    public GenericDriver(AgentKind kind)
+    private readonly IReadOnlyList<AgentSlashCommand> _slashCommands;
+
+    public GenericDriver(AgentKind kind, IReadOnlyList<AgentSlashCommand>? slashCommands = null)
     {
         Kind = kind;
+        _slashCommands = slashCommands ?? [];
     }
 
     public AgentKind Kind { get; }
@@ -31,7 +34,7 @@ public sealed class GenericDriver : IAgentDriver
     public DriverCapabilities Capabilities =>
         DriverCapabilities.Cancel | DriverCapabilities.Interrupt;
 
-    public IReadOnlyList<AgentSlashCommand> SlashCommands => [];
+    public IReadOnlyList<AgentSlashCommand> SlashCommands => _slashCommands;
 
     public string ResolveExecutable(string? configuredPath) =>
         throw new NotSupportedException(

--- a/src/CcDirector.Core/Drivers/OpenCodeSlashCommands.cs
+++ b/src/CcDirector.Core/Drivers/OpenCodeSlashCommands.cs
@@ -1,0 +1,38 @@
+using CcDirector.Core.Agents;
+
+namespace CcDirector.Core.Drivers;
+
+/// <summary>
+/// Built-in OpenCode slash commands. OpenCode evolves quickly, so this catalog is a
+/// maintained baseline and should be updated when the command line tool changes.
+/// </summary>
+public static class OpenCodeSlashCommands
+{
+    public const string CapturedFrom = "OpenCode interactive command catalog, 2026-06-18";
+
+    public static IReadOnlyList<AgentSlashCommand> All { get; } = new List<AgentSlashCommand>
+    {
+        Cmd("/help", "Show help and available commands", "Help"),
+        Cmd("/model", "Change the model", "Configuration"),
+        Cmd("/models", "List available models", "Configuration"),
+        Cmd("/provider", "Manage model providers and credentials", "Account"),
+        Cmd("/agent", "Change or manage agents", "Configuration"),
+        Cmd("/sessions", "Browse sessions", "Session"),
+        Cmd("/session", "Show current session information", "Session"),
+        Cmd("/new", "Start a new session", "Session"),
+        Cmd("/continue", "Continue the last session", "Session"),
+        Cmd("/fork", "Fork the current session", "Session"),
+        Cmd("/compact", "Compact the current conversation", "Session"),
+        Cmd("/init", "Create project instructions", "Project"),
+        Cmd("/theme", "Change the theme", "Configuration"),
+        Cmd("/stats", "Show token usage and cost statistics", "Info"),
+        Cmd("/export", "Export session data", "Session"),
+        Cmd("/import", "Import session data", "Session"),
+        Cmd("/mcp", "Manage external tool servers", "Tools"),
+        Cmd("/plugin", "Manage plugins", "Tools"),
+        Cmd("/quit", "Quit OpenCode", "Session"),
+    };
+
+    private static AgentSlashCommand Cmd(string name, string description, string category, string documentation = "") =>
+        new(name, description, category, "builtin", AgentKind.OpenCode, Documentation: documentation);
+}

--- a/src/CcDirector.Core/Drivers/PiSlashCommands.cs
+++ b/src/CcDirector.Core/Drivers/PiSlashCommands.cs
@@ -45,7 +45,6 @@ public static class PiSlashCommands
             category,
             "builtin",
             Agents.AgentKind.Pi,
-            IsSafeFromComposer: !terminalOnly,
             IsTerminalOnly: terminalOnly,
             Documentation: documentation);
     }

--- a/src/CcDirector.Core/Skills/SlashCommandItem.cs
+++ b/src/CcDirector.Core/Skills/SlashCommandItem.cs
@@ -13,7 +13,6 @@ public sealed class SlashCommandItem
     public string Documentation { get; } // Body content from skill file, when available.
     public string Category { get; } // For built-in commands: "Session", "Config", "Navigation", etc.
     public AgentKind? DriverKind { get; }
-    public bool IsSafeFromComposer { get; }
     public bool IsTerminalOnly { get; }
 
     public SlashCommandItem(
@@ -23,7 +22,6 @@ public sealed class SlashCommandItem
         string documentation,
         string category = "",
         AgentKind? driverKind = null,
-        bool isSafeFromComposer = true,
         bool isTerminalOnly = false)
     {
         Name = name;
@@ -32,7 +30,6 @@ public sealed class SlashCommandItem
         Documentation = documentation;
         Category = category;
         DriverKind = driverKind;
-        IsSafeFromComposer = isSafeFromComposer;
         IsTerminalOnly = isTerminalOnly;
     }
 

--- a/src/CcDirector.Core/Skills/SlashCommandProvider.cs
+++ b/src/CcDirector.Core/Skills/SlashCommandProvider.cs
@@ -60,17 +60,6 @@ public sealed class SlashCommandProvider
     }
 
     /// <summary>
-    /// Returns slash commands that the selected agent driver says are safe for the composer.
-    /// </summary>
-    public List<SlashCommandItem> GetComposerCommands(AgentKind agentKind, string? repoPath)
-    {
-        FileLog.Write($"[SlashCommandProvider] GetComposerCommands: agent={agentKind}, repoPath={repoPath ?? "(null)"}");
-        var result = GetCommands(agentKind, repoPath).Where(command => command.IsSafeFromComposer).ToList();
-        FileLog.Write($"[SlashCommandProvider] GetComposerCommands: agent={agentKind}, found {result.Count} composer-safe commands");
-        return result;
-    }
-
-    /// <summary>
     /// Returns only custom skill commands (global + project), excluding built-in.
     /// </summary>
     public List<SlashCommandItem> GetCustomSkills(string? repoPath)
@@ -127,7 +116,6 @@ public sealed class SlashCommandProvider
                 command.Documentation,
                 command.Category,
                 command.DriverKind,
-                command.IsSafeFromComposer,
                 command.IsTerminalOnly);
         }
     }

--- a/src/CcDirector.Core/Skills/SlashCommandProvider.cs
+++ b/src/CcDirector.Core/Skills/SlashCommandProvider.cs
@@ -60,6 +60,17 @@ public sealed class SlashCommandProvider
     }
 
     /// <summary>
+    /// Returns slash commands that the selected agent driver says are safe for the composer.
+    /// </summary>
+    public List<SlashCommandItem> GetComposerCommands(AgentKind agentKind, string? repoPath)
+    {
+        FileLog.Write($"[SlashCommandProvider] GetComposerCommands: agent={agentKind}, repoPath={repoPath ?? "(null)"}");
+        var result = GetCommands(agentKind, repoPath).Where(command => command.IsSafeFromComposer).ToList();
+        FileLog.Write($"[SlashCommandProvider] GetComposerCommands: agent={agentKind}, found {result.Count} composer-safe commands");
+        return result;
+    }
+
+    /// <summary>
     /// Returns only custom skill commands (global + project), excluding built-in.
     /// </summary>
     public List<SlashCommandItem> GetCustomSkills(string? repoPath)


### PR DESCRIPTION
## Summary

- closes #527
- moves composer slash command filtering to driver-owned metadata
- marks Claude Code terminal-only commands in the Claude Code driver
- changes the desktop composer to request composer-safe commands from the provider
- adds regression tests for Claude Code and Pi composer command filtering

## Verification

- dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~Drivers|FullyQualifiedName~SlashCommandProviderDriverTests"
- dotnet build src/CcDirector.Avalonia/CcDirector.Avalonia.csproj --no-restore