### PR TITLE
feat: add Help documentation and feedback menu items

### DIFF
--- a/src/CcDirector.Avalonia/FeedbackDialog.axaml
+++ b/src/CcDirector.Avalonia/FeedbackDialog.axaml
@@ -1,0 +1,130 @@
+<Window x:Class="CcDirector.Avalonia.FeedbackDialog"
+        xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Send Feedback"
+        Width="560" Height="600"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#252526">
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0"
+                   Text="Send Feedback"
+                   Foreground="#CCCCCC"
+                   FontSize="16"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,4" />
+
+        <TextBlock Grid.Row="1"
+                   Text="This creates a ticket in the DevThrottle repository. The team is notified by email automatically."
+                   Foreground="#AAAAAA"
+                   FontSize="12"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,16" />
+
+        <!-- Title -->
+        <StackPanel Grid.Row="2" Margin="0,0,0,12">
+            <TextBlock Text="TITLE"
+                       Foreground="#007ACC"
+                       FontSize="12"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,4" />
+            <TextBox x:Name="TitleBox"
+                     Watermark="Short summary of your feedback"
+                     Background="#3C3C3C"
+                     Foreground="#CCCCCC"
+                     BorderThickness="0"
+                     Height="30" />
+        </StackPanel>
+
+        <!-- Description label -->
+        <TextBlock Grid.Row="3"
+                   Text="DESCRIPTION"
+                   Foreground="#007ACC"
+                   FontSize="12"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,4" />
+
+        <!-- Description box -->
+        <TextBox Grid.Row="4"
+                 x:Name="DescriptionBox"
+                 Watermark="What happened? What did you expect? Steps to reproduce, if any."
+                 Background="#3C3C3C"
+                 Foreground="#CCCCCC"
+                 BorderThickness="0"
+                 AcceptsReturn="True"
+                 TextWrapping="Wrap"
+                 VerticalContentAlignment="Top"
+                 VerticalAlignment="Stretch"
+                 Margin="0,0,0,12" />
+
+        <!-- Screenshot row -->
+        <StackPanel Grid.Row="5" Margin="0,0,0,8">
+            <TextBlock Text="SCREENSHOT (OPTIONAL)"
+                       Foreground="#007ACC"
+                       FontSize="12"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,4" />
+            <StackPanel Orientation="Horizontal">
+                <Button x:Name="BtnAttachScreenshot"
+                        Content="Attach screenshot of CC Director"
+                        Height="28"
+                        Background="#3C3C3C" Foreground="#CCCCCC"
+                        BorderThickness="0" Cursor="Hand"
+                        Click="BtnAttachScreenshot_Click" />
+                <Button x:Name="BtnRemoveScreenshot"
+                        Content="Remove"
+                        Height="28" Width="80"
+                        Margin="8,0,0,0"
+                        IsVisible="False"
+                        Background="#3C3C3C" Foreground="#CCCCCC"
+                        BorderThickness="0" Cursor="Hand"
+                        Click="BtnRemoveScreenshot_Click" />
+            </StackPanel>
+            <Border x:Name="ScreenshotPreviewBorder"
+                    IsVisible="False"
+                    BorderBrush="#3C3C3C" BorderThickness="1"
+                    Margin="0,8,0,0"
+                    HorizontalAlignment="Left">
+                <Image x:Name="ScreenshotPreview"
+                       MaxHeight="140"
+                       Stretch="Uniform" />
+            </Border>
+        </StackPanel>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="6"
+                   x:Name="StatusText"
+                   Foreground="#AAAAAA"
+                   FontSize="12"
+                   TextWrapping="Wrap"
+                   IsVisible="False"
+                   Margin="0,4,0,0" />
+
+        <!-- Action buttons -->
+        <StackPanel Grid.Row="7" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button x:Name="BtnSubmit" Content="Submit" Width="110" Height="28"
+                    Background="#007ACC" Foreground="#FFFFFF"
+                    BorderThickness="0" Cursor="Hand"
+                    Margin="0,0,8,0"
+                    Click="BtnSubmit_Click" />
+            <Button x:Name="BtnCancel" Content="Cancel" Width="80" Height="28"
+                    Background="#3C3C3C" Foreground="#CCCCCC"
+                    BorderThickness="0" Cursor="Hand"
+                    Click="BtnCancel_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/CcDirector.Avalonia/FeedbackDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FeedbackDialog.axaml.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Feedback;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// Collects feedback (title, description, optional screenshot of the CC Director
+/// window) and files it as a GitHub issue via <see cref="FeedbackService"/>. The
+/// screenshot is captured from the owner window's visual tree with
+/// <see cref="RenderTargetBitmap"/>, so this modal dialog never appears in it.
+/// </summary>
+public partial class FeedbackDialog : Window
+{
+    private readonly Window _owner;
+    private byte[]? _screenshotPng;
+
+    public FeedbackDialog(Window owner)
+    {
+        FileLog.Write("[FeedbackDialog] Constructor: initializing");
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        InitializeComponent();
+        Opened += OnOpened;
+    }
+
+    // Land the cursor in the title field so the user can type immediately.
+    private void OnOpened(object? sender, EventArgs e)
+    {
+        Opened -= OnOpened;
+        try
+        {
+            TitleBox.Focus();
+            TitleBox.SelectAll();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FeedbackDialog] OnOpened FAILED: {ex.Message}");
+        }
+    }
+
+    private void BtnAttachScreenshot_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FeedbackDialog] BtnAttachScreenshot_Click: capturing main window");
+        try
+        {
+            var scaling = _owner.RenderScaling;
+            var clientSize = _owner.ClientSize;
+            var pixelSize = new PixelSize(
+                Math.Max(1, (int)Math.Ceiling(clientSize.Width * scaling)),
+                Math.Max(1, (int)Math.Ceiling(clientSize.Height * scaling)));
+            var dpi = new Vector(96 * scaling, 96 * scaling);
+
+            using var rtb = new RenderTargetBitmap(pixelSize, dpi);
+            rtb.Render(_owner);
+
+            using var ms = new MemoryStream();
+            rtb.Save(ms);
+            _screenshotPng = ms.ToArray();
+
+            using var preview = new MemoryStream(_screenshotPng);
+            ScreenshotPreview.Source = new Bitmap(preview);
+            ScreenshotPreviewBorder.IsVisible = true;
+            BtnRemoveScreenshot.IsVisible = true;
+            BtnAttachScreenshot.Content = "Recapture screenshot";
+            ShowStatus($"Screenshot attached ({_screenshotPng.Length / 1024} KB).", isError: false);
+            FileLog.Write($"[FeedbackDialog] BtnAttachScreenshot_Click: captured {_screenshotPng.Length} bytes");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FeedbackDialog] BtnAttachScreenshot_Click FAILED: {ex}");
+            ShowStatus($"Could not capture screenshot: {ex.Message}", isError: true);
+        }
+    }
+
+    private void BtnRemoveScreenshot_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FeedbackDialog] BtnRemoveScreenshot_Click");
+        _screenshotPng = null;
+        ScreenshotPreview.Source = null;
+        ScreenshotPreviewBorder.IsVisible = false;
+        BtnRemoveScreenshot.IsVisible = false;
+        BtnAttachScreenshot.Content = "Attach screenshot of CC Director";
+        StatusText.IsVisible = false;
+    }
+
+    private async void BtnSubmit_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FeedbackDialog] BtnSubmit_Click: submitting feedback");
+        var title = TitleBox.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            ShowStatus("Please enter a title before submitting.", isError: true);
+            return;
+        }
+
+        SetBusy(true);
+        ShowStatus("Submitting feedback...", isError: false);
+        try
+        {
+            var description = DescriptionBox.Text ?? string.Empty;
+            var environment = BuildEnvironmentInfo();
+            var screenshot = _screenshotPng;
+
+            var issue = await Task.Run(async () =>
+            {
+                var token = GitHubCredentials.ReadToken();
+                using var client = new GitHubRestClient(token);
+                var service = new FeedbackService(client);
+                return await service.SubmitAsync(title, description, screenshot, environment, CancellationToken.None);
+            });
+
+            FileLog.Write($"[FeedbackDialog] BtnSubmit_Click: submitted as issue #{issue.Number}");
+            // The owner shows the confirmation toast; the dialog's job is done, so close it.
+            Close(true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FeedbackDialog] BtnSubmit_Click FAILED: {ex}");
+            ShowStatus($"Could not submit feedback: {ex.Message}", isError: true);
+            SetBusy(false);
+        }
+    }
+
+    private void BtnCancel_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FeedbackDialog] BtnCancel_Click: closing");
+        Close(false);
+    }
+
+    /// <summary>Diagnostic footer appended to the issue body to help triage.</summary>
+    private static string BuildEnvironmentInfo()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Environment:");
+        sb.AppendLine($"- CC Director version: {AppVersion.Display}");
+        sb.AppendLine($"- Operating system: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}");
+        return sb.ToString();
+    }
+
+    private void SetBusy(bool busy)
+    {
+        BtnSubmit.IsEnabled = !busy;
+        BtnCancel.IsEnabled = !busy;
+        BtnAttachScreenshot.IsEnabled = !busy;
+        BtnRemoveScreenshot.IsEnabled = !busy;
+        TitleBox.IsEnabled = !busy;
+        DescriptionBox.IsEnabled = !busy;
+    }
+
+    private void ShowStatus(string message, bool isError)
+    {
+        StatusText.Text = message;
+        StatusText.Foreground = new SolidColorBrush(Color.Parse(isError ? "#F48771" : "#AAAAAA"));
+        StatusText.IsVisible = true;
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2975,6 +2975,14 @@ public partial class MainWindow : Window
 
         // ===== Help =====
         var help = new NativeMenuItem("Help") { Menu = new NativeMenu() };
+        help.Menu.Items.Add(Item("Documentation", () =>
+        {
+            FileLog.Write("[MainWindow] Menu: Documentation -> https://devthrottle.com/docs");
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://devthrottle.com/docs")
+                { UseShellExecute = true });
+        }));
+        help.Menu.Items.Add(Item("Send Feedback...", () => BtnFeedback_Click(this, new RoutedEventArgs())));
+        help.Menu.Items.Add(new NativeMenuItemSeparator());
         help.Menu.Items.Add(Item("About CC Director", () => BtnHelp_Click(this, new RoutedEventArgs())));
         menu.Items.Add(help);
 
