### PR TITLE
feat: Codex full-access preset and persist agent launch mode

### DIFF
--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -182,6 +182,7 @@ public partial class SettingsDialog : Window
                 ["preset_id"] = row.PresetId,
                 ["default_model"] = row.DefaultModel,
                 ["args_override"] = row.ArgsOverride,
+                ["launch_mode"] = row.LaunchMode.ToString(),
             });
         return array.ToJsonString();
     }
@@ -276,6 +277,7 @@ public partial class SettingsDialog : Window
                 PresetId = row.PresetId,
                 DefaultModel = row.DefaultModel,
                 ArgsOverride = row.ArgsOverride,
+                LaunchMode = row.LaunchMode,
             };
 
             var dialog = new AgentEditorDialog(existing, siblingNames, CurrentOptions());
@@ -311,6 +313,7 @@ public partial class SettingsDialog : Window
             existing.PresetId = result.PresetId;
             existing.DefaultModel = result.DefaultModel;
             existing.ArgsOverride = result.ArgsOverride;
+            existing.LaunchMode = result.LaunchMode;
             existing.StatusText = ReadStatusText(result);
         }
         else
@@ -507,6 +510,7 @@ public partial class SettingsDialog : Window
                 PresetId = row.PresetId,
                 DefaultModel = row.DefaultModel,
                 ArgsOverride = row.ArgsOverride,
+                LaunchMode = row.LaunchMode,
             });
         return entries;
     }
@@ -874,6 +878,7 @@ public sealed class AgentEntryRow : INotifyPropertyChanged
     public string PresetId { get; set; } = "";
     public string DefaultModel { get; set; } = "";
     public string ArgsOverride { get; set; } = "";
+    public LaunchMode LaunchMode { get; set; } = LaunchMode.Guided;
 
     private string _statusText = "";
     public string StatusText
@@ -930,6 +935,7 @@ public sealed class AgentEntryRow : INotifyPropertyChanged
         PresetId = entry.PresetId,
         DefaultModel = entry.DefaultModel,
         ArgsOverride = entry.ArgsOverride,
+        LaunchMode = entry.LaunchMode,
         StatusText = statusText,
     };
 

--- a/src/CcDirector.Core.Tests/Agents/AgentToolCatalogTests.cs
+++ b/src/CcDirector.Core.Tests/Agents/AgentToolCatalogTests.cs
@@ -37,6 +37,20 @@ public class AgentToolCatalogTests
     }
 
     [Fact]
+    public void CodexEntry_DefaultPresetIsStandard_AndOffersFullAccess()
+    {
+        var codex = AgentToolCatalog.GetEntry(AgentKind.Codex);
+
+        Assert.Equal(AgentToolCatalog.StandardPresetName, codex.DefaultPreset.Name);
+        Assert.Equal("", codex.DefaultPreset.Arguments);
+
+        var fullAccess = codex.Presets.FirstOrDefault(p => p.Name == AgentToolCatalog.CodexFullAccessPresetName);
+        Assert.NotNull(fullAccess);
+        Assert.Equal(AgentToolCatalog.CodexFullAccessArg, fullAccess.Arguments);
+        Assert.Equal("--sandbox danger-full-access --ask-for-approval never", AgentToolCatalog.CodexFullAccessArg);
+    }
+
+    [Fact]
     public void ClaudeEntry_DefaultPresetIsAutomatic_WithSkipPermissions()
     {
         // Issue #436 (supersedes #391): Claude now defaults to Automatic (skip permissions).

--- a/src/CcDirector.Core.Tests/Configuration/AgentToolConfigTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/AgentToolConfigTests.cs
@@ -84,6 +84,18 @@ public class AgentToolConfigTests
     }
 
     [Fact]
+    public void ResolveEffectiveCommandLineArguments_CodexFullAccessPreset_HasFullAccessFlags()
+    {
+        var config = new AgentToolConfig
+        {
+            Tool = AgentKind.Codex,
+            PresetName = AgentToolCatalog.CodexFullAccessPresetName,
+        };
+
+        Assert.Equal(AgentToolCatalog.CodexFullAccessArg, config.ResolveEffectiveCommandLineArguments());
+    }
+
+    [Fact]
     public void ResolveEffectiveCommandLineArguments_AutomaticPresetWithModel_AppendsModelFlag()
     {
         var config = new AgentToolConfig

--- a/src/CcDirector.Core/Agents/AgentToolCatalog.cs
+++ b/src/CcDirector.Core/Agents/AgentToolCatalog.cs
@@ -64,6 +64,12 @@ public static class AgentToolCatalog
     /// <summary>The name of the Cursor opt-in permission-bypass preset (issue #517).</summary>
     public const string CursorAutomaticPresetName = "Automatic (yolo)";
 
+    /// <summary>The name of the Codex opt-in full-access preset.</summary>
+    public const string CodexFullAccessPresetName = "Full access";
+
+    /// <summary>The exact Codex flags for full filesystem and network access with no approval prompts.</summary>
+    public const string CodexFullAccessArg = "--sandbox danger-full-access --ask-for-approval never";
+
     /// <summary>
     /// The exact Cursor flag the automatic preset adds (and the standard preset omits).
     /// Cursor's permission-bypass equivalent of Claude's --dangerously-skip-permissions
@@ -120,7 +126,15 @@ public static class AgentToolCatalog
         // The other agents have a single standard preset and no recommended model argument
         // (their model is selected inside the tool, not via a Director-passed flag in v1).
         var pi = StandardOnly(AgentKind.Pi, "Pi");
-        var codex = StandardOnly(AgentKind.Codex, "Codex");
+        var codex = new AgentToolCatalogEntry(
+            AgentKind.Codex,
+            "Codex",
+            new[]
+            {
+                new AgentCommandPreset(StandardPresetName, ""),
+                new AgentCommandPreset(CodexFullAccessPresetName, CodexFullAccessArg),
+            },
+            "");
         var gemini = StandardOnly(AgentKind.Gemini, "Gemini");
         var openCode = StandardOnly(AgentKind.OpenCode, "OpenCode");
 


### PR DESCRIPTION
Add a second command preset for the Codex agent and persist each agent entry's launch mode.

- **AgentToolCatalog**: give Codex a `Full access` preset (`--sandbox danger-full-access --ask-for-approval never`) alongside the standard preset, for unattended runs.
- **SettingsDialog**: carry `LaunchMode` on each agent entry row through load, edit (agent editor dialog), serialize, and save, so the choice round-trips.
- **Tests**: cover the Codex full-access preset in the catalog and the command-line arguments it resolves to.

Built and tested locally against current `main`: solution builds with 0 warnings/0 errors, and `CcDirector.Core.Tests` (the assembly holding these tests) passes 2104/2104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)