### PR TITLE
feat(#583): Director credential store and offline logged-in check

### DIFF
--- a/docs/cencon/architecture_manifest.yaml
+++ b/docs/cencon/architecture_manifest.yaml
@@ -473,6 +473,15 @@ containers:
       - name: AboutInfo
         description: Assembles the About/diagnostics payload (version, build, URLs, installed components) shared by the Director About dialog and the Cockpit /about page
         file: Diagnostics/AboutInfo.cs
+      - name: DevThrottleAccountService
+        description: The DevThrottle account credential and authentication service (issue #583) - the foundation for log-in-once-online-then-run-offline. Receives the access-plus-refresh token pair from the login-completion flow, stores it in the operating system credential store (encrypted at rest via the IProtectedTokenStore binding), answers "is this install logged in?" locally with NO network call (JwtAccessTokenValidator signature + expiry only), renews the access token in the background using the refresh token when online (ITokenRefresher), keeps running on the cached credential when offline, and clears the credential on logout. Records a logged-in event on first store and a logout event on clear via AuthEventLog (the always-on authentication floor; richer telemetry is #582). Distinct from ClaudeAccountStore (the Claude sign-in account at accounts.json, a different concern). The single foundation the startup gate (#580), first-run login (#581), and account area (#582) build on.
+        files:
+          - Account/DevThrottleAccountService.cs
+          - Account/DevThrottleTokens.cs
+          - Account/IProtectedTokenStore.cs
+          - Account/JwtAccessTokenValidator.cs
+          - Account/AuthEventLog.cs
+          - Account/ITokenRefresher.cs
 
   - id: native_apis
     name: Platform-Specific APIs
@@ -505,6 +514,9 @@ containers:
         files:
           - ConPty/ProcessHost.cs
           - UnixPty/UnixProcessHost.cs
+      - name: Windows Data Protection credential store (Windows only)
+        description: The operating system credential store binding for the DevThrottle account (issue #583). WindowsProtectedTokenStore encrypts the account token pair at rest with Windows Data Protection (the DPAPI, via System.Security.Cryptography.ProtectedData, CurrentUser scope) so the raw token is never written to disk in plain text; only the same Windows user on the same machine can decrypt it. Implements IProtectedTokenStore (CcDirector.Core) so the macOS Keychain can be a later drop-in.
+        file: Account/WindowsProtectedTokenStore.cs
 
   - id: communication_manager
     name: Communication Manager

--- a/docs/cencon/proof/issue-583/director-log-excerpt.log
+++ b/docs/cencon/proof/issue-583/director-log-excerpt.log
@@ -1,0 +1,41 @@
+﻿2026-06-21 01:30:58.067 [WindowsProtectedTokenStore] ctor: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin
+2026-06-21 01:30:58.069 [DevThrottleAccountService] IsLoggedIn: checking cached credential locally (no network call)
+2026-06-21 01:30:58.070 [WindowsProtectedTokenStore] Load: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin, exists=False
+2026-06-21 01:30:58.070 [DevThrottleAccountService] IsLoggedIn: no stored credential -> false
+2026-06-21 01:30:58.107 [DevThrottleAccountService] StoreTokens: storing token pair in credential store
+2026-06-21 01:30:58.107 [WindowsProtectedTokenStore] Save: encrypting token pair to credential store
+2026-06-21 01:30:58.115 [WindowsProtectedTokenStore] Save: wrote 422 encrypted bytes
+2026-06-21 01:30:58.115 [AuthEventLog] RecordLoggedIn
+2026-06-21 01:30:58.119 [DevThrottleAccountService] StoreTokens: stored
+2026-06-21 01:30:58.126 [DevThrottleAccountService] IsLoggedIn: checking cached credential locally (no network call)
+2026-06-21 01:30:58.126 [WindowsProtectedTokenStore] Load: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin, exists=True
+2026-06-21 01:30:58.129 [WindowsProtectedTokenStore] Load: decrypted token pair (hasTokens=True)
+2026-06-21 01:30:58.131 [JwtAccessTokenValidator] Validate: signature OK, expiresAtUtc=2026-06-21T06:30:58.0000000Z, expired=False
+2026-06-21 01:30:58.131 [DevThrottleAccountService] IsLoggedIn: valid=True, expiredButWellFormed=False, result=True (no network call)
+2026-06-21 01:30:58.131 [WindowsProtectedTokenStore] Save: encrypting token pair to credential store
+2026-06-21 01:30:58.132 [WindowsProtectedTokenStore] Save: wrote 422 encrypted bytes
+2026-06-21 01:30:58.132 [DevThrottleAccountService] IsLoggedIn: checking cached credential locally (no network call)
+2026-06-21 01:30:58.132 [WindowsProtectedTokenStore] Load: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin, exists=True
+2026-06-21 01:30:58.138 [WindowsProtectedTokenStore] Load: decrypted token pair (hasTokens=True)
+2026-06-21 01:30:58.138 [JwtAccessTokenValidator] Validate: signature does not verify (tampered or wrong key)
+2026-06-21 01:30:58.138 [DevThrottleAccountService] IsLoggedIn: valid=False, expiredButWellFormed=False, result=False (no network call)
+2026-06-21 01:30:58.138 [WindowsProtectedTokenStore] Save: encrypting token pair to credential store
+2026-06-21 01:30:58.138 [WindowsProtectedTokenStore] Save: wrote 422 encrypted bytes
+2026-06-21 01:30:58.144 [DevThrottleAccountService] RefreshIfNeededAsync: evaluating cached credential
+2026-06-21 01:30:58.144 [WindowsProtectedTokenStore] Load: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin, exists=True
+2026-06-21 01:30:58.144 [WindowsProtectedTokenStore] Load: decrypted token pair (hasTokens=True)
+2026-06-21 01:30:58.144 [JwtAccessTokenValidator] Validate: signature OK, expiresAtUtc=2026-06-21T04:30:58.0000000Z, expired=True
+2026-06-21 01:30:58.144 [DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh
+2026-06-21 01:30:58.144 [WindowsProtectedTokenStore] Save: encrypting token pair to credential store
+2026-06-21 01:30:58.145 [WindowsProtectedTokenStore] Save: wrote 422 encrypted bytes
+2026-06-21 01:30:58.145 [DevThrottleAccountService] RefreshIfNeededAsync: refreshed access token stored
+2026-06-21 01:30:58.152 [WindowsProtectedTokenStore] Load: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin, exists=True
+2026-06-21 01:30:58.152 [WindowsProtectedTokenStore] Load: decrypted token pair (hasTokens=True)
+2026-06-21 01:30:58.153 [DevThrottleAccountService] Logout: clearing credential store
+2026-06-21 01:30:58.153 [WindowsProtectedTokenStore] Clear: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin, exists=True
+2026-06-21 01:30:58.153 [AuthEventLog] RecordLoggedOut
+2026-06-21 01:30:58.154 [DevThrottleAccountService] Logout: cleared
+2026-06-21 01:30:58.154 [DevThrottleAccountService] IsLoggedIn: checking cached credential locally (no network call)
+2026-06-21 01:30:58.154 [WindowsProtectedTokenStore] Load: blobPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin, exists=False
+2026-06-21 01:30:58.154 [DevThrottleAccountService] IsLoggedIn: no stored credential -> false
+2026-06-21 01:30:58.154 [AuthEventLog] ReadAll: logPath=%TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-auth-events.jsonl, exists=True

--- a/docs/cencon/proof/issue-583/proof-output.txt
+++ b/docs/cencon/proof/issue-583/proof-output.txt
@@ -1,0 +1,49 @@
+﻿===== Issue #583 LIVE PROOF: Director credential store + offline logged-in check =====
+Config dir (clean profile): %TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896
+
+[PASS] AC3 clean profile: IsLoggedIn() with no stored credential returns false
+        Expected: false
+        Actual:   False
+
+[PASS] AC1 store entry exists after storing the token pair
+        Expected: file exists at %TEMP%\dt583-proof-8d8a276b6ada4285a4e449ae10f52896\devthrottle-credential.bin
+        Actual:   exists
+[PASS] AC1 raw token string does NOT appear in plain text anywhere under the config dir
+        Expected: no file under config dir contains the raw token string
+        Actual:   no match found (encrypted at rest)
+        DPAPI blob: 422 bytes, first 16 hex: 01000000D08C9DDF0115D1118C7A00C0
+
+[PASS] AC2 offline IsLoggedIn() returns true from the cached credential alone
+        Expected: true
+        Actual:   True
+[PASS] AC2 IsLoggedIn() made NO outbound network call
+        Expected: refresher (the only network seam) never invoked
+        Actual:   never invoked
+
+[PASS] AC5 tampered/wrong-signature cached access token is treated as NOT logged in
+        Expected: false
+        Actual:   False
+
+[PASS] AC4 background refresh renewed the access token with no user action
+        Expected: RefreshIfNeededAsync returns true and the stored access token is the renewed one
+        Actual:   returned True, stored access token matches renewed = True
+[PASS] AC4 the store entry changed (DPAPI blob bytes differ before vs after refresh)
+        Expected: blob bytes differ
+        Actual:   blob changed
+
+[PASS] AC6 logout clears the store (DPAPI blob removed)
+        Expected: blob file removed
+        Actual:   removed
+[PASS] AC6 the next IsLoggedIn() returns false after logout
+        Expected: false
+        Actual:   False
+[PASS] AC6 a logout event was recorded (and a logged-in event on first store)
+        Expected: auth-event log contains logged-in and logout
+        Actual:   logged-in=True, logout=True
+        auth-events.jsonl contents:
+          logged-in @ 2026-06-21T05:30:58.1156516Z
+          logout @ 2026-06-21T05:30:58.1537681Z
+
+===== RESULT: 11 checks passed, 0 failed =====
+FileLog written to: %LOCALAPPDATA%\cc-director\logs\director\director-2026-06-21-42088.log
+Log excerpt (41 lines) written to: D:\ReposFred\devthrottle-wt-583\docs\cencon\proof\issue-583\director-log-excerpt.log

--- a/docs/cencon/proof/issue-583/qa-independent-harness-output.txt
+++ b/docs/cencon/proof/issue-583/qa-independent-harness-output.txt
@@ -1,0 +1,22 @@
+QA ROOT (isolated CC_DIRECTOR_ROOT) = C:\Users\soren\AppData\Local\Temp\qa-583-root-1191cccad50f4e178382db26322027fe
+Credential blob path = C:\Users\soren\AppData\Local\Temp\qa-583-root-1191cccad50f4e178382db26322027fe\config\director\devthrottle-credential.bin
+Auth events log path = C:\Users\soren\AppData\Local\Temp\qa-583-root-1191cccad50f4e178382db26322027fe\config\director\devthrottle-auth-events.jsonl
+
+[PASS] AC3 clean-profile check returns false: IsLoggedIn()=False, refresherCalled=False
+[PASS] AC1 tokens written to DPAPI store: blob exists=True
+[PASS] AC1 raw token NOT in plaintext under config dir: no plaintext match anywhere under root
+[PASS] AC1 blob carries DPAPI CurrentUser magic header: first4=[01 00 00 00], len=454
+[PASS] AC2 offline check returns true from cache: IsLoggedIn()=True
+[PASS] AC2 offline check made NO network call: refresher invoked=False
+[PASS] AC(event) logged-in event recorded on first store: events=[logged-in]
+[PASS] AC5 tampered token treated as NOT logged in: IsLoggedIn()=False
+[PASS] AC5 wrong-signature token treated as NOT logged in: IsLoggedIn()=False
+[PASS] AC4 background refresh ran for expired+valid-refresh: refreshed=True, refresherCalled=True
+[PASS] AC4 store entry changed after refresh: blob changed=True
+[PASS] AC4 renewed token is now valid (logged in): IsLoggedIn()=True
+[PASS] AC4 offline refresh declines gracefully, keeps cached credential: refreshed=False, stillLoggedIn=True
+[PASS] AC6 logout clears the store: blob exists=False
+[PASS] AC6 next check after logout returns false: IsLoggedIn()=False
+[PASS] AC6 logout event recorded: events=[logged-in,logout]
+
+RESULT: 16 passed, 0 failed

--- a/docs/cencon/proof/issue-583/qa-report.html
+++ b/docs/cencon/proof/issue-583/qa-report.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #583 (Director credential store and offline logged-in check)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; line-height: 1.5; }
+  h1 { font-size: 1.5rem; }
+  h2 { font-size: 1.2rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: 0.3rem; }
+  table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+  th, td { border: 1px solid #ccc; padding: 0.5rem 0.7rem; text-align: left; vertical-align: top; font-size: 0.92rem; }
+  th { background: #f0f0f0; }
+  .pass { color: #0a7a0a; font-weight: bold; }
+  .verdict { background: #e6ffe6; border: 2px solid #0a7a0a; padding: 1rem; margin-top: 2rem; font-weight: bold; }
+  code, pre { font-family: Consolas, monospace; font-size: 0.85rem; }
+  pre { background: #f6f6f6; padding: 0.8rem; overflow-x: auto; border: 1px solid #ddd; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #583</h1>
+<p><strong>Title:</strong> [Account] Director credential store and offline logged-in check<br>
+<strong>Pull request:</strong> #595 (branch <code>issue-583-credential-store</code>)<br>
+<strong>QA method:</strong> Independent verification per the CenCon QA Agent role. The QA session built
+the pull-request branch in its own checkout, ran the full Core test suite, and exercised every
+acceptance criterion end-to-end through its OWN harness against the REAL Windows Data Protection
+(DPAPI) credential store - the developer's binary and screenshots were not reused.</p>
+
+<h2>Build and regression</h2>
+<table>
+<tr><th>Check</th><th>Result</th></tr>
+<tr><td><code>dotnet build cc-director.sln</code></td><td class="pass">Build succeeded. 0 Warning(s), 0 Error(s) (TreatWarningsAsErrors)</td></tr>
+<tr><td><code>dotnet test src/CcDirector.Core.Tests</code> (full regression sweep)</td><td class="pass">2163 passed, 0 failed, 6 skipped (skips are unrelated nul-file watcher tests)</td></tr>
+<tr><td>Account-area unit tests (developer's 22 plus adjacent)</td><td class="pass">45 passed, 0 failed</td></tr>
+<tr><td>CenCon doc-drift: <code>docs/cencon/architecture_manifest.yaml</code></td><td class="pass">Updated - DevThrottleAccountService recorded under core_services; WindowsProtectedTokenStore recorded under native_apis</td></tr>
+<tr><td>Security lens (token never logged / never plaintext at rest)</td><td class="pass">FileLog calls log status/counts only; AuthEventLog stores kind+timestamp only; blob DPAPI-encrypted (verified)</td></tr>
+</table>
+
+<h2>Acceptance criteria - independent end-to-end verification</h2>
+<p>Run against the real DPAPI store inside an isolated <code>CC_DIRECTOR_ROOT</code> so the entire
+config directory could be grepped (text and raw bytes) for the plaintext token marker. A recording
+refresher captured whether the network seam was ever invoked. Full output in
+<code>qa-independent-harness-output.txt</code>.</p>
+<table>
+<tr><th>#</th><th>Acceptance criterion</th><th>Expected</th><th>Actual (QA)</th><th>Verdict</th></tr>
+<tr><td>1</td><td>Test token pair stored in DPAPI store; raw token not found in plaintext under the config directory</td><td>Blob written; no plaintext match; encrypted at rest</td><td>Blob exists; DPAPI CurrentUser magic header <code>01 00 00 00</code> present (454 bytes); grep of every file under the root found no plaintext or raw-byte match for the access or refresh markers</td><td class="pass">PASS</td></tr>
+<tr><td>2</td><td>With networking disabled, "is this install logged in?" returns true from cache with no outbound network call</td><td>true; no network call</td><td><code>IsLoggedIn()=True</code>; recording refresher provably never invoked (<code>Called=False</code>)</td><td class="pass">PASS</td></tr>
+<tr><td>3</td><td>With no stored credential, the check returns false (clean profile)</td><td>false</td><td><code>IsLoggedIn()=False</code> on the clean isolated profile; refresher not called</td><td class="pass">PASS</td></tr>
+<tr><td>4</td><td>Expired access + valid refresh + online: background refresh renews with no user action; store entry changes</td><td>renews; store changes</td><td><code>RefreshIfNeededAsync()=True</code>; refresher invoked; blob bytes changed before vs after; renewed token then validates as logged in. Offline (refresher returns null) declines gracefully and keeps the cached credential.</td><td class="pass">PASS</td></tr>
+<tr><td>5</td><td>Tampered / wrong-signature cached token treated as not logged in</td><td>false</td><td>Final-byte-flipped token -> <code>IsLoggedIn()=False</code>; valid-structure-but-wrong-key token -> <code>IsLoggedIn()=False</code></td><td class="pass">PASS</td></tr>
+<tr><td>6</td><td>Logout clears the store, the next check returns false, and a logout event is recorded</td><td>store empty; false; logout event</td><td>Blob deleted; <code>IsLoggedIn()=False</code>; event log = <code>[logged-in, logout]</code> (logged-in recorded on first store, logout on clear)</td><td class="pass">PASS</td></tr>
+</table>
+
+<h2>Harness output (QA-produced, against the real DPAPI store)</h2>
+<pre>QA ROOT (isolated CC_DIRECTOR_ROOT) = ...Temp\qa-583-root-...
+[PASS] AC3 clean-profile check returns false: IsLoggedIn()=False, refresherCalled=False
+[PASS] AC1 tokens written to DPAPI store: blob exists=True
+[PASS] AC1 raw token NOT in plaintext under config dir: no plaintext match anywhere under root
+[PASS] AC1 blob carries DPAPI CurrentUser magic header: first4=[01 00 00 00], len=454
+[PASS] AC2 offline check returns true from cache: IsLoggedIn()=True
+[PASS] AC2 offline check made NO network call: refresher invoked=False
+[PASS] AC(event) logged-in event recorded on first store: events=[logged-in]
+[PASS] AC5 tampered token treated as NOT logged in: IsLoggedIn()=False
+[PASS] AC5 wrong-signature token treated as NOT logged in: IsLoggedIn()=False
+[PASS] AC4 background refresh ran for expired+valid-refresh: refreshed=True, refresherCalled=True
+[PASS] AC4 store entry changed after refresh: blob changed=True
+[PASS] AC4 renewed token is now valid (logged in): IsLoggedIn()=True
+[PASS] AC4 offline refresh declines gracefully, keeps cached credential: refreshed=False, stillLoggedIn=True
+[PASS] AC6 logout clears the store: blob exists=False
+[PASS] AC6 next check after logout returns false: IsLoggedIn()=False
+[PASS] AC6 logout event recorded: events=[logged-in,logout]
+
+RESULT: 16 passed, 0 failed</pre>
+
+<div class="verdict">VERIFIED - all 6 acceptance criteria met. Build clean (0 warnings, 0 errors), full
+Core regression suite green (2163 passed), architecture manifest updated, no security-rule violation.
+Issue #583 PASSES QA.</div>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-583/report.html
+++ b/docs/cencon/proof/issue-583/report.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Proof - Issue #583 Director credential store and offline logged-in check</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1e1e1e; max-width: 1000px; }
+  h1 { font-size: 1.4rem; }
+  h2 { font-size: 1.1rem; margin-top: 1.8rem; border-bottom: 1px solid #ccc; padding-bottom: 0.3rem; }
+  table { border-collapse: collapse; width: 100%; margin: 0.8rem 0; }
+  th, td { border: 1px solid #bbb; padding: 0.5rem 0.7rem; text-align: left; vertical-align: top; font-size: 0.9rem; }
+  th { background: #f0f0f0; }
+  .pass { color: #0a7a0a; font-weight: bold; }
+  code, pre { font-family: Consolas, monospace; font-size: 0.85rem; }
+  pre { background: #f6f6f6; border: 1px solid #ddd; padding: 0.8rem; overflow-x: auto; white-space: pre-wrap; }
+  .note { background: #fffbe6; border: 1px solid #e6d27a; padding: 0.6rem 0.9rem; border-radius: 4px; }
+</style>
+</head>
+<body>
+<h1>Proof Report - Issue #583</h1>
+<p><strong>[Account] Director credential store and offline logged-in check</strong> - store account
+tokens in the operating system credential store, verify offline, refresh online.</p>
+
+<h2>What was implemented</h2>
+<p>A greenfield DevThrottle credential and authentication service in the Core layer
+(<code>CcDirector.Core</code>, the <code>core_services</code> container) plus the Windows operating
+system credential store binding (the <code>native_apis</code> container). This is the single
+foundation the startup gate (#580), first-run login (#581), and account area (#582) build on. It is
+distinct from <code>ClaudeAccountStore</code> (the Claude sign-in account, a different concern).</p>
+
+<ul>
+  <li><code>Account/DevThrottleTokens.cs</code> - the access-plus-refresh token pair record.</li>
+  <li><code>Account/IProtectedTokenStore.cs</code> - the operating system credential store binding
+      (interface, so the macOS Keychain can be a later drop-in).</li>
+  <li><code>Account/WindowsProtectedTokenStore.cs</code> - the Windows Data Protection (DPAPI)
+      implementation: serializes the pair to JSON, encrypts it with the current user's data-protection
+      key via <code>System.Security.Cryptography.ProtectedData</code> (CurrentUser scope), and writes
+      an opaque binary blob. The raw token never touches disk in plain text.</li>
+  <li><code>Account/JwtAccessTokenValidator.cs</code> - local-only validation (no network): verifies
+      the access token's HMAC-SHA256 signature against the configured signing secret and checks
+      <code>exp</code>. Distinguishes a genuinely-ours expired token (renewable) from a
+      tampered/wrong-signature token (never logged in).</li>
+  <li><code>Account/ITokenRefresher.cs</code> - the one network-touching seam: exchanges a refresh
+      token for a fresh pair. The offline logged-in check never calls it.</li>
+  <li><code>Account/AuthEventLog.cs</code> - append-only JSON-lines authentication-floor event log
+      (logged-in on first store, logout on clear). Records only kind + timestamp, never the token.</li>
+  <li><code>Account/DevThrottleAccountService.cs</code> - the orchestrator: <code>StoreTokens</code>,
+      <code>IsLoggedIn()</code> (local, no network), <code>RefreshIfNeededAsync</code> (background
+      renew, keeps the cached credential when offline), <code>Logout</code>.</li>
+  <li>Path helpers added to <code>Storage/CcStorage.cs</code>; the
+      <code>System.Security.Cryptography.ProtectedData</code> package added to
+      <code>CcDirector.Core.csproj</code>; the new components recorded in
+      <code>docs/cencon/architecture_manifest.yaml</code>.</li>
+</ul>
+
+<h2>How it was proven</h2>
+<p>Two independent gates:</p>
+<ol>
+  <li><strong>Unit tests</strong> - 22 tests in <code>CcDirector.Core.Tests/Account/</code> (the full
+      <code>Account</code> namespace ran green: 45 passed, 0 failed - the count includes the
+      pre-existing <code>ClaudeAccountStore</code> tests).</li>
+  <li><strong>Live end-to-end proof harness</strong> - a standalone program that exercises the REAL
+      <code>DevThrottleAccountService</code> with the REAL <code>WindowsProtectedTokenStore</code>
+      (real Windows DPAPI) against a real temporary config directory - no storage test doubles. Output
+      captured in <code>proof-output.txt</code>; the service's own enterprise log lines captured in
+      <code>director-log-excerpt.log</code> (paths redacted of the local username). The on-disk DPAPI
+      blob begins with the canonical Windows DPAPI magic header
+      <code>01000000D08C9DDF0115D1118C7A00C0</code>, confirming real operating-system encryption.</li>
+</ol>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>Acceptance criterion</th><th>Expected</th><th>Actual (live proof)</th><th>Result</th></tr>
+  <tr>
+    <td>Stored tokens written to the Windows Data Protection store; a search of everything under the
+        config dir does not find the raw token in plain text.</td>
+    <td>Store entry exists; no plaintext match.</td>
+    <td>422-byte DPAPI blob written (magic header present); grep of the whole config dir for the raw
+        access and refresh token strings (UTF-8 and raw bytes) found no match.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>With networking disabled, the logged-in check returns true from the cache and makes no
+        outbound network call.</td>
+    <td>true; no network call.</td>
+    <td><code>IsLoggedIn()</code> returned true; the only network seam
+        (<code>ITokenRefresher</code>) was provably never invoked; log line
+        <code>IsLoggedIn: ... result=True (no network call)</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>With no stored credential the check returns false (clean profile).</td>
+    <td>false.</td>
+    <td>On the clean temp profile <code>IsLoggedIn()</code> returned false; log line
+        <code>IsLoggedIn: no stored credential -&gt; false</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Expired access token + valid refresh + networking enabled: the service renews the access token
+        in the background with no user action; the store entry changes.</td>
+    <td>Store entry changes; refresh log line.</td>
+    <td><code>RefreshIfNeededAsync</code> returned true and stored the renewed access token; the DPAPI
+        blob bytes differed before vs after; log lines <code>access token expired, attempting
+        background refresh</code> then <code>refreshed access token stored</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>A tampered or wrong-signature cached access token is treated as not logged in.</td>
+    <td>false.</td>
+    <td>After flipping the signature byte, <code>IsLoggedIn()</code> returned false; log line
+        <code>signature does not verify (tampered or wrong key)</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Logout clears the store, the next check returns false, and a logout event is recorded.</td>
+    <td>Empty store; false; logout event logged.</td>
+    <td>The DPAPI blob was removed; next <code>IsLoggedIn()</code> returned false; the auth-event log
+        contained both a <code>logged-in</code> (first store) and a <code>logout</code> event.</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Live proof output</h2>
+<p>See <code>proof-output.txt</code> in this directory. Summary line:
+<code>===== RESULT: 11 checks passed, 0 failed =====</code></p>
+
+<h2>Service log excerpt (AC2 / AC4 highlights)</h2>
+<pre>[DevThrottleAccountService] IsLoggedIn: no stored credential -&gt; false
+[WindowsProtectedTokenStore] Save: wrote 422 encrypted bytes
+[AuthEventLog] RecordLoggedIn
+[JwtAccessTokenValidator] Validate: signature OK, expired=False
+[DevThrottleAccountService] IsLoggedIn: valid=True, expiredButWellFormed=False, result=True (no network call)
+[JwtAccessTokenValidator] Validate: signature does not verify (tampered or wrong key)
+[DevThrottleAccountService] IsLoggedIn: valid=False, expiredButWellFormed=False, result=False (no network call)
+[JwtAccessTokenValidator] Validate: signature OK, expired=True
+[DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh
+[DevThrottleAccountService] RefreshIfNeededAsync: refreshed access token stored
+[AuthEventLog] RecordLoggedOut
+[DevThrottleAccountService] IsLoggedIn: no stored credential -&gt; false</pre>
+<p>Full excerpt in <code>director-log-excerpt.log</code>.</p>
+
+<h2>CenCon impact</h2>
+<p>Added the <code>DevThrottleAccountService</code> family to the <code>core_services</code> container
+and the Windows Data Protection credential store to the <code>native_apis</code> container in
+<code>docs/cencon/architecture_manifest.yaml</code> (both were named in the issue's Affected
+Containers). No blocking security rule (CCD-01..CCD-07 in <code>security_profile.yaml</code>) is
+violated: no hardcoded credentials, no null-forgiving operator, no <code>.Result</code>/<code>.Wait()</code>,
+no PII paths in source; the token is never written to a log. The signing secret is supplied to the
+validator at construction (from configuration / the Key Vault at the wiring point), never hardcoded.</p>
+
+<div class="note">
+<strong>Scope note (assumptions confirmed by the issue):</strong> the browser sign-in page, the token
+hand-back protocol, and account resolution are owned by the internal-repository backend and are OUT of
+this issue. This Director-desktop side is implemented and proven against a test-issued HS256 token pair,
+exactly as the issue authorizes. The live backend exchange is supplied later as an implementation of
+<code>ITokenRefresher</code> (wired with #581). The tokens are treated as Supabase tokens (a signed
+access JWT plus a long-lived refresh token).</div>
+
+<h2>Conclusion</h2>
+<p><strong>I believe this is finished.</strong> Every acceptance criterion is met, proven twice (unit
+tests + a live run against the real operating-system credential store), the full solution builds clean
+(<code>dotnet build cc-director.sln</code> - 0 warnings, 0 errors, under
+<code>TreatWarningsAsErrors</code>), and the CenCon manifest is updated in the same change.</p>
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/Account/AuthEventLogTests.cs
+++ b/src/CcDirector.Core.Tests/Account/AuthEventLogTests.cs
@@ -1,0 +1,45 @@
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+public sealed class AuthEventLogTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _logPath;
+
+    public AuthEventLogTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-dt-events-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _logPath = Path.Combine(_tempDir, "auth-events.jsonl");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void ReadAll_NoLog_ReturnsEmpty()
+    {
+        var log = new AuthEventLog(_logPath);
+
+        Assert.Empty(log.ReadAll());
+    }
+
+    [Fact]
+    public void RecordLoggedInThenLoggedOut_ReadAllReturnsBothInOrder()
+    {
+        var log = new AuthEventLog(_logPath);
+
+        log.RecordLoggedIn();
+        log.RecordLoggedOut();
+
+        var events = log.ReadAll();
+        Assert.Equal(2, events.Count);
+        Assert.Equal(AuthEventLog.LoggedIn, events[0].Kind);
+        Assert.Equal(AuthEventLog.LoggedOut, events[1].Kind);
+    }
+}

--- a/src/CcDirector.Core.Tests/Account/DevThrottleAccountServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DevThrottleAccountServiceTests.cs
@@ -1,0 +1,184 @@
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+public sealed class DevThrottleAccountServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly AuthEventLog _eventLog;
+    private readonly string _eventLogPath;
+    private readonly DateTime _now = new(2026, 6, 21, 12, 0, 0, DateTimeKind.Utc);
+
+    public DevThrottleAccountServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-dt-acct-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _eventLogPath = Path.Combine(_tempDir, "auth-events.jsonl");
+        _eventLog = new AuthEventLog(_eventLogPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private JwtAccessTokenValidator Validator() =>
+        new(TestJwt.SigningSecret, new FixedTime(_now));
+
+    private DevThrottleAccountService MakeService(
+        IProtectedTokenStore store,
+        ITokenRefresher? refresher = null)
+        => new(store, Validator(), _eventLog, refresher ?? new StubTokenRefresher(null));
+
+    // Acceptance criterion: with no stored credential, the check returns false.
+    [Fact]
+    public void IsLoggedIn_NoStoredCredential_ReturnsFalse()
+    {
+        var service = MakeService(new InMemoryTokenStore());
+
+        Assert.False(service.IsLoggedIn());
+    }
+
+    // Acceptance criterion: a valid cached credential returns true (offline - no network call;
+    // the service has no network dependency on this path, and the only network seam, ITokenRefresher,
+    // is provably never invoked here).
+    [Fact]
+    public void IsLoggedIn_ValidCachedCredential_ReturnsTrueWithoutCallingRefresher()
+    {
+        var store = new InMemoryTokenStore();
+        var refresher = new StubTokenRefresher(null);
+        var service = MakeService(store, refresher);
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(1)), "refresh-1"));
+
+        var result = service.IsLoggedIn();
+
+        Assert.True(result);
+        Assert.False(refresher.WasCalled);
+    }
+
+    // Acceptance criterion: an expired-but-well-formed cached credential still reports logged-in
+    // (offline), so the gate does not lock the user out while the background refresh has not run yet.
+    [Fact]
+    public void IsLoggedIn_ExpiredButWellFormedCredential_ReturnsTrueWithoutNetwork()
+    {
+        var store = new InMemoryTokenStore();
+        var refresher = new StubTokenRefresher(null);
+        var service = MakeService(store, refresher);
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(-1)), "refresh-1"));
+
+        var result = service.IsLoggedIn();
+
+        Assert.True(result);
+        Assert.False(refresher.WasCalled);
+    }
+
+    // Acceptance criterion: a tampered/wrong-signature cached access token is treated as not logged in.
+    [Fact]
+    public void IsLoggedIn_TamperedCredential_ReturnsFalse()
+    {
+        var store = new InMemoryTokenStore();
+        var service = MakeService(store);
+        var tampered = TestJwt.Tamper(TestJwt.Create(_now.AddHours(1)));
+        store.Save(new DevThrottleTokens(tampered, "refresh-1"));
+
+        Assert.False(service.IsLoggedIn());
+    }
+
+    // Acceptance criterion: with a cached credential whose access token has expired but whose refresh
+    // token is valid, and networking enabled, the service renews the access token in the background.
+    [Fact]
+    public async Task RefreshIfNeededAsync_ExpiredAccessTokenValidRefresh_RenewsAndStores()
+    {
+        var store = new InMemoryTokenStore();
+        var freshTokens = new DevThrottleTokens(TestJwt.Create(_now.AddHours(2)), "refresh-2");
+        var refresher = new StubTokenRefresher(freshTokens);
+        var service = MakeService(store, refresher);
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(-1)), "refresh-1"));
+
+        var refreshed = await service.RefreshIfNeededAsync();
+
+        Assert.True(refreshed);
+        Assert.True(refresher.WasCalled);
+        Assert.Equal("refresh-1", refresher.ReceivedRefreshToken);
+        var stored = store.Load();
+        Assert.NotNull(stored);
+        Assert.Equal(freshTokens.AccessToken, stored.AccessToken);
+        Assert.Equal("refresh-2", stored.RefreshToken);
+    }
+
+    // Background refresh while offline: the exchange returns nothing, the cached credential is kept.
+    [Fact]
+    public async Task RefreshIfNeededAsync_OfflineExpiredAccessToken_KeepsCachedCredential()
+    {
+        var store = new InMemoryTokenStore();
+        var refresher = new StubTokenRefresher(null);
+        var service = MakeService(store, refresher);
+        var expired = TestJwt.Create(_now.AddHours(-1));
+        service.StoreTokens(new DevThrottleTokens(expired, "refresh-1"));
+
+        var refreshed = await service.RefreshIfNeededAsync();
+
+        Assert.False(refreshed);
+        Assert.True(refresher.WasCalled);
+        var stored = store.Load();
+        Assert.NotNull(stored);
+        Assert.Equal(expired, stored.AccessToken);
+    }
+
+    // A still-valid access token needs no refresh and never calls the network seam.
+    [Fact]
+    public async Task RefreshIfNeededAsync_ValidAccessToken_NoRefresh()
+    {
+        var store = new InMemoryTokenStore();
+        var refresher = new StubTokenRefresher(new DevThrottleTokens("new", "new"));
+        var service = MakeService(store, refresher);
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(1)), "refresh-1"));
+
+        var refreshed = await service.RefreshIfNeededAsync();
+
+        Assert.False(refreshed);
+        Assert.False(refresher.WasCalled);
+    }
+
+    // Acceptance criterion: logout clears the store, the next check returns false, and a logout event
+    // is recorded.
+    [Fact]
+    public void Logout_ClearsStoreNextCheckFalseAndRecordsLogoutEvent()
+    {
+        var store = new InMemoryTokenStore();
+        var service = MakeService(store);
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(1)), "refresh-1"));
+        Assert.True(service.IsLoggedIn());
+
+        service.Logout();
+
+        Assert.False(store.HasTokens);
+        Assert.False(service.IsLoggedIn());
+        var events = _eventLog.ReadAll();
+        Assert.Contains(events, e => e.Kind == AuthEventLog.LoggedOut);
+    }
+
+    // Acceptance criterion (event side): a logged-in event is recorded on first store, and is not
+    // re-recorded on a re-store of an already-logged-in install.
+    [Fact]
+    public void StoreTokens_FirstStore_RecordsLoggedInEventOnce()
+    {
+        var store = new InMemoryTokenStore();
+        var service = MakeService(store);
+
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(1)), "refresh-1"));
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(2)), "refresh-2"));
+
+        var loggedInEvents = _eventLog.ReadAll().Count(e => e.Kind == AuthEventLog.LoggedIn);
+        Assert.Equal(1, loggedInEvents);
+    }
+
+    private sealed class FixedTime : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedTime(DateTime nowUtc) => _now = new DateTimeOffset(nowUtc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/src/CcDirector.Core.Tests/Account/InMemoryTokenStore.cs
+++ b/src/CcDirector.Core.Tests/Account/InMemoryTokenStore.cs
@@ -1,0 +1,28 @@
+using CcDirector.Core.Account;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// In-memory <see cref="IProtectedTokenStore"/> for unit tests. Lets the service logic
+/// (logged-in check, refresh, logout, event recording) be tested cross-platform without touching
+/// the Windows-only Data Protection store. The DPAPI store itself is tested separately in
+/// <see cref="WindowsProtectedTokenStoreTests"/>.
+/// </summary>
+internal sealed class InMemoryTokenStore : IProtectedTokenStore
+{
+    private DevThrottleTokens? _tokens;
+
+    public int SaveCount { get; private set; }
+
+    public bool HasTokens => _tokens is not null;
+
+    public void Save(DevThrottleTokens tokens)
+    {
+        _tokens = tokens;
+        SaveCount++;
+    }
+
+    public DevThrottleTokens? Load() => _tokens;
+
+    public void Clear() => _tokens = null;
+}

--- a/src/CcDirector.Core.Tests/Account/JwtAccessTokenValidatorTests.cs
+++ b/src/CcDirector.Core.Tests/Account/JwtAccessTokenValidatorTests.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+public sealed class JwtAccessTokenValidatorTests
+{
+    private static JwtAccessTokenValidator MakeValidator(DateTime nowUtc)
+    {
+        var time = new FakeTimeProvider(nowUtc);
+        return new JwtAccessTokenValidator(TestJwt.SigningSecret, time);
+    }
+
+    [Fact]
+    public void Validate_WellSignedUnexpiredToken_IsValid()
+    {
+        var now = new DateTime(2026, 6, 21, 12, 0, 0, DateTimeKind.Utc);
+        var validator = MakeValidator(now);
+        var token = TestJwt.Create(now.AddHours(1));
+
+        var result = validator.Validate(token);
+
+        Assert.True(result.IsValid);
+        Assert.False(result.IsExpiredButWellFormed);
+    }
+
+    [Fact]
+    public void Validate_WellSignedExpiredToken_IsExpiredButWellFormed()
+    {
+        var now = new DateTime(2026, 6, 21, 12, 0, 0, DateTimeKind.Utc);
+        var validator = MakeValidator(now);
+        var token = TestJwt.Create(now.AddHours(-1));
+
+        var result = validator.Validate(token);
+
+        Assert.False(result.IsValid);
+        Assert.True(result.IsExpiredButWellFormed);
+    }
+
+    [Fact]
+    public void Validate_TamperedSignature_IsNotValidAndNotWellFormed()
+    {
+        var now = new DateTime(2026, 6, 21, 12, 0, 0, DateTimeKind.Utc);
+        var validator = MakeValidator(now);
+        var token = TestJwt.Tamper(TestJwt.Create(now.AddHours(1)));
+
+        var result = validator.Validate(token);
+
+        Assert.False(result.IsValid);
+        Assert.False(result.IsExpiredButWellFormed);
+    }
+
+    [Fact]
+    public void Validate_TokenSignedWithWrongSecret_IsNotValidAndNotWellFormed()
+    {
+        var now = new DateTime(2026, 6, 21, 12, 0, 0, DateTimeKind.Utc);
+        var validator = MakeValidator(now);
+        var token = TestJwt.Create(now.AddHours(1), secret: "a-completely-different-secret");
+
+        var result = validator.Validate(token);
+
+        Assert.False(result.IsValid);
+        Assert.False(result.IsExpiredButWellFormed);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    public void Validate_MalformedToken_IsNotValid(string token)
+    {
+        var validator = MakeValidator(DateTime.UtcNow);
+
+        var result = validator.Validate(token);
+
+        Assert.False(result.IsValid);
+        Assert.False(result.IsExpiredButWellFormed);
+    }
+
+    [SuppressMessage("Performance", "CA1812", Justification = "Instantiated by tests via MakeValidator.")]
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTime nowUtc) => _now = new DateTimeOffset(nowUtc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/src/CcDirector.Core.Tests/Account/StubTokenRefresher.cs
+++ b/src/CcDirector.Core.Tests/Account/StubTokenRefresher.cs
@@ -1,0 +1,28 @@
+using CcDirector.Core.Account;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Stub <see cref="ITokenRefresher"/> for unit tests. Returns a configured token pair to simulate a
+/// successful backend exchange, or null to simulate being offline / the backend declining. Records
+/// whether it was called and the refresh token it received.
+/// </summary>
+internal sealed class StubTokenRefresher : ITokenRefresher
+{
+    private readonly DevThrottleTokens? _result;
+
+    public StubTokenRefresher(DevThrottleTokens? result)
+    {
+        _result = result;
+    }
+
+    public bool WasCalled { get; private set; }
+    public string? ReceivedRefreshToken { get; private set; }
+
+    public Task<DevThrottleTokens?> RefreshAsync(string refreshToken, CancellationToken ct = default)
+    {
+        WasCalled = true;
+        ReceivedRefreshToken = refreshToken;
+        return Task.FromResult(_result);
+    }
+}

--- a/src/CcDirector.Core.Tests/Account/TestJwt.cs
+++ b/src/CcDirector.Core.Tests/Account/TestJwt.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Builds test-issued HMAC-SHA256 ("HS256") JSON Web Tokens so the credential service can be proven
+/// against a test token pair while the real backend sign-in does not yet exist (issue #583
+/// authorizes this). Mirrors the shape of a Supabase access token: a header declaring HS256, a
+/// payload with an <c>exp</c> claim, and an HMAC-SHA256 signature.
+/// </summary>
+internal static class TestJwt
+{
+    public const string SigningSecret = "test-signing-secret-for-issue-583-credential-store";
+
+    /// <summary>Creates a valid HS256 token signed with <paramref name="secret"/>, expiring at <paramref name="expiresAtUtc"/>.</summary>
+    public static string Create(DateTime expiresAtUtc, string secret = SigningSecret)
+    {
+        var header = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["alg"] = "HS256",
+            ["typ"] = "JWT",
+        }));
+
+        var payload = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["sub"] = "test-user",
+            ["exp"] = new DateTimeOffset(expiresAtUtc, TimeSpan.Zero).ToUnixTimeSeconds(),
+        }));
+
+        var signingInput = $"{header}.{payload}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var signature = Base64Url(hmac.ComputeHash(Encoding.ASCII.GetBytes(signingInput)));
+        return $"{signingInput}.{signature}";
+    }
+
+    /// <summary>Returns the token with its final signature byte flipped, so the signature no longer verifies.</summary>
+    public static string Tamper(string token)
+    {
+        var lastChar = token[^1];
+        var replacement = lastChar == 'A' ? 'B' : 'A';
+        return token[..^1] + replacement;
+    }
+
+    private static string Base64Url(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/src/CcDirector.Core.Tests/Account/WindowsProtectedTokenStoreTests.cs
+++ b/src/CcDirector.Core.Tests/Account/WindowsProtectedTokenStoreTests.cs
@@ -1,0 +1,114 @@
+using System.Runtime.Versioning;
+using System.Text;
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Tests the Windows Data Protection (DPAPI) credential store. Windows-only - the DPAPI is a
+/// Windows API, so these facts no-op on other platforms (guarded by the OnWindows check) and the
+/// class is annotated [SupportedOSPlatform("windows")] so the platform-compatibility analyzer is
+/// satisfied.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsProtectedTokenStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _blobPath;
+
+    public WindowsProtectedTokenStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-dt-dpapi-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _blobPath = Path.Combine(_tempDir, "devthrottle-credential.bin");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static bool OnWindows => OperatingSystem.IsWindows();
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsTheTokenPair()
+    {
+        if (!OnWindows) return;
+
+        var store = new WindowsProtectedTokenStore(_blobPath);
+        var tokens = new DevThrottleTokens("access-abc", "refresh-xyz");
+
+        store.Save(tokens);
+        var loaded = store.Load();
+
+        Assert.True(store.HasTokens);
+        Assert.NotNull(loaded);
+        Assert.Equal("access-abc", loaded.AccessToken);
+        Assert.Equal("refresh-xyz", loaded.RefreshToken);
+    }
+
+    // Acceptance criterion: a search of the stored blob does not find the raw token string in plain
+    // text - the blob is DPAPI-encrypted at rest.
+    [Fact]
+    public void Save_DoesNotWriteRawTokenInPlainText()
+    {
+        if (!OnWindows) return;
+
+        var store = new WindowsProtectedTokenStore(_blobPath);
+        const string rawAccess = "RAW-ACCESS-TOKEN-PLAINTEXT-MARKER-583";
+        const string rawRefresh = "RAW-REFRESH-TOKEN-PLAINTEXT-MARKER-583";
+        store.Save(new DevThrottleTokens(rawAccess, rawRefresh));
+
+        var bytesOnDisk = File.ReadAllBytes(_blobPath);
+        var textOnDisk = Encoding.UTF8.GetString(bytesOnDisk);
+
+        Assert.DoesNotContain(rawAccess, textOnDisk, StringComparison.Ordinal);
+        Assert.DoesNotContain(rawRefresh, textOnDisk, StringComparison.Ordinal);
+        // The ASCII bytes of the token must not appear anywhere in the encrypted blob either.
+        Assert.False(ContainsBytes(bytesOnDisk, Encoding.ASCII.GetBytes(rawAccess)));
+    }
+
+    [Fact]
+    public void Clear_RemovesTheStoredEntry()
+    {
+        if (!OnWindows) return;
+
+        var store = new WindowsProtectedTokenStore(_blobPath);
+        store.Save(new DevThrottleTokens("access", "refresh"));
+        Assert.True(store.HasTokens);
+
+        store.Clear();
+
+        Assert.False(store.HasTokens);
+        Assert.Null(store.Load());
+    }
+
+    [Fact]
+    public void Load_NoStoredEntry_ReturnsNull()
+    {
+        if (!OnWindows) return;
+
+        var store = new WindowsProtectedTokenStore(_blobPath);
+
+        Assert.False(store.HasTokens);
+        Assert.Null(store.Load());
+    }
+
+    private static bool ContainsBytes(byte[] haystack, byte[] needle)
+    {
+        if (needle.Length == 0 || haystack.Length < needle.Length)
+            return false;
+        for (var i = 0; i <= haystack.Length - needle.Length; i++)
+        {
+            var match = true;
+            for (var j = 0; j < needle.Length; j++)
+            {
+                if (haystack[i + j] != needle[j]) { match = false; break; }
+            }
+            if (match) return true;
+        }
+        return false;
+    }
+}

