### PR TITLE
feat(voice): in-voice-mode ear icon on sessions (#554)

### DIFF
--- a/docs/cencon/proof/issue-554/report.md
+++ b/docs/cencon/proof/issue-554/report.md
@@ -1,0 +1,112 @@
+# Issue 554 - In-voice-mode ear icon on sessions (proof)
+
+## Summary
+
+A session being driven by voice (the phone is on the Voice / in-car tab) now shows a small
+vector ear indicator on all three session surfaces, so an operator can glance and see "this one
+is in voice mode" consistently. The indicator appears only while voice mode is on and clears the
+moment the session leaves voice mode.
+
+The underlying flag already existed: Session.VoiceMode (true when ViewMode == Voice) flows to
+SessionDto.VoiceMode. This change only adds the consistent ear visual and a live change
+notification for the desktop rail.
+
+## What changed
+
+### Shared model (live update support)
+
+- src/CcDirector.Core/Sessions/Session.cs
+  - ViewMode changed from a plain auto-property to a property with a backing field that raises a
+    new OnViewModeChanged(old, new) event when it changes. This lets the desktop rail's
+    view-model update the ear indicator live as a phone enters and leaves the Voice tab, instead of
+    waiting for a list rebuild. VoiceMode / MobileMode remain pure derivations of ViewMode.
+
+### Surface 1 - Desktop Avalonia rail
+
+- src/CcDirector.Avalonia/SessionViewModel.cs
+  - Added IsVoiceMode - a pure passthrough of Session.VoiceMode.
+  - Subscribes to Session.OnViewModeChanged and raises PropertyChanged(nameof(IsVoiceMode))
+    on the UI thread so the ear shows/clears live.
+- src/CcDirector.Avalonia/MainWindow.axaml
+  - On the badge line (LINE 2) of the session-item template, added a 14x14 Viewbox containing two
+    vector Path strokes (outer ear fold + inner canal). IsVisible="{Binding IsVoiceMode}".
+    Stroke uses {DynamicResource TextForeground} (no hard-coded color), matching the existing
+    badge sizing/placement.
+
+### Surface 2 - Cockpit session rail
+
+- src/CcDirector.Cockpit/Components/SessionRail.razor
+  - Replaced the tag-voice "voice" text with an inline SVG ear (same two-path geometry) inside the
+    same tag-voice pill, shown when s.VoiceMode. Kept the tag-voice styling hook.
+- src/CcDirector.Cockpit/wwwroot/app.css
+  - tag-voice is now an inline-flex pill sized to the ear; added .tag-voice .ear-icon
+    (12x12). The ear inherits the pill's existing color via currentColor.
+
+### Surface 3 - /m mobile list
+
+- src/CcDirector.Cockpit/wwwroot/m/m.js
+  - In the list-row render, an inline SVG ear (same geometry) is prepended to the session name when
+    s.voiceMode is true (the DTO field is voiceMode in the JSON). The name text moved into a
+    .scard-name-text span so it still ellipsizes around the ear.
+- src/CcDirector.Cockpit/wwwroot/m/m.css
+  - .scard-name is now a flex row; .scard-name-text keeps the nowrap/ellipsis; added
+    .scard-name .ear-icon (16x16, color:var(--accent)).
+- Cache-bust bumped v21 -> v22 in m/index.html (css + js) and m/sw.js (CACHE name + SHELL list),
+  following the existing pattern, so phones pick up the new m.js/m.css.
+
+## Icon approach (NO emoji / NO unicode)
+
+The ear is a VECTOR drawing on every surface - never a unicode/emoji ear character:
+
+- Desktop: Avalonia Path geometry inside a Viewbox (two stroked paths).
+- Cockpit + /m: inline svg with two path elements (currentColor stroke).
+
+All source remains ASCII. The same two-path geometry (outer ear fold curve + inner canal curve) is
+used on all three surfaces for a consistent shape.
+
+## How the VoiceMode bool was sourced per surface
+
+- Desktop: new SessionViewModel.IsVoiceMode passthrough of Session.VoiceMode, kept live via the
+  new Session.OnViewModeChanged event.
+- Cockpit: existing SessionDto.VoiceMode (s.VoiceMode) - already rendered the old text tag.
+- /m: existing voiceMode field on the session DTO JSON (s.voiceMode).
+
+## Build
+
+dotnet build cc-director.sln - Build succeeded, 0 Warnings, 0 Errors.
+(Built with -p:WarningsNotAsErrors=NU1903 locally to bypass the SQLite NuGet-audit advisory; no
+csproj change committed.)
+
+## Tests
+
+New tests added:
+
+- src/CcDirector.Core.Tests/SessionViewModeTests.cs - pins the OnViewModeChanged event
+  (raises old/new, no raise on unchanged) and the VoiceMode derivation. 3 tests, all pass.
+
+Affected suites run (all green except one pre-existing, unrelated environmental failure):
+
+- Core.Tests: 2110 passed, 0 failed, 4 skipped.
+- Avalonia.Tests: 66 passed, 0 failed.
+- Cockpit.Tests: 63 passed, 0 failed.
+- Gateway.Tests: 837 passed, 1 failed.
+  - The one failure is DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider
+    ("expected at least 1 partial transcript, got 0"). This is a LIVE speech-to-text streaming test
+    that connects to a real provider with a 90-second deadline; it shares no code with this ear-icon
+    change and fails for an environmental/provider-timing reason (no partials returned in time). Not
+    introduced by this work.
+
+## Visual confirmation still needed (manual)
+
+UI-icon visibility is not unit-testable here, and launching all three user interfaces with a real
+voice-mode session is a manual step. A human run should confirm, on each surface, the ear is PRESENT
+on a voice-mode session and ABSENT on a non-voice session:
+
+1. Desktop rail (SESSIONS list): put a phone on a session's Voice tab; the ear appears on LINE 2
+   next to the agent/type badges, and clears when the phone leaves the Voice tab.
+2. Cockpit rail: the same session shows the blue tag-voice pill now containing the ear (no longer
+   the word "voice").
+3. /m mobile list: the session row shows the accent-colored ear before the name.
+
+Look specifically at: ear present vs absent, the ear renders as a drawn shape (not a box/garbage
+glyph), and it does not push the session name off-row.

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -454,6 +454,31 @@
                                     <!-- LINE 2: identity badges only - the wide items.
                                          Alone on their own line they always fit. -->
                                     <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                                        <!-- In-voice-mode ear indicator (issue #554): shown only
+                                             while a phone is watching this session through the Voice
+                                             (in-car) tab. A vector ear (outer fold + inner canal),
+                                             never a glyph, tinted with the active-icon foreground so
+                                             it reads as an indicator, not a status color. -->
+                                        <Viewbox Width="14" Height="14"
+                                                 IsVisible="{Binding IsVoiceMode}"
+                                                 VerticalAlignment="Center"
+                                                 Margin="0,0,6,0"
+                                                 ToolTip.Tip="In voice mode - a phone is driving this session by voice">
+                                            <Canvas Width="24" Height="24">
+                                                <Path Stroke="{DynamicResource TextForeground}"
+                                                      StrokeThickness="2"
+                                                      StrokeLineCap="Round"
+                                                      StrokeJoin="Round"
+                                                      Fill="Transparent"
+                                                      Data="M7 11 C7 6.6 10.1 4 12.5 4 C15.5 4 18 6.4 18 9.5 C18 12.4 16 13.7 14.7 14.7 C13.7 15.5 13 16.1 13 17.2 C13 18.7 11.9 19.9 10.4 19.9 C9 19.9 7.9 18.8 7.9 17.4" />
+                                                <Path Stroke="{DynamicResource TextForeground}"
+                                                      StrokeThickness="2"
+                                                      StrokeLineCap="Round"
+                                                      StrokeJoin="Round"
+                                                      Fill="Transparent"
+                                                      Data="M10.2 10.4 C10.2 9.1 11.2 8.1 12.5 8.1 C13.8 8.1 14.8 9.1 14.8 10.4 C14.8 11.6 13.9 12.1 13.2 12.7" />
+                                            </Canvas>
+                                        </Viewbox>
                                         <!-- Agent badge: shows which CLI this session is running -->
                                         <Border Background="{Binding AgentBadgeBrush}"
                                                 CornerRadius="6"

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -69,6 +69,7 @@ public class SessionViewModel : INotifyPropertyChanged
         session.OnStatusColorChanged += OnStatusColorChanged;
         session.OnCachedExplainChanged += OnCachedExplainChangedVm;
         session.OnHoldChanged += OnHoldChangedVm;
+        session.OnViewModeChanged += OnViewModeChangedVm;
 
         if (session.PromptQueue != null)
         {
@@ -133,6 +134,16 @@ public class SessionViewModel : INotifyPropertyChanged
             OnPropertyChanged(nameof(StatusReason));
             OnPropertyChanged(nameof(IsOnHold));
         });
+    }
+
+    /// <summary>True when a phone is currently watching this session through the Voice (in-car)
+    /// tab. Drives the rail's in-voice-mode ear indicator (issue #554). A pure passthrough of
+    /// <see cref="Session.VoiceMode"/> so the rail never reads the model directly.</summary>
+    public bool IsVoiceMode => Session.VoiceMode;
+
+    private void OnViewModeChangedVm(MobileViewMode oldMode, MobileViewMode newMode)
+    {
+        Dispatcher.UIThread.Post(() => OnPropertyChanged(nameof(IsVoiceMode)));
     }
 
     private void OnCachedExplainChangedVm()

