### PR TITLE
fix(#566): deflake CI - skip/quarantine environment-dependent and timing-flaky tests

### DIFF
--- a/docs/cencon/proof/issue-566/addressed-tests.md
+++ b/docs/cencon/proof/issue-566/addressed-tests.md
@@ -1,0 +1,108 @@
+# Issue 566 - Deflake CI Build and Test proof
+
+Goal: make the continuous integration "Build & Test (.NET)" gate deterministically
+green by skipping or quarantining tests that depend on the runner environment (a live
+external provider, an installed external command-line tool) or on real-process timing,
+following the precedent already in the tree (the static `[Fact(Skip = ...)]` used for
+`SessionAskRunnerTests.AskAsync_ClaudeCode_RealDriverWithFixtureTranscript_ReturnsParsedAnswer`,
+`SessionEdgeCaseTests.ConcurrentSessionCreation_AllSucceed`, and `NulFileWatcherTests`).
+
+Both test projects use xUnit version 2 (`xunit` Version `2.*`), which has no clean
+dynamic skip (no `Assert.Skip`). So the precedent-matching mechanism is the static
+`[Fact(Skip = "<reason>")]` attribute, with the reason naming why.
+
+## Each addressed test
+
+### 1. CcDirector.Core.Tests.Recording.RecordingIngestServiceTests.Worker_TranscribesQueuedRecording_EndToEnd
+
+- Mechanism: static quarantine, `[Fact(Skip = ...)]`.
+- Reason: irreducible background-worker plus filesystem timing race. The test starts the
+  real background worker (`runWorker: true`), a timer-driven thread that drains the queue,
+  transcribes, and persists status to disk, then polls for the "transcribed" state. Pass
+  or fail depends on the worker's tick plus the status-file write winning a race against
+  the poll deadline; it has intermittently failed on continuous integration at
+  `RecordingIngestService.SaveStatus` (observed on pull request 561 and on the post-merge
+  main run, passing on a plain re-run). There is no external dependency to probe.
+- Remaining deterministic coverage: the exact transcription plus SaveStatus path is
+  covered by `Complete_AssemblesCleansAndFiles` and the other tests in the same file that
+  drive `ProcessRecordingAsync` synchronously (no background worker). The queue-only
+  enqueue behavior is covered by `Complete_OnlyEnqueues_DoesNotTranscribeInline`. The only
+  thing not exercised is the background worker thread draining the queue on its own timer.
+
+### 2. CcDirector.Gateway.Tests.DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider
+
+- Mechanism: static quarantine, `[Fact(Skip = ...)]`. (The existing runtime early-return
+  guards for the absent-dependency case are kept inside the body, but the static skip now
+  also stops the racy assertion from running where the dependency is present.)
+- Reason: needs a live OpenAI Realtime streaming speech-to-text provider (a reachable
+  WebSocket plus a valid `OPENAI_API_KEY`) and ffmpeg on the command path to decode the
+  Phase 0 clip - none of which the continuous integration runner has. Even where the
+  dependency is present it asserts `partialsObserved >= 1`, which races the live provider's
+  nondeterministic mid-stream partial emission; the Realtime application programming
+  interface does not guarantee a partial transcript arrives before the final within the
+  deadline (observed failure "expected at least 1 partial transcript, got 0").
+- Remaining deterministic coverage: the dictate WebSocket served assets and the
+  400-on-non-upgrade behavior are covered by `DictatePage_is_served`,
+  `NonWebSocketGet_to_dictate_returns_400`, and `WorkletScript_is_served` in the same file;
+  the realtime provider's connect, retry, and protocol parsing are covered offline by
+  `OpenAiRealtimeProviderConnectTests` and `OpenAiRealtimeProtocolTests`; the capture-first
+  pipeline is covered by `DictationPipelineTests`. The only thing not run on continuous
+  integration is the single live full-stack transcription, which requires the
+  environment-gated provider.
+
+### 3. CcDirector.Core.Tests.SessionLifecycleTests.KillAllSessions_KillsAllRunning
+
+- Mechanism: static quarantine, `[Fact(Skip = ...)]`.
+- Reason: irreducible real-process timing race. The test spawns two real stand-in shell
+  processes (cmd.exe or sh) and asserts both report `SessionStatus.Running` immediately
+  after creation, before killing them. That post-create assertion races the real process:
+  under load on a continuous integration runner the stand-in can already be observed as
+  exited by the time the assertion runs (observed failure "Expected Running, Actual
+  Exited"), even though the kill behavior under test is correct. There is no external
+  dependency to probe.
+- Remaining deterministic coverage: the kill and lifecycle behavior is still covered by
+  `KillSession_RunningSession_TransitionsToExited`, `KillSession_AlreadyExited_DoesNotThrow`,
+  and `KillAllSessions_NoSessions_DoesNotThrow` in the same file, plus
+  `Dispose_DisposesAllSessions`.
+
+## Sweep of the rest of the test projects
+
+Searched both test projects for tests that hit a live network or provider, an installed
+external command-line tool, or assert on real multi-process timing. All of the following
+already self-skip cleanly (early `return`) when their dependency is absent, so they do not
+run and cannot fail on the bare continuous integration runner (which sets neither
+`OPENAI_API_KEY` nor an opt-in variable, and has no ffmpeg):
+
+- `CcDirector.Core.Tests.Dictation.CleanupOrchestratorLiveTests` - self-skips without `OPENAI_API_KEY`.
+- `CcDirector.Core.Tests.Dictation.DictationPipelineLiveTests` - self-skips without `OPENAI_API_KEY`, ffmpeg, or the Phase 0 clips.
+- `CcDirector.Core.Tests.Dictation.OpenAiRealtimeProviderIntegrationTests` - self-skips without `OPENAI_API_KEY` (and ffmpeg for the real-audio case).
+- `CcDirector.Core.Tests.Wingman.WingmanAnswerLiveTests` - self-skips unless `WINGMAN_LIVE_TESTS=1` and `OPENAI_API_KEY` are set.
+- `CcDirector.Gateway.Tests.RecordingEndpointsE2ETests` - self-skips unless `CC_REC_E2E=1` and `OPENAI_API_KEY` are set.
+- `CcDirector.Core.Tests.Recording.RecordingIngestServiceTests.EndToEnd_RealTranscription_Phase0Clips_PreservesCompanyTerms` - self-skips without `OPENAI_API_KEY` or the clips.
+- `CcDirector.Gateway.Tests.DictationEndpointTests.ClientCloseWithoutStop_recovers_transcript_instead_of_discarding` - self-skips without `OPENAI_API_KEY`, ffmpeg, or the clip. (Its assertions are not the flagged failure; left as a runtime self-skip.)
+
+Deterministic by construction (no live calls): `LivePreviewTranscriberTests` (fake HTTP
+handler), `VoiceTurnEndpointTests`, `GatewayVoiceTurnAsyncTests`, `VoiceEndpointTests`,
+`BriefBuilderTests` (all null out `OPENAI_API_KEY` to force the no-key path),
+`KeyVaultTests`, `VaultEndpointsTests`, `VaultGatewayIntegrationTests` (in-process loopback,
+no external service).
+
+No other test was found that would fail on a bare continuous integration runner.
+
+## Local build and test results
+
+- `dotnet build cc-director.sln -c Release`: Build succeeded, 0 warnings, 0 errors.
+- `dotnet test src/CcDirector.Core.Tests`: Passed, Failed 0, Passed 2141, Skipped 6.
+- `dotnet test src/CcDirector.Gateway.Tests`: Passed, Failed 0, Passed 837, Skipped 1.
+
+The three addressed tests confirmed as Skipped in the run output:
+- `SessionLifecycleTests.KillAllSessions_KillsAllRunning`
+- `Recording.RecordingIngestServiceTests.Worker_TranscribesQueuedRecording_EndToEnd`
+- `DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider`
+
+## Acceptance note for the human and quality assurance reviewer
+
+The acceptance criterion of three consecutive green continuous integration runs on a
+no-op change is verified post-merge by a human or the quality assurance agent; this change
+does not push three times. The diff and the local green run above are the developer-side
+proof.

--- a/src/CcDirector.Core.Tests/Recording/RecordingIngestServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Recording/RecordingIngestServiceTests.cs
@@ -307,7 +307,20 @@ public sealed class RecordingIngestServiceTests : IDisposable
         Assert.Equal(1, status.ChunksTranscribed);
     }
 
-    [Fact]
+    // This test starts the REAL background worker (runWorker: true) - a timer-driven
+    // thread that drains the queue, transcribes, and persists status to disk - then
+    // polls for the "transcribed" state. The pass/fail depends on the background
+    // worker's tick plus filesystem write timing winning a race against the poll
+    // deadline; it has intermittently failed on continuous integration at
+    // RecordingIngestService.SaveStatus (observed on pull request #561 and on the
+    // post-merge main run, passing on a plain re-run). There is no external dependency
+    // to probe - it is an irreducible background-worker/IO timing race - so it is
+    // statically quarantined, matching the existing ConPty/NUL convention. The exact
+    // transcription + SaveStatus path is still covered deterministically by
+    // Complete_AssemblesCleansAndFiles and the other tests that drive
+    // ProcessRecordingAsync synchronously (no background worker); the queue-only
+    // enqueue behavior is covered by Complete_OnlyEnqueues_DoesNotTranscribeInline.
+    [Fact(Skip = "Flaky on CI: races the real background worker tick + status-file write against the poll deadline (fails at RecordingIngestService.SaveStatus; no external dependency to probe). The transcription/SaveStatus path is covered deterministically by the synchronous ProcessRecordingAsync tests in this file.")]
     public async Task Worker_TranscribesQueuedRecording_EndToEnd()
     {
         // The real background worker (runWorker: true) must drain the queue with

--- a/src/CcDirector.Core.Tests/SessionLifecycleTests.cs
+++ b/src/CcDirector.Core.Tests/SessionLifecycleTests.cs
@@ -155,7 +155,19 @@ public class SessionLifecycleTests : IDisposable
         _manager.RemoveSession(Guid.NewGuid());
     }
 
-    [Fact]
+    // This test spawns two REAL stand-in shell processes (cmd.exe / sh) and then
+    // asserts both report SessionStatus.Running immediately after creation, before
+    // killing them. That post-create assertion races the real process: under load on
+    // a continuous integration runner the stand-in can already have been observed as
+    // exited by the time the assertion runs (observed failure "Expected Running,
+    // Actual Exited"), even though the kill behavior under test is correct. There is
+    // no external dependency to probe here - it is an irreducible real-process timing
+    // race - so it is statically quarantined, matching the existing ConPty convention
+    // (see SessionEdgeCaseTests.ConcurrentSessionCreation_AllSucceed and
+    // NulFileWatcherTests). The deterministic kill/lifecycle behavior is still covered
+    // by KillSession_RunningSession_TransitionsToExited, KillSession_AlreadyExited_DoesNotThrow,
+    // and KillAllSessions_NoSessions_DoesNotThrow in this same file, plus Dispose_DisposesAllSessions.
+    [Fact(Skip = "Flaky on CI: races real stand-in process spawns; the post-create Running assertion can observe Exited under load (no external dependency to probe). Kill/lifecycle behavior is covered deterministically by the other KillSession tests in this file.")]
     public async Task KillAllSessions_KillsAllRunning()
     {
         var s1 = _manager.CreateSession(Path.GetTempPath());

--- a/src/CcDirector.Gateway.Tests/DictationEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationEndpointTests.cs
@@ -132,7 +132,24 @@ public sealed class DictationEndpointTests : IAsyncLifetime
         Assert.Contains("pcm16-writer", body);
     }
 
-    [Fact]
+    // This end-to-end test needs a LIVE OpenAI Realtime streaming speech-to-text
+    // provider (reachable WebSocket + a valid OPENAI_API_KEY) AND ffmpeg on PATH to
+    // decode the Phase 0 clip; the continuous integration runner has none of these, so
+    // it cannot run there. Even where the dependency IS present it asserts
+    // partialsObserved >= 1, which races the live provider's nondeterministic
+    // mid-stream partial emission - the Realtime API does not guarantee a partial
+    // transcript arrives before the final within the deadline (observed CI/local
+    // failure "expected at least 1 partial transcript, got 0"). So it is statically
+    // quarantined, naming the missing dependency and the race, matching the existing
+    // convention. The dictate WebSocket protocol, served assets, and 400-on-non-upgrade
+    // behavior are covered deterministically by DictatePage_is_served,
+    // NonWebSocketGet_to_dictate_returns_400, and WorkletScript_is_served in this same
+    // file; the realtime provider's connect/retry and protocol parsing are covered
+    // offline by OpenAiRealtimeProviderConnectTests and OpenAiRealtimeProtocolTests; the
+    // capture-first pipeline is covered by DictationPipelineTests. The only thing not
+    // run on CI is the single live full-stack transcription, which requires the
+    // environment-gated provider.
+    [Fact(Skip = "Requires a live OpenAI Realtime streaming speech-to-text provider (reachable WebSocket + OPENAI_API_KEY) and ffmpeg on PATH, absent on CI runners; also races the live provider's nondeterministic partial-transcript emission (the partialsObserved >= 1 assertion). Protocol/asset/connect coverage runs deterministically elsewhere (see comment).")]
     public async Task FullPipeline_transcribes_phase0_clip2_with_realtime_provider()
     {
         var audioPath = FindClip2Mp3();


### PR DESCRIPTION
Closes #566.

## What this does

Makes the continuous integration "Build & Test (.NET)" gate deterministically green by quarantining three tests that intermittently fail on the runner for reasons unrelated to the change under test. Each uses a static `[Fact(Skip = ...)]` (both test projects are xUnit version 2, which has no dynamic skip), with the reason naming the missing dependency or the race - matching the existing ConPty and NUL precedent in the tree.

## Tests addressed

| Test | Mechanism | Reason | Remaining deterministic coverage |
|---|---|---|---|
| `RecordingIngestServiceTests.Worker_TranscribesQueuedRecording_EndToEnd` | static quarantine | irreducible background-worker plus filesystem timing race; fails at `RecordingIngestService.SaveStatus` (observed on pull request 561 and post-merge main, passed on re-run); no external dependency to probe | the transcription plus SaveStatus path is covered by `Complete_AssemblesCleansAndFiles` and the other synchronous `ProcessRecordingAsync` tests; enqueue by `Complete_OnlyEnqueues_DoesNotTranscribeInline` |
| `DictationEndpointTests.FullPipeline_transcribes_phase0_clip2_with_realtime_provider` | static quarantine (runtime self-skip guards kept in body) | needs a live OpenAI Realtime streaming provider (WebSocket plus key) and ffmpeg, absent on the runner; also races the provider's nondeterministic partial emission ("expected at least 1 partial transcript, got 0") | served assets and 400 behavior by `DictatePage_is_served`, `NonWebSocketGet_to_dictate_returns_400`, `WorkletScript_is_served`; provider connect/retry/protocol offline by `OpenAiRealtimeProviderConnectTests` and `OpenAiRealtimeProtocolTests`; pipeline by `DictationPipelineTests`. Only the single live full-stack transcription is now environment-gated. |
| `SessionLifecycleTests.KillAllSessions_KillsAllRunning` | static quarantine | real-process timing race: the post-create `Running` assertion can observe `Exited` under load ("Expected Running, Actual Exited"); no external dependency to probe | kill/lifecycle covered by `KillSession_RunningSession_TransitionsToExited`, `KillSession_AlreadyExited_DoesNotThrow`, `KillAllSessions_NoSessions_DoesNotThrow`, `Dispose_DisposesAllSessions` |

No behavior loses its only deterministic coverage.

## Sweep

Swept both test projects for tests hitting a live network or provider, an installed external command-line tool, or real multi-process timing. All others already self-skip with an early `return` when their dependency is absent (the runner sets neither `OPENAI_API_KEY` nor an opt-in variable, and has no ffmpeg), so they do not run and cannot fail on the bare runner: `CleanupOrchestratorLiveTests`, `DictationPipelineLiveTests`, `OpenAiRealtimeProviderIntegrationTests`, `WingmanAnswerLiveTests` (opt-in `WINGMAN_LIVE_TESTS`), `RecordingEndpointsE2ETests` (opt-in `CC_REC_E2E`), `EndToEnd_RealTranscription_Phase0Clips_PreservesCompanyTerms`, and `ClientCloseWithoutStop_recovers_transcript_instead_of_discarding`. Details in the proof note.

## Local results

- `dotnet build cc-director.sln -c Release`: Build succeeded, 0 warnings, 0 errors.
- `dotnet test src/CcDirector.Core.Tests`: Failed 0, Passed 2141, Skipped 6.
- `dotnet test src/CcDirector.Gateway.Tests`: Failed 0, Passed 837, Skipped 1.

All three addressed tests confirmed Skipped in the run output.

## Note on the three-green-runs acceptance criterion

The acceptance criterion of three consecutive green continuous integration runs on a no-op change is verified post-merge by a human or the quality assurance agent; this change does not push three times. The diff and the local green run are the developer-side proof, bundled under `docs/cencon/proof/issue-566/addressed-tests.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)