--- a/src/CcDirector.Core/Account/AuthEventLog.cs
+++ b/src/CcDirector.Core/Account/AuthEventLog.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// One always-on authentication-floor event - a "logged-in" recorded the first time a token pair
+/// is stored, or a "logout" recorded when the store is cleared. This is the minimum, always-on
+/// authentication telemetry; the richer, user-controllable telemetry is owned by the account area
+/// (issue #582). The record never carries the token itself.
+/// </summary>
+/// <param name="Kind">The event kind: <c>logged-in</c> or <c>logout</c>.</param>
+/// <param name="At">When the event occurred (UTC).</param>
+public sealed record AuthEvent(string Kind, DateTime At);
+
+/// <summary>
+/// Append-only local record of authentication-floor events, written as JSON-lines under the
+/// Director config directory (one event per line). It records only the event kind and timestamp -
+/// never the access or refresh token - so the log can never leak a credential.
+/// </summary>
+public sealed class AuthEventLog
+{
+    /// <summary>The "logged-in on first store" event kind.</summary>
+    public const string LoggedIn = "logged-in";
+
+    /// <summary>The "logout on clear" event kind.</summary>
+    public const string LoggedOut = "logout";
+
+    private readonly string _logPath;
+
+    /// <summary>
+    /// Creates the log. The default location is the authentication-events file under the Director
+    /// config directory; tests pass an explicit path to a temporary directory.
+    /// </summary>
+    public AuthEventLog(string? logPath = null)
+    {
+        _logPath = logPath ?? CcStorage.DevThrottleAuthEventsLog();
+    }
+
+    /// <summary>Records a "logged-in" event (called the first time a token pair is stored).</summary>
+    public void RecordLoggedIn()
+    {
+        FileLog.Write("[AuthEventLog] RecordLoggedIn");
+        Append(new AuthEvent(LoggedIn, DateTime.UtcNow));
+    }
+
+    /// <summary>Records a "logout" event (called when the store is cleared).</summary>
+    public void RecordLoggedOut()
+    {
+        FileLog.Write("[AuthEventLog] RecordLoggedOut");
+        Append(new AuthEvent(LoggedOut, DateTime.UtcNow));
+    }
+
+    /// <summary>Reads every recorded event in the order it was written, oldest first.</summary>
+    public IReadOnlyList<AuthEvent> ReadAll()
+    {
+        FileLog.Write($"[AuthEventLog] ReadAll: logPath={_logPath}, exists={File.Exists(_logPath)}");
+        if (!File.Exists(_logPath))
+            return Array.Empty<AuthEvent>();
+
+        var events = new List<AuthEvent>();
+        foreach (var line in File.ReadAllLines(_logPath))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            var parsed = JsonSerializer.Deserialize<AuthEvent>(line);
+            if (parsed is not null)
+                events.Add(parsed);
+        }
+        return events;
+    }
+
+    private void Append(AuthEvent authEvent)
+    {
+        var dir = Path.GetDirectoryName(_logPath)
+            ?? throw new InvalidOperationException($"Cannot determine directory for path: {_logPath}");
+        Directory.CreateDirectory(dir);
+        File.AppendAllText(_logPath, JsonSerializer.Serialize(authEvent) + Environment.NewLine);
+    }
+}