--- a/src/CcDirector.Cockpit/Components/SessionRail.razor
+++ b/src/CcDirector.Cockpit/Components/SessionRail.razor
@@ -75,9 +75,17 @@
                     {
                         <span class="tag tag-hold">hold</span>
                     }
+                    @* In-voice-mode ear indicator (issue #554): a vector ear (outer fold + inner
+                       canal), never a glyph, in place of the old "voice" text. Keeps the tag-voice
+                       hook so the pill styling and color stay in one place. *@
                     @if (s.VoiceMode)
                     {
-                        <span class="tag tag-voice">voice</span>
+                        <span class="tag tag-voice" title="In voice mode - a phone is driving this session by voice">
+                            <svg class="ear-icon" viewBox="0 0 24 24" fill="none" aria-label="voice mode" role="img">
+                                <path d="M7 11 C7 6.6 10.1 4 12.5 4 C15.5 4 18 6.4 18 9.5 C18 12.4 16 13.7 14.7 14.7 C13.7 15.5 13 16.1 13 17.2 C13 18.7 11.9 19.9 10.4 19.9 C9 19.9 7.9 18.8 7.9 17.4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                                <path d="M10.2 10.4 C10.2 9.1 11.2 8.1 12.5 8.1 C13.8 8.1 14.8 9.1 14.8 10.4 C14.8 11.6 13.9 12.1 13.2 12.7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                            </svg>
+                        </span>
                     }
                     @* Issue #237: show the Director's port (resolved from the registry by the
                        session's DirectorId), not the GUID prefix. Full GUID stays in the title. *@

