### PR TITLE
fix(installer): drop the unwired repair-tools verb from the cc-* shim message

### DIFF
--- a/tools/cc-director-setup-engine.Tests/PythonToolsHealAndShimTests.cs
+++ b/tools/cc-director-setup-engine.Tests/PythonToolsHealAndShimTests.cs
@@ -233,6 +233,6 @@ public sealed class PythonToolsHealAndShimTests : IDisposable
 
         Assert.NotEqual(0, p.ExitCode); // non-zero, not cmd.exe's raw "is not recognized" (which is exit 9009 but with no guidance)
         Assert.Contains("not fully installed", output, StringComparison.Ordinal);
-        Assert.Contains("repair-tools", output, StringComparison.Ordinal);
+        Assert.Contains("Fix it", output, StringComparison.Ordinal); // points only at the live repair path (Home > Fix it)
     }
 }

--- a/tools/cc-director-setup-engine/PythonToolsInstaller.cs
+++ b/tools/cc-director-setup-engine/PythonToolsInstaller.cs
@@ -383,7 +383,7 @@ public sealed class PythonToolsInstaller
     internal static string BuildWindowsShimBody(string script) =>
         "@echo off\r\n"
         + $"if not exist \"%~dp0..\\pyenv\\Scripts\\{script}.exe\" (\r\n"
-        + $"  echo cc-* tools are not fully installed - run the repair: Home ^> Fix it, or cc-director-setup-cli repair-tools 1^>^&2\r\n"
+        + $"  echo cc-* tools are not fully installed - run the repair: Home ^> Fix it 1^>^&2\r\n"
         + "  exit /b 1\r\n"
         + ")\r\n"
         + $"\"%~dp0..\\pyenv\\Scripts\\{script}.exe\" %*\r\n";


### PR DESCRIPTION
Follow-up to #577/#578. The self-checking shim's guidance pointed at both 'Home > Fix it' (works) and 'cc-director-setup-cli repair-tools' (a CLI verb that is not wired). Keep only the live path. Test updated to assert the 'Fix it' guidance.

Engine tests: 8/8 pass (incl. the shim-body test). Build clean.