--- a/src/CcDirector.Core/Account/DevThrottleAccountService.cs
+++ b/src/CcDirector.Core/Account/DevThrottleAccountService.cs
@@ -1,0 +1,164 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The DevThrottle credential and authentication service - the single foundation the startup gate
+/// (issue #580), the first-run login (issue #581), and the account area (issue #582) build on. It
+/// receives the access-plus-refresh token pair from the login-completion flow, stores it in the
+/// operating system credential store (encrypted at rest), answers "is this install logged in?"
+/// locally with no network call, renews the access token in the background using the refresh token
+/// when connectivity is available, and clears the credential on logout.
+///
+/// This is the DevThrottle account, distinct from the Claude sign-in account store
+/// (<c>ClaudeAccountStore</c>, which holds Claude OAuth credentials as plain-text JSON for a
+/// different purpose). The store binding is injected so Windows Data Protection is used on Windows
+/// and the macOS Keychain can be a later drop-in.
+/// </summary>
+public sealed class DevThrottleAccountService
+{
+    private readonly IProtectedTokenStore _store;
+    private readonly JwtAccessTokenValidator _validator;
+    private readonly AuthEventLog _eventLog;
+    private readonly ITokenRefresher _refresher;
+    private readonly object _gate = new();
+
+    /// <summary>
+    /// Creates the service from its collaborators. None is optional - each one is a real dependency
+    /// the service needs to do its job (no fallback construction).
+    /// </summary>
+    /// <param name="store">The operating system credential store binding (encrypted at rest).</param>
+    /// <param name="validator">The local signature-and-expiry validator (no network).</param>
+    /// <param name="eventLog">The authentication-floor event recorder.</param>
+    /// <param name="refresher">The backend refresh-token exchange (the one network-touching seam).</param>
+    public DevThrottleAccountService(
+        IProtectedTokenStore store,
+        JwtAccessTokenValidator validator,
+        AuthEventLog eventLog,
+        ITokenRefresher refresher)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+        _eventLog = eventLog ?? throw new ArgumentNullException(nameof(eventLog));
+        _refresher = refresher ?? throw new ArgumentNullException(nameof(refresher));
+    }
+
+    /// <summary>
+    /// Stores the token pair handed back by the login-completion flow in the operating system
+    /// credential store. Records a "logged-in" event the first time a credential is stored on this
+    /// install (a re-store of an already logged-in install does not re-record).
+    /// </summary>
+    public void StoreTokens(DevThrottleTokens tokens)
+    {
+        if (tokens is null)
+            throw new ArgumentNullException(nameof(tokens));
+
+        FileLog.Write("[DevThrottleAccountService] StoreTokens: storing token pair in credential store");
+        lock (_gate)
+        {
+            var wasLoggedInBefore = _store.HasTokens;
+            _store.Save(tokens);
+            if (!wasLoggedInBefore)
+                _eventLog.RecordLoggedIn();
+        }
+        FileLog.Write("[DevThrottleAccountService] StoreTokens: stored");
+    }
+
+    /// <summary>
+    /// Answers "is this install logged in?" entirely from the cached credential, with NO outbound
+    /// network call. Returns true when a stored access token's signature verifies and either has not
+    /// expired or is expired-but-well-formed (a genuinely-ours token that the background refresh can
+    /// renew). Returns false when no credential is stored, the stored entry cannot be decrypted, or
+    /// the access token is tampered / wrong-signature.
+    /// </summary>
+    public bool IsLoggedIn()
+    {
+        FileLog.Write("[DevThrottleAccountService] IsLoggedIn: checking cached credential locally (no network call)");
+
+        DevThrottleTokens? tokens;
+        lock (_gate)
+        {
+            tokens = _store.Load();
+        }
+
+        if (tokens is null)
+        {
+            FileLog.Write("[DevThrottleAccountService] IsLoggedIn: no stored credential -> false");
+            return false;
+        }
+
+        var validation = _validator.Validate(tokens.AccessToken);
+        var loggedIn = validation.IsValid || validation.IsExpiredButWellFormed;
+        FileLog.Write($"[DevThrottleAccountService] IsLoggedIn: valid={validation.IsValid}, expiredButWellFormed={validation.IsExpiredButWellFormed}, result={loggedIn} (no network call)");
+        return loggedIn;
+    }
+
+    /// <summary>
+    /// Renews the access token in the background using the refresh token when the cached access
+    /// token has expired and connectivity is available. When the access token is still valid this
+    /// is a no-op. When the refresh exchange returns no token pair (offline or the backend declines)
+    /// the service keeps running on the cached credential and returns false. Returns true only when
+    /// a renewed token pair was stored.
+    /// </summary>
+    public async Task<bool> RefreshIfNeededAsync(CancellationToken ct = default)
+    {
+        FileLog.Write("[DevThrottleAccountService] RefreshIfNeededAsync: evaluating cached credential");
+
+        DevThrottleTokens? tokens;
+        lock (_gate)
+        {
+            tokens = _store.Load();
+        }
+
+        if (tokens is null)
+        {
+            FileLog.Write("[DevThrottleAccountService] RefreshIfNeededAsync: no stored credential -> nothing to refresh");
+            return false;
+        }
+
+        var validation = _validator.Validate(tokens.AccessToken);
+        if (validation.IsValid)
+        {
+            FileLog.Write("[DevThrottleAccountService] RefreshIfNeededAsync: access token still valid -> no refresh needed");
+            return false;
+        }
+
+        if (!validation.IsExpiredButWellFormed)
+        {
+            FileLog.Write("[DevThrottleAccountService] RefreshIfNeededAsync: access token not renewable (tampered/wrong-signature) -> not refreshing");
+            return false;
+        }
+
+        FileLog.Write("[DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh");
+        var renewed = await _refresher.RefreshAsync(tokens.RefreshToken, ct);
+        if (renewed is null)
+        {
+            FileLog.Write("[DevThrottleAccountService] RefreshIfNeededAsync: refresh unavailable (offline or declined) -> keeping cached credential");
+            return false;
+        }
+
+        lock (_gate)
+        {
+            _store.Save(renewed);
+        }
+        FileLog.Write("[DevThrottleAccountService] RefreshIfNeededAsync: refreshed access token stored");
+        return true;
+    }
+
+    /// <summary>
+    /// Clears the stored credential and records a "logout" event. After this the next
+    /// <see cref="IsLoggedIn"/> returns false.
+    /// </summary>
+    public void Logout()
+    {
+        FileLog.Write("[DevThrottleAccountService] Logout: clearing credential store");
+        lock (_gate)
+        {
+            var wasLoggedIn = _store.HasTokens;
+            _store.Clear();
+            if (wasLoggedIn)
+                _eventLog.RecordLoggedOut();
+        }
+        FileLog.Write("[DevThrottleAccountService] Logout: cleared");
+    }
+}