--- a/src/CcDirector.Cockpit/wwwroot/app.css
+++ b/src/CcDirector.Cockpit/wwwroot/app.css
@@ -275,7 +275,11 @@ body{background:var(--panel);color:var(--text);
 .sess-state{font-size:10px;color:var(--text3);display:flex;align-items:center;gap:6px}
 .tag{font-size:9px;border-radius:6px;padding:0 5px;line-height:14px}
 .tag-hold{color:var(--text3);background:#404040}
-.tag-voice{color:#04101f;background:var(--blue)}
+/* In-voice-mode ear (#554): the blue pill now holds a vector ear instead of the word
+   "voice"; the ear inherits the dark pill text color via currentColor. */
+.tag-voice{color:#04101f;background:var(--blue);display:inline-flex;align-items:center;
+  padding:0 4px}
+.tag-voice .ear-icon{width:12px;height:12px;display:block}
 /* session type (#211): OUTLINED chips in a palette distinct from the state colors
    (red/green/amber/blue), so type-as-identity can never be mistaken for a state. */
 .tag-type{background:transparent;border:1px solid;line-height:12px;font-weight:600}

--- a/src/CcDirector.Cockpit/wwwroot/m/index.html
+++ b/src/CcDirector.Cockpit/wwwroot/m/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
 <meta name="theme-color" content="#0b1020" />
 <title>Wingman Voice</title>
-<link rel="stylesheet" href="/m/m.css?v=21" />
+<link rel="stylesheet" href="/m/m.css?v=22" />
 </head>
 <body>
   <!-- ============ Session list ============ -->
@@ -98,6 +98,6 @@
   </section>
 
   <audio id="tts-audio" preload="auto" hidden></audio>
-  <script src="/m/m.js?v=21"></script>
+  <script src="/m/m.js?v=22"></script>
 </body>
 </html>

--- a/src/CcDirector.Cockpit/wwwroot/m/m.css
+++ b/src/CcDirector.Cockpit/wwwroot/m/m.css
@@ -30,7 +30,11 @@ body{background:var(--bg);color:var(--text);
 .scard:active{background:var(--panel2)}
 .scard .dot{flex:0 0 auto}
 .scard-main{min-width:0}
-.scard-name{font-size:16px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.scard-name{font-size:16px;font-weight:600;display:flex;align-items:center;gap:6px;min-width:0}
+.scard-name-text{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0}
+/* In-voice-mode ear (#554): a small vector ear before the name on voice-driven rows;
+   accent-tinted, never shrinks so the name ellipsizes around it. */
+.scard-name .ear-icon{width:16px;height:16px;flex:0 0 auto;color:var(--accent)}
 .scard-sub{font-size:12px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px}
 .scard-chev{color:var(--muted);font-size:20px;flex:0 0 auto}
 .scard-play{flex:0 0 auto;width:48px;height:48px;border-radius:50%;border:none;cursor:pointer;

--- a/src/CcDirector.Cockpit/wwwroot/m/m.js
+++ b/src/CcDirector.Cockpit/wwwroot/m/m.js
@@ -89,8 +89,11 @@
         // Voice-ready rows show the play triangle INSTEAD of the chevron (keeps the row from
         // overflowing on a narrow phone, and the triangle is the obvious affordance).
         var tail=ready[s.sessionId]?'<button class="scard-play" type="button" aria-label="Play voice">&#9654;</button>':'<span class="scard-chev">&rsaquo;</span>';
-        li.innerHTML='<span class="dot" style="background:'+dotColor(effColor(s))+'"></span><span class="scard-main"><div class="scard-name"></div><div class="scard-sub"></div></span>'+tail;
-        li.querySelector(".scard-name").textContent=titleOf(s);
+        // In-voice-mode ear (issue #554): a vector ear (outer fold + inner canal) sits before the
+        // name when a phone is driving this session by voice (DTO field voiceMode). Never a glyph.
+        var ear=s.voiceMode?'<svg class="ear-icon" viewBox="0 0 24 24" fill="none" aria-label="voice mode" role="img"><path d="M7 11 C7 6.6 10.1 4 12.5 4 C15.5 4 18 6.4 18 9.5 C18 12.4 16 13.7 14.7 14.7 C13.7 15.5 13 16.1 13 17.2 C13 18.7 11.9 19.9 10.4 19.9 C9 19.9 7.9 18.8 7.9 17.4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M10.2 10.4 C10.2 9.1 11.2 8.1 12.5 8.1 C13.8 8.1 14.8 9.1 14.8 10.4 C14.8 11.6 13.9 12.1 13.2 12.7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>':'';
+        li.innerHTML='<span class="dot" style="background:'+dotColor(effColor(s))+'"></span><span class="scard-main"><div class="scard-name">'+ear+'<span class="scard-name-text"></span></div><div class="scard-sub"></div></span>'+tail;
+        li.querySelector(".scard-name-text").textContent=titleOf(s);
         li.querySelector(".scard-sub").textContent=(ready[s.sessionId]?"voice ready  -  ":"")+humanState(s.assessedState||s.activityState)+extra;
         // Tapping the row BODY opens the session WITHOUT auto-playing (drive-safe; unchanged).
         li.addEventListener("click", function(){ openSession(s, false); });

--- a/src/CcDirector.Cockpit/wwwroot/m/sw.js
+++ b/src/CcDirector.Cockpit/wwwroot/m/sw.js
@@ -2,8 +2,8 @@
 // a stale version when there IS a connection. Strategy = network-first for the /m/ shell: try the
 // network (and refresh the cache), fall back to the cached copy only when offline or the network
 // stalls. API calls (/sessions, /wingman/*) are never touched - they pass straight through.
-var CACHE = "wingman-voice-v21";
-var SHELL = ["/m/index.html", "/m/m.css?v=21", "/m/m.js?v=21"];
+var CACHE = "wingman-voice-v22";
+var SHELL = ["/m/index.html", "/m/m.css?v=22", "/m/m.js?v=22"];
 var NET_TIMEOUT_MS = 4000;
 
 self.addEventListener("install", function (e) {

--- a/src/CcDirector.Core.Tests/SessionViewModeTests.cs
+++ b/src/CcDirector.Core.Tests/SessionViewModeTests.cs
@@ -1,0 +1,71 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Tests for the mobile view-mode change notification added for the in-voice-mode ear icon
+/// (issue #554). The desktop session view-model listens to <see cref="Session.OnViewModeChanged"/>
+/// so the ear indicator appears and clears live as a phone enters and leaves the Voice tab, and
+/// the derived <see cref="Session.VoiceMode"/> / <see cref="Session.MobileMode"/> flags must track
+/// <see cref="Session.ViewMode"/> exactly.
+/// </summary>
+public sealed class SessionViewModeTests
+{
+    private static Session NewSession() => new Session(
+        Guid.NewGuid(),
+        repoPath: @"C:\test\repo",
+        workingDirectory: @"C:\test\repo",
+        claudeArgs: null,
+        backend: new StubSessionBackend(),
+        claudeSessionId: "claude-test",
+        activityState: ActivityState.Idle,
+        createdAt: DateTimeOffset.UtcNow,
+        customName: null,
+        customColor: null);
+
+    [Fact]
+    public void VoiceMode_IsTrue_OnlyWhenViewModeIsVoice()
+    {
+        using var s = NewSession();
+
+        Assert.False(s.VoiceMode); // default Off
+
+        s.ViewMode = MobileViewMode.Text;
+        Assert.False(s.VoiceMode);
+
+        s.ViewMode = MobileViewMode.Voice;
+        Assert.True(s.VoiceMode);
+
+        s.ViewMode = MobileViewMode.Off;
+        Assert.False(s.VoiceMode);
+    }
+
+    [Fact]
+    public void SettingViewMode_RaisesOnViewModeChanged_WithOldAndNew()
+    {
+        using var s = NewSession();
+        var events = new List<(MobileViewMode Old, MobileViewMode New)>();
+        s.OnViewModeChanged += (oldMode, newMode) => events.Add((oldMode, newMode));
+
+        s.ViewMode = MobileViewMode.Voice;
+        s.ViewMode = MobileViewMode.Off;
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal((MobileViewMode.Off, MobileViewMode.Voice), events[0]);
+        Assert.Equal((MobileViewMode.Voice, MobileViewMode.Off), events[1]);
+    }
+
+    [Fact]
+    public void SettingViewMode_ToSameValue_DoesNotRaise()
+    {
+        using var s = NewSession();
+        s.ViewMode = MobileViewMode.Voice;
+
+        var raised = 0;
+        s.OnViewModeChanged += (_, _) => raised++;
+        s.ViewMode = MobileViewMode.Voice; // unchanged
+
+        Assert.Equal(0, raised);
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -380,7 +380,25 @@ public sealed class Session : IDisposable
     /// and <see cref="VoiceMode"/> are derived from it. Off by default. Not persisted: it tracks
     /// what a remote viewer is looking at right now, not durable session state.
     /// </summary>
-    public MobileViewMode ViewMode { get; set; } = MobileViewMode.Off;
+    public MobileViewMode ViewMode
+    {
+        get => _viewMode;
+        set
+        {
+            if (_viewMode == value) return;
+            var old = _viewMode;
+            _viewMode = value;
+            OnViewModeChanged?.Invoke(old, value);
+        }
+    }
+    private MobileViewMode _viewMode = MobileViewMode.Off;
+
+    /// <summary>
+    /// Raised when <see cref="ViewMode"/> changes (old, new). The desktop session view-model
+    /// listens so the in-voice-mode ear indicator (issue #554) appears and clears live as a
+    /// phone enters and leaves the Voice tab, without waiting for a list rebuild.
+    /// </summary>
+    public event Action<MobileViewMode, MobileViewMode>? OnViewModeChanged;
 
     /// <summary>
     /// True when a phone is actively watching this session in either mobile mode (Text or Voice).


### PR DESCRIPTION
Adds a consistent in-voice-mode ear icon (vector/SVG, no unicode) on the desktop rail, Cockpit rail, and /m list. Rebased onto main after #556 (voice reliability) merged; supersedes the auto-closed PR #557 (its base branch voice/553-reliability was deleted on the #556 merge). Closes #554.

Build clean; 66/66 Avalonia tests pass. Visual confirmation of the ear present/absent per surface needs a human run (see docs/cencon/proof/issue-554/report.md).