@@ -2982,6 +2990,15 @@ public partial class MainWindow : Window
     }
 
     // ==================== TOP APP BAR ====================
+
+    private async void BtnFeedback_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[MainWindow] BtnFeedback_Click: opening feedback dialog");
+        var dialog = new FeedbackDialog(this);
+        var result = await dialog.ShowDialog<bool?>(this);
+        if (result == true)
+            ShowNotification("Thank you. Your feedback has been submitted.");
+    }
 
     private async void BtnClaudeConfig_Click(object? sender, RoutedEventArgs e)
     {

--- a/src/CcDirector.Core.Tests/Feedback/FeedbackServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Feedback/FeedbackServiceTests.cs
@@ -1,0 +1,75 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Feedback;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Feedback;
+
+public sealed class FeedbackServiceTests
+{
+    [Fact]
+    public async Task SubmitAsync_NoScreenshot_CreatesIssueWithoutUpload()
+    {
+        var stub = new StubGitHubClient();
+        var service = new FeedbackService(stub);
+
+        var issue = await service.SubmitAsync(
+            "Terminal flickers", "It flickers when scrolling.", screenshotPng: null,
+            environment: "Environment:\n- CC Director version: 1.2.3",
+            CancellationToken.None);
+
+        Assert.Empty(stub.Uploads);
+        Assert.Equal(1, stub.CreateIssueCalls);
+        Assert.Equal("[Feedback] Terminal flickers", stub.CreatedIssueTitle);
+        Assert.Contains("It flickers when scrolling.", stub.CreatedIssueBody);
+        Assert.Contains("CC Director version: 1.2.3", stub.CreatedIssueBody);
+        Assert.DoesNotContain("![screenshot]", stub.CreatedIssueBody);
+        Assert.Contains("thefrederiksen/devthrottle", issue.HtmlUrl);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_WithScreenshot_UploadsToAssetsBranchAndEmbeds()
+    {
+        var stub = new StubGitHubClient
+        {
+            UploadDownloadUrl = "https://raw.githubusercontent.com/thefrederiksen/devthrottle/feedback-assets/feedback/screenshots/x.png",
+        };
+        var service = new FeedbackService(stub);
+        var png = new byte[] { 1, 2, 3, 4 };
+
+        await service.SubmitAsync("Crash on launch", "Boom.", png, environment: null, CancellationToken.None);
+
+        var upload = Assert.Single(stub.Uploads);
+        Assert.Equal(FeedbackService.ScreenshotBranch, upload.Branch);
+        Assert.StartsWith("feedback/screenshots/", upload.Path);
+        Assert.EndsWith(".png", upload.Path);
+        Assert.Equal(png.Length, upload.Bytes);
+        Assert.Contains("![screenshot](https://raw.githubusercontent.com/thefrederiksen/devthrottle/feedback-assets/feedback/screenshots/x.png)",
+            stub.CreatedIssueBody);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_EmptyDescription_UsesPlaceholder()
+    {
+        var stub = new StubGitHubClient();
+        var service = new FeedbackService(stub);
+
+        await service.SubmitAsync("Title only", "   ", screenshotPng: null, environment: null, CancellationToken.None);
+
+        Assert.Contains("(no description provided)", stub.CreatedIssueBody);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SubmitAsync_BlankTitle_Throws(string title)
+    {
+        var stub = new StubGitHubClient();
+        var service = new FeedbackService(stub);
+
+        await Assert.ThrowsAsync<System.ArgumentException>(() =>
+            service.SubmitAsync(title, "desc", screenshotPng: null, environment: null, CancellationToken.None));
+
+        Assert.Equal(0, stub.CreateIssueCalls);
+    }
+}

--- a/src/CcDirector.Core.Tests/StubGitHubClient.cs
+++ b/src/CcDirector.Core.Tests/StubGitHubClient.cs
@@ -38,6 +38,16 @@ internal sealed class StubGitHubClient : IGitHubClient
         return Task.FromResult(new GhIssue(IssueNumber, $"https://github.com/{owner}/{repo}/issues/{IssueNumber}"));
     }
 
+    public List<(string Branch, string Path, int Bytes, string Message)> Uploads { get; } = new();
+    public string UploadDownloadUrl { get; set; } =
+        "https://raw.githubusercontent.com/thefrederiksen/devthrottle/feedback-assets/feedback/screenshots/test.png";
+
+    public Task<string> UploadFileAsync(string owner, string repo, string branch, string path, byte[] content, string commitMessage, CancellationToken ct)
+    {
+        lock (_lock) Uploads.Add((branch, path, content.Length, commitMessage));
+        return Task.FromResult(UploadDownloadUrl);
+    }
+
     public Task<GhComment> PostCommentAsync(string owner, string repo, long issueNumber, string body, CancellationToken ct)
     {
         lock (_lock) PostedComments.Add((issueNumber, body));

--- a/src/CcDirector.Core/Backends/GitHubRestClient.cs
+++ b/src/CcDirector.Core/Backends/GitHubRestClient.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -47,6 +48,70 @@ public sealed class GitHubRestClient : IGitHubClient, IDisposable
         var root = doc.RootElement;
         return new GhIssue(root.GetProperty("number").GetInt64(), root.GetProperty("html_url").GetString() ?? "");
     }
+
+    public async Task<string> UploadFileAsync(string owner, string repo, string branch, string path, byte[] content, string commitMessage, CancellationToken ct)
+    {
+        await EnsureBranchAsync(owner, repo, branch, ct);
+
+        var payload = new
+        {
+            message = commitMessage,
+            content = Convert.ToBase64String(content),
+            branch,
+        };
+        using var doc = await PutJsonAsync($"/repos/{owner}/{repo}/contents/{EncodePath(path)}", payload, ct);
+        var fileEl = doc.RootElement.GetProperty("content");
+        var downloadUrl = fileEl.GetProperty("download_url").GetString();
+        if (string.IsNullOrEmpty(downloadUrl))
+            throw new InvalidOperationException($"GitHub Contents API did not return a download_url for {path}.");
+        return downloadUrl;
+    }
+
+    /// <summary>
+    /// Ensure <paramref name="branch"/> exists, creating it from the repository's
+    /// default branch when it does not. No-op when the branch is already present.
+    /// </summary>
+    private async Task EnsureBranchAsync(string owner, string repo, string branch, CancellationToken ct)
+    {
+        if (await RefExistsAsync(owner, repo, $"heads/{branch}", ct))
+            return;
+
+        var defaultBranch = await GetDefaultBranchAsync(owner, repo, ct);
+        var sha = await GetRefShaAsync(owner, repo, $"heads/{defaultBranch}", ct);
+
+        using var content = JsonContent.Create(new { @ref = $"refs/heads/{branch}", sha });
+        using var resp = await _http.PostAsync($"/repos/{owner}/{repo}/git/refs", content, ct);
+        await EnsureSuccessAsync(resp, ct);
+        FileLog.Write($"[GitHubRestClient] Created branch {branch} from {defaultBranch} in {owner}/{repo}");
+    }
+
+    private async Task<bool> RefExistsAsync(string owner, string repo, string gitRef, CancellationToken ct)
+    {
+        using var resp = await _http.GetAsync($"/repos/{owner}/{repo}/git/ref/{gitRef}", ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+            return false;
+        await EnsureSuccessAsync(resp, ct);
+        return true;
+    }
+
+    private async Task<string> GetDefaultBranchAsync(string owner, string repo, CancellationToken ct)
+    {
+        using var doc = await GetJsonAsync($"/repos/{owner}/{repo}", ct);
+        return doc.RootElement.GetProperty("default_branch").GetString()
+            ?? throw new InvalidOperationException($"GitHub did not report a default_branch for {owner}/{repo}.");
+    }
+
+    private async Task<string> GetRefShaAsync(string owner, string repo, string gitRef, CancellationToken ct)
+    {
+        using var doc = await GetJsonAsync($"/repos/{owner}/{repo}/git/ref/{gitRef}", ct);
+        return doc.RootElement.GetProperty("object").GetProperty("sha").GetString()
+            ?? throw new InvalidOperationException($"GitHub ref {gitRef} has no object sha in {owner}/{repo}.");
+    }
+
+    // Encode each path segment but keep the slashes that separate them, so a path
+    // like "feedback/screenshots/x.png" maps to a valid Contents API URL.
+    private static string EncodePath(string path)
+        => string.Join('/', path.Split('/').Select(Uri.EscapeDataString));
 
     public async Task<GhComment> PostCommentAsync(string owner, string repo, long issueNumber, string body, CancellationToken ct)
     {
@@ -131,6 +196,15 @@ public sealed class GitHubRestClient : IGitHubClient, IDisposable
     {
         using var content = JsonContent.Create(payload);
         using var resp = await _http.PostAsync(url, content, ct);
+        await EnsureSuccessAsync(resp, ct);
+        var stream = await resp.Content.ReadAsStreamAsync(ct);
+        return await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+    }
+
+    private async Task<JsonDocument> PutJsonAsync(string url, object payload, CancellationToken ct)
+    {
+        using var content = JsonContent.Create(payload);
+        using var resp = await _http.PutAsync(url, content, ct);
         await EnsureSuccessAsync(resp, ct);
         var stream = await resp.Content.ReadAsStreamAsync(ct);
         return await JsonDocument.ParseAsync(stream, cancellationToken: ct);

--- a/src/CcDirector.Core/Backends/IGitHubClient.cs
+++ b/src/CcDirector.Core/Backends/IGitHubClient.cs
@@ -10,6 +10,15 @@ public interface IGitHubClient
     /// <summary>Create a new issue. Returns the created issue (number + html url).</summary>
     Task<GhIssue> CreateIssueAsync(string owner, string repo, string title, string body, CancellationToken ct);
 
+    /// <summary>
+    /// Create a file on a branch via the Contents API and return the raw download
+    /// URL of the committed file (suitable for embedding in issue markdown as an
+    /// image). The branch is created from the repository's default branch when it
+    /// does not yet exist, so screenshot uploads can be isolated on a dedicated
+    /// branch instead of cluttering the default branch.
+    /// </summary>
+    Task<string> UploadFileAsync(string owner, string repo, string branch, string path, byte[] content, string commitMessage, CancellationToken ct);
+
     /// <summary>Post a comment on an issue/PR thread. Returns the created comment.</summary>
     Task<GhComment> PostCommentAsync(string owner, string repo, long issueNumber, string body, CancellationToken ct);
 

--- a/src/CcDirector.Core/Feedback/FeedbackService.cs
+++ b/src/CcDirector.Core/Feedback/FeedbackService.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Feedback;
+
+/// <summary>
+/// Turns a user's feedback (a title, a description, and an optional screenshot)
+/// into a GitHub issue on the DevThrottle product repository. When a screenshot is
+/// supplied it is committed to a dedicated assets branch first, then embedded in the
+/// issue body so it renders inline. The notification email is delivered by GitHub
+/// itself: anyone watching the repository (for example email@devthrottle.com) is
+/// emailed the moment the issue is created, so this service does not send mail.
+///
+/// The orchestration lives here, behind <see cref="IGitHubClient"/>, so it can be
+/// unit-tested without touching the network.
+/// </summary>
+public sealed class FeedbackService
+{
+    /// <summary>Owner of the product repository feedback issues are filed against.</summary>
+    public const string Owner = "thefrederiksen";
+
+    /// <summary>Name of the product repository feedback issues are filed against.</summary>
+    public const string Repository = "devthrottle";
+
+    /// <summary>
+    /// Dedicated branch screenshots are committed to, so feedback images never land
+    /// on the default branch or in the code history.
+    /// </summary>
+    public const string ScreenshotBranch = "feedback-assets";
+
+    private readonly IGitHubClient _client;
+
+    public FeedbackService(IGitHubClient client)
+        => _client = client ?? throw new ArgumentNullException(nameof(client));
+
+    /// <summary>
+    /// Submit feedback. Uploads the screenshot (when present), then creates the issue
+    /// and returns it (number + html url). <paramref name="screenshotPng"/> is PNG
+    /// bytes or null when the user chose not to attach one; <paramref name="environment"/>
+    /// is optional diagnostic text appended to the body to help triage.
+    /// </summary>
+    public async Task<GhIssue> SubmitAsync(
+        string title,
+        string description,
+        byte[]? screenshotPng,
+        string? environment,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("A feedback title is required.", nameof(title));
+
+        FileLog.Write($"[FeedbackService] SubmitAsync: title={title}, hasScreenshot={screenshotPng is { Length: > 0 }}");
+
+        var body = new StringBuilder();
+        body.Append(string.IsNullOrWhiteSpace(description) ? "(no description provided)" : description.Trim());
+
+        if (screenshotPng is { Length: > 0 })
+        {
+            // The path is unique per submission so it never collides with an existing
+            // file on the branch (the Contents API would otherwise need the blob sha).
+            var path = $"feedback/screenshots/{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid():N}.png";
+            var downloadUrl = await _client.UploadFileAsync(
+                Owner, Repository, ScreenshotBranch, path, screenshotPng,
+                $"Add feedback screenshot for: {title}", ct);
+            body.Append("\n\n");
+            body.Append($"![screenshot]({downloadUrl})");
+            FileLog.Write($"[FeedbackService] SubmitAsync: screenshot uploaded to {path}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(environment))
+        {
+            body.Append("\n\n---\n");
+            body.Append(environment.Trim());
+        }
+
+        var issue = await _client.CreateIssueAsync(Owner, Repository, $"[Feedback] {title.Trim()}", body.ToString(), ct);
+        FileLog.Write($"[FeedbackService] SubmitAsync: created issue #{issue.Number} at {issue.HtmlUrl}");
+        return issue;
+    }
+}


### PR DESCRIPTION
## Summary
Adds two Help-menu items to the desktop app:

- **Documentation** opens https://devthrottle.com/docs in the default browser.
- **Send Feedback...** opens a dialog that files a GitHub issue on the product repository via a new `FeedbackService`, optionally embedding a screenshot of the main window.

## Details
- Screenshots are captured from the main window with `RenderTargetBitmap` (the modal itself never appears in the capture) and committed to a dedicated `feedback-assets` branch via the GitHub Contents API, then embedded inline in the issue.
- Team notification is delivered by GitHub repository watching (email@devthrottle.com watches the repo) rather than app-sent email, so there is no "from" account problem and no new infrastructure.
- The dialog focuses the title field on open and closes itself on a successful submit, confirming with a toast in the main window.

## Tests
- `FeedbackServiceTests`: orchestration with and without a screenshot, empty-description placeholder, and blank-title guard.
- Existing GitHub client tests updated for the new `UploadFileAsync` interface method (23 pass).
- Avalonia project builds with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)