--- a/src/CcDirector.Core/Account/DevThrottleTokens.cs
+++ b/src/CcDirector.Core/Account/DevThrottleTokens.cs
@@ -1,0 +1,14 @@
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The access-plus-refresh token pair handed to the credential service by the login-completion
+/// flow (a loopback listener or a device-code exchange). These are Supabase tokens: a signed,
+/// short-lived access token (a JSON Web Token) plus a long-lived refresh token.
+///
+/// This pair is the unit the credential service receives, stores in the operating system
+/// credential store, validates locally, and renews in the background. It is never written to
+/// disk in plain text - the store encrypts it at rest.
+/// </summary>
+/// <param name="AccessToken">The signed access token (a JSON Web Token; validated locally for signature and expiry).</param>
+/// <param name="RefreshToken">The long-lived refresh token used to renew the access token when connectivity is available.</param>
+public sealed record DevThrottleTokens(string AccessToken, string RefreshToken);

--- a/src/CcDirector.Core/Account/IProtectedTokenStore.cs
+++ b/src/CcDirector.Core/Account/IProtectedTokenStore.cs
@@ -1,0 +1,31 @@
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The binding to the operating system credential store. The tokens are written here encrypted
+/// at rest - on Windows through Windows Data Protection (the DPAPI, via
+/// <c>System.Security.Cryptography.ProtectedData</c>); the macOS Keychain is a later
+/// implementation of this same interface.
+///
+/// The store deals only in the encrypted token pair: it never exposes the raw bytes to disk in
+/// plain text, and a reader on a different machine or user account cannot decrypt them.
+/// </summary>
+public interface IProtectedTokenStore
+{
+    /// <summary>True when a token pair is currently stored.</summary>
+    bool HasTokens { get; }
+
+    /// <summary>
+    /// Encrypts and writes the token pair to the operating system credential store, replacing any
+    /// existing entry.
+    /// </summary>
+    void Save(DevThrottleTokens tokens);
+
+    /// <summary>
+    /// Reads and decrypts the stored token pair, or returns null when nothing is stored or the
+    /// stored entry cannot be decrypted (for example, copied from another machine).
+    /// </summary>
+    DevThrottleTokens? Load();
+
+    /// <summary>Removes the stored token pair. A no-op when nothing is stored.</summary>
+    void Clear();
+}

--- a/src/CcDirector.Core/Account/ITokenRefresher.cs
+++ b/src/CcDirector.Core/Account/ITokenRefresher.cs
@@ -1,0 +1,18 @@
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// Exchanges a refresh token for a fresh token pair against the DevThrottle backend. This is the
+/// one network-touching seam in the credential service: the live exchange against the
+/// internal-repository backend is supplied as an implementation of this interface, and the offline
+/// logged-in check never calls it. Tests supply a stub so the background-refresh path can be proven
+/// without the live backend (the issue authorizes a test-issued token pair).
+/// </summary>
+public interface ITokenRefresher
+{
+    /// <summary>
+    /// Attempts to renew the token pair using the current refresh token. Returns the new token pair
+    /// when the exchange succeeds, or null when connectivity is unavailable or the backend declines
+    /// (the caller keeps running on the cached credential).
+    /// </summary>
+    Task<DevThrottleTokens?> RefreshAsync(string refreshToken, CancellationToken ct = default);
+}

--- a/src/CcDirector.Core/Account/JwtAccessTokenValidator.cs
+++ b/src/CcDirector.Core/Account/JwtAccessTokenValidator.cs
@@ -1,0 +1,138 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The outcome of validating a cached access token locally. <see cref="IsValid"/> is true only
+/// for a correctly-signed, unexpired token; <see cref="IsExpiredButWellFormed"/> distinguishes a
+/// token that is genuinely ours but past its expiry (renewable with the refresh token) from one
+/// that is malformed or carries a wrong signature (never logged in).
+/// </summary>
+/// <param name="IsValid">True when the signature verifies and the token has not expired.</param>
+/// <param name="IsExpiredButWellFormed">True when the signature verifies but the token is past its expiry.</param>
+/// <param name="ExpiresAtUtc">The token's expiry instant, when present.</param>
+public sealed record AccessTokenValidation(bool IsValid, bool IsExpiredButWellFormed, DateTime? ExpiresAtUtc);
+
+/// <summary>
+/// Validates a cached access token entirely locally - signature and expiry only - with no network
+/// call. DevThrottle access tokens are Supabase JSON Web Tokens signed with HMAC-SHA256 (the
+/// "HS256" algorithm), so the signature is verified against the configured signing secret without
+/// contacting any server. A token with a wrong or tampered signature, an unsupported algorithm, or
+/// a malformed structure is reported as not valid (and not well-formed), so the logged-in check
+/// treats it as not logged in.
+/// </summary>
+public sealed class JwtAccessTokenValidator
+{
+    private readonly byte[] _signingSecret;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Creates the validator with the HMAC-SHA256 signing secret the backend issues tokens with.
+    /// </summary>
+    /// <param name="signingSecret">The shared signing secret used to verify the token's HMAC-SHA256 signature.</param>
+    /// <param name="timeProvider">Time source for expiry checks; defaults to the system clock. Injected so tests control "now".</param>
+    public JwtAccessTokenValidator(string signingSecret, TimeProvider? timeProvider = null)
+    {
+        if (string.IsNullOrEmpty(signingSecret))
+            throw new ArgumentException("Signing secret is required", nameof(signingSecret));
+
+        _signingSecret = Encoding.UTF8.GetBytes(signingSecret);
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Validates the access token's signature and expiry locally. Makes no network call. Returns a
+    /// not-valid, not-well-formed result for a malformed token, an unsupported algorithm, or a wrong
+    /// signature; a valid signature past expiry is reported well-formed-but-expired so the caller can
+    /// renew it with the refresh token.
+    /// </summary>
+    public AccessTokenValidation Validate(string accessToken)
+    {
+        var parts = accessToken?.Split('.') ?? Array.Empty<string>();
+        if (parts.Length != 3)
+        {
+            FileLog.Write("[JwtAccessTokenValidator] Validate: not a three-part JSON Web Token");
+            return new AccessTokenValidation(IsValid: false, IsExpiredButWellFormed: false, ExpiresAtUtc: null);
+        }
+
+        if (!HeaderDeclaresHs256(parts[0]))
+        {
+            FileLog.Write("[JwtAccessTokenValidator] Validate: header does not declare the HMAC-SHA256 algorithm");
+            return new AccessTokenValidation(IsValid: false, IsExpiredButWellFormed: false, ExpiresAtUtc: null);
+        }
+
+        if (!SignatureVerifies(parts[0], parts[1], parts[2]))
+        {
+            FileLog.Write("[JwtAccessTokenValidator] Validate: signature does not verify (tampered or wrong key)");
+            return new AccessTokenValidation(IsValid: false, IsExpiredButWellFormed: false, ExpiresAtUtc: null);
+        }
+
+        var expiresAtUtc = ReadExpiry(parts[1]);
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var expired = expiresAtUtc is not null && expiresAtUtc.Value <= nowUtc;
+
+        FileLog.Write($"[JwtAccessTokenValidator] Validate: signature OK, expiresAtUtc={expiresAtUtc:o}, expired={expired}");
+        return new AccessTokenValidation(IsValid: !expired, IsExpiredButWellFormed: expired, ExpiresAtUtc: expiresAtUtc);
+    }
+
+    private static bool HeaderDeclaresHs256(string encodedHeader)
+    {
+        var headerJson = DecodeSegment(encodedHeader);
+        if (headerJson is null)
+            return false;
+
+        using var doc = JsonDocument.Parse(headerJson);
+        return doc.RootElement.TryGetProperty("alg", out var alg)
+            && string.Equals(alg.GetString(), "HS256", StringComparison.Ordinal);
+    }
+
+    private bool SignatureVerifies(string encodedHeader, string encodedPayload, string encodedSignature)
+    {
+        var signingInput = Encoding.ASCII.GetBytes($"{encodedHeader}.{encodedPayload}");
+        using var hmac = new HMACSHA256(_signingSecret);
+        var expected = hmac.ComputeHash(signingInput);
+
+        var actual = DecodeSegmentBytes(encodedSignature);
+        if (actual is null)
+            return false;
+
+        return CryptographicOperations.FixedTimeEquals(expected, actual);
+    }
+
+    private static DateTime? ReadExpiry(string encodedPayload)
+    {
+        var payloadJson = DecodeSegment(encodedPayload);
+        if (payloadJson is null)
+            return null;
+
+        using var doc = JsonDocument.Parse(payloadJson);
+        if (!doc.RootElement.TryGetProperty("exp", out var exp) || exp.ValueKind != JsonValueKind.Number)
+            return null;
+
+        return DateTimeOffset.FromUnixTimeSeconds(exp.GetInt64()).UtcDateTime;
+    }
+
+    private static string? DecodeSegment(string segment)
+    {
+        var bytes = DecodeSegmentBytes(segment);
+        return bytes is null ? null : Encoding.UTF8.GetString(bytes);
+    }
+
+    private static byte[]? DecodeSegmentBytes(string segment)
+    {
+        // JSON Web Tokens use base64url without padding; restore standard base64 before decoding.
+        var normalized = segment.Replace('-', '+').Replace('_', '/');
+        switch (normalized.Length % 4)
+        {
+            case 2: normalized += "=="; break;
+            case 3: normalized += "="; break;
+        }
+
+        return Convert.TryFromBase64String(normalized, new byte[normalized.Length], out var written)
+            ? Convert.FromBase64String(normalized)
+            : null;
+    }
+}

--- a/src/CcDirector.Core/Account/WindowsProtectedTokenStore.cs
+++ b/src/CcDirector.Core/Account/WindowsProtectedTokenStore.cs
@@ -1,0 +1,81 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// Windows implementation of the operating system credential store, backed by Windows Data
+/// Protection (the DPAPI) through <see cref="ProtectedData"/>. The token pair is serialized to
+/// JSON, encrypted with the current user's data-protection key, and written as an opaque binary
+/// blob under the Director config directory. Because the blob is encrypted at rest, the raw token
+/// string never appears in plain text on disk, and only the same Windows user on the same machine
+/// can decrypt it.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsProtectedTokenStore : IProtectedTokenStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly string _blobPath;
+
+    /// <summary>
+    /// Creates the store. The default location is the encrypted credential blob under the Director
+    /// config directory; tests pass an explicit path to a temporary directory.
+    /// </summary>
+    public WindowsProtectedTokenStore(string? blobPath = null)
+    {
+        _blobPath = blobPath ?? CcStorage.DevThrottleCredentialBlob();
+        FileLog.Write($"[WindowsProtectedTokenStore] ctor: blobPath={_blobPath}");
+    }
+
+    public bool HasTokens => File.Exists(_blobPath);
+
+    public void Save(DevThrottleTokens tokens)
+    {
+        FileLog.Write("[WindowsProtectedTokenStore] Save: encrypting token pair to credential store");
+
+        if (tokens is null)
+            throw new ArgumentNullException(nameof(tokens));
+        if (string.IsNullOrEmpty(tokens.AccessToken))
+            throw new ArgumentException("Access token is required", nameof(tokens));
+
+        var dir = Path.GetDirectoryName(_blobPath)
+            ?? throw new InvalidOperationException($"Cannot determine directory for path: {_blobPath}");
+        Directory.CreateDirectory(dir);
+
+        var plain = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(tokens, JsonOptions));
+        var encrypted = ProtectedData.Protect(plain, optionalEntropy: null, scope: DataProtectionScope.CurrentUser);
+        File.WriteAllBytes(_blobPath, encrypted);
+
+        FileLog.Write($"[WindowsProtectedTokenStore] Save: wrote {encrypted.Length} encrypted bytes");
+    }
+
+    public DevThrottleTokens? Load()
+    {
+        FileLog.Write($"[WindowsProtectedTokenStore] Load: blobPath={_blobPath}, exists={File.Exists(_blobPath)}");
+
+        if (!File.Exists(_blobPath))
+            return null;
+
+        var encrypted = File.ReadAllBytes(_blobPath);
+        var plain = ProtectedData.Unprotect(encrypted, optionalEntropy: null, scope: DataProtectionScope.CurrentUser);
+        var tokens = JsonSerializer.Deserialize<DevThrottleTokens>(Encoding.UTF8.GetString(plain), JsonOptions);
+
+        FileLog.Write($"[WindowsProtectedTokenStore] Load: decrypted token pair (hasTokens={tokens is not null})");
+        return tokens;
+    }
+
+    public void Clear()
+    {
+        FileLog.Write($"[WindowsProtectedTokenStore] Clear: blobPath={_blobPath}, exists={File.Exists(_blobPath)}");
+        if (File.Exists(_blobPath))
+            File.Delete(_blobPath);
+    }
+}

--- a/src/CcDirector.Core/CcDirector.Core.csproj
+++ b/src/CcDirector.Core/CcDirector.Core.csproj
@@ -23,6 +23,9 @@
     <PackageReference Include="Whisper.net" Version="1.8.0" />
     <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
     <PackageReference Include="YamlDotNet" Version="16.2.1" />
+    <!-- Windows Data Protection (DPAPI) for the DevThrottle account credential store - encrypts
+         the account token pair at rest so the raw token is never written to disk in plain text. -->
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -200,6 +200,23 @@ public static class CcStorage
     /// <summary>Communication queue database: config/comm-queue/communications.db</summary>
     public static string CommQueueDb() => Path.Combine(ToolConfig("comm-queue"), "communications.db");
 
+    /// <summary>
+    /// Encrypted DevThrottle account credential blob: config/director/devthrottle-credential.bin.
+    /// The access-plus-refresh token pair is written here encrypted at rest by the operating system
+    /// credential store (Windows Data Protection on Windows), never as plain text. Distinct from the
+    /// Claude sign-in account store (accounts.json) - this is the DevThrottle account.
+    /// </summary>
+    public static string DevThrottleCredentialBlob() =>
+        Path.Combine(ToolConfig("director"), "devthrottle-credential.bin");
+
+    /// <summary>
+    /// DevThrottle authentication-floor event log: config/director/devthrottle-auth-events.jsonl.
+    /// Append-only JSON-lines record of "logged-in" / "logout" events. Records only the event kind
+    /// and timestamp - never the token - so it can never leak a credential.
+    /// </summary>
+    public static string DevThrottleAuthEventsLog() =>
+        Path.Combine(ToolConfig("director"), "devthrottle-auth-events.jsonl");
+
     // -- Life Operating System coaching directories --
 
     /// <summary>Life OS coaching root: vault/life/</summary>


### PR DESCRIPTION
## Release Notes

Adds the DevThrottle account credential and authentication service - the Director-desktop foundation for "log in once online, then run offline". Receives the account token pair, stores it encrypted in the operating system credential store (Windows Data Protection), answers "is this install logged in?" locally with no network call, refreshes the access token in the background when online, and clears on logout. Foundation for the startup gate (#580), first-run login (#581), and account area (#582).

## Changes

- `CcDirector.Core/Account/` (new): `DevThrottleAccountService`, `WindowsProtectedTokenStore` (DPAPI) + `IProtectedTokenStore`, `JwtAccessTokenValidator`, `ITokenRefresher`, `AuthEventLog`, `DevThrottleTokens`.
- `Storage/CcStorage.cs`: credential blob + auth-events path helpers.
- `CcDirector.Core.csproj`: add `System.Security.Cryptography.ProtectedData`.
- `docs/cencon/architecture_manifest.yaml`: record the new components under `core_services` and `native_apis`.
- 22 unit tests in `CcDirector.Core.Tests/Account/`.

## How to Test

1. `dotnet build cc-director.sln` -> 0 warnings, 0 errors.
2. `dotnet test src/CcDirector.Core.Tests --filter FullyQualifiedName~Account` -> all green.
3. Live proof against the real Windows DPAPI store is recorded under `docs/cencon/proof/issue-583/` (`report.html`, `proof-output.txt`, `director-log-excerpt.log`).

## Expected Result

All six acceptance criteria pass: tokens stored encrypted (no plaintext under the config dir), offline check true with no network call, no-credential check false, expired+valid-refresh renews in the background, tampered token treated as not logged in, logout clears the store and records a logout event.

## Before / After

Before: no DevThrottle account credential store; the only related code was the unrelated Claude `ClaudeAccountStore` (plaintext `accounts.json`). After: a credential service that encrypts the account token pair at rest and verifies login offline.

Proof: docs/cencon/proof/issue-583/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)