### PR TITLE
[ControlApi] Agent management REST API under /settings/agents with full Settings-UI parity (#584)

### DIFF
--- a/docs/cencon/proof/issue-584/qa-report.html
+++ b/docs/cencon/proof/issue-584/qa-report.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof - Issue #584 - Agent management REST API under /settings/agents</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; max-width: 1100px; }
+  h1 { border-bottom: 3px solid #5319e7; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #5319e7; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: #f3f0fb; }
+  .pass { color: #0a7d28; font-weight: bold; }
+  .fail { color: #c0202a; font-weight: bold; }
+  code, pre { background: #f6f6f6; border: 1px solid #e0e0e0; border-radius: 4px; padding: .1rem .3rem; font-family: Consolas, monospace; font-size: .85rem; }
+  pre { padding: .8rem; overflow-x: auto; white-space: pre-wrap; }
+  .verdict { background: #e6f7ea; border: 2px solid #0a7d28; padding: 1rem; border-radius: 6px; font-size: 1.1rem; }
+  .meta { color: #555; font-size: .9rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #584</h1>
+<p class="meta">
+  <strong>Title:</strong> [ControlApi] Agent management REST API under /settings/agents with full Settings-UI parity<br>
+  <strong>Pull request:</strong> #603 &middot; branch <code>issue-584-agents-rest-api</code> &middot; commit <code>cc8a463</code><br>
+  <strong>QA method:</strong> Independent verification. The QA Agent did NOT reuse the Developer's binary, tests, or screenshots.
+  The QA Agent built the pull-request branch in its own isolated checkout, then booted the REAL <code>ControlApiHost</code>
+  on an ephemeral loopback port against an ISOLATED config root and drove every acceptance criterion over real HTTP with
+  its own client and its own assertions (Expected vs Actual recorded per criterion). Output reproduced verbatim below.
+</p>
+
+<h2>Verdict</h2>
+<p class="verdict">VERIFIED - all acceptance criteria met. 12/12 criterion-groups PASS in an independent live run against the
+real Control API host. Build clean (0 warnings, 0 errors); developer's 18 end-to-end tests pass; full Gateway.Tests
+regression suite green. No CenCon security rule (DT-01..DT-07) broken; no architecture/security doc change warranted
+(pure additive endpoint behind the existing loopback + auth trust boundary).</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Acceptance criterion</th><th>Expected</th><th>Actual (independent live run)</th><th>Result</th></tr>
+<tr><td>1</td><td>List returns every entry; matches <code>agent.entries</code> in the file</td><td>REST list == file order/count</td><td>REST count=2, ids=[id-claude,id-codex], file count=2</td><td class="pass">PASS</td></tr>
+<tr><td>2</td><td>Get a single entry by id, all values, matching file</td><td>All fields returned</td><td>name=Claude Code, type=ClaudeCode, preset=Standard, model=sonnet, exe=claude, mode=Guided</td><td class="pass">PASS</td></tr>
+<tr><td>3</td><td>Add a new entry; present in file and list afterward</td><td>201 + appears in file + list</td><td>status=201, newId assigned, file count 2-&gt;3, list count=3</td><td class="pass">PASS</td></tr>
+<tr><td>4</td><td>Update each of 8 fields singly; get returns new value, present in file, no other entry changed</td><td>Each field round-trips; sibling + unrelated sections untouched</td><td>displayName, type, enabled, executablePath, presetId, defaultModel, argsOverride, launchMode all round-tripped to file; codex sibling byte-identical; gateway section untouched on every patch</td><td class="pass">PASS</td></tr>
+<tr><td>5</td><td>Remove a named entry; absent from file and list</td><td>Gone from both</td><td>status=200, file count 3-&gt;2, codex absent from file and list</td><td class="pass">PASS</td></tr>
+<tr><td>6</td><td>Reorder; file order matches requested order</td><td>File order == requested</td><td>status=200, requested order == resulting <code>agent.entries</code> order</td><td class="pass">PASS</td></tr>
+<tr><td>7</td><td>Detect: built-in returns resolved path/source/found; custom returns "nothing to detect"</td><td>Built-in resolves; custom says nothing to detect</td><td>builtin: detectable=true, found=true, source=PATH; custom (RawCli): detectable=false, found=false, message="...a custom command has nothing to detect."</td><td class="pass">PASS</td></tr>
+<tr><td>8</td><td>Quick check returns success flag + message and persists validation status the way the tab does</td><td>Result returned; status in config.json</td><td>ok=false (bogus path), message returned; <code>config.json agent_status.claude.ok=false</code> with <code>tested_at_utc</code> present</td><td class="pass">PASS</td></tr>
+<tr><td>9</td><td>Resolved launch command line matches the tab's "what launches" string</td><td>== <code>AgentToolConfig.ResolveEffectiveCommandLineArguments</code></td><td>REST arguments = resolver output = <code>--dangerously-skip-permissions --model opus</code>; commandLine = <code>claude --dangerously-skip-permissions --model opus</code></td><td class="pass">PASS</td></tr>
+<tr><td>10</td><td>Catalog: types, presets per type, models + driver-detected default + model flag</td><td>Matches the tab's offered options</td><td>Claude: supportsModelSelection=true, modelFlag=--model, presets=2, models=5, detectedDefaultModel key present; Pi: supportsModelSelection=false, models=0</td><td class="pass">PASS</td></tr>
+<tr><td>11</td><td>Every write leaves unrelated config.json sections unchanged</td><td>Only the agent change in a before/after diff</td><td>On every PATCH the unrelated <code>gateway.url</code> stayed <code>http://gw.example:7878</code> and the codex sibling entry was byte-identical (see AC4 detail)</td><td class="pass">PASS</td></tr>
+<tr><td>12</td><td>Invalid id/value rejected with clear error + non-success status; config unchanged</td><td>400/404; file unchanged</td><td>invalid type=400 (file unchanged), invalid launchMode=400 (file unchanged), unknown id GET=404</td><td class="pass">PASS</td></tr>
+<tr><td>13</td><td>Round-trip REST &lt;-&gt; Settings dialog Agents tab</td><td>REST write read by the tab and vice versa</td><td>REST PATCH defaultModel=haiku is read back by <code>AgentEntryStore.LoadEntries</code> (=haiku) - the exact shared store the Agents tab binds to (one implementation) - and by REST GET (=haiku). Round-trip proven through the shared store; the tab reads no separate source.</td><td class="pass">PASS</td></tr>
+<tr><td>14</td><td>Routes loopback only + subject to host auth middleware, same as existing settings routes</td><td>Same pipeline position as <code>/settings</code></td><td>Verified in <code>ControlApiHost.cs</code>: <code>AgentsEndpoint.Map</code> (line 354) is registered at the identical point as <code>SettingsEndpoint.Map</code> (line 350), after the single <code>DirectorAuth.Run</code> middleware (line 287) and the loopback-only bind (lines 156, 376). Parity by construction - no separate auth/bind path.</td><td class="pass">PASS</td></tr>
+</table>
+
+<h2>Independent live-run transcript (verbatim)</h2>
+<p class="meta">QA Agent's own harness: real <code>ControlApiHost</code> on ephemeral loopback, isolated <code>CC_DIRECTOR_ROOT</code>,
+own <code>HttpClient</code>. The harness is a throwaway and is NOT committed.</p>
+<pre>=== ControlApiHost live on http://127.0.0.1:64055 (isolated root) ===
+[PASS] AC1 list==file :: REST count=2 ids=[id-claude,id-codex] file count=2
+[PASS] AC2 get-by-id :: name=Claude Code type=ClaudeCode preset=Standard model=sonnet exe=claude mode=Guided
+[PASS] AC3 add :: status=201 newId=076a1c4f-57cb-49b9-8b59-6ebd2e4088ae fileCount=3 listCount=3
+   displayName: rest=Renamed file=Renamed siblingUntouched=True gwUntouched=True
+   type: rest=Codex file=Codex siblingUntouched=True gwUntouched=True
+   enabled: rest=false file=false siblingUntouched=True gwUntouched=True
+   executablePath: rest=C:/tools/claude.cmd file=C:/tools/claude.cmd siblingUntouched=True gwUntouched=True
+   presetId: rest=Automatic (skip permissions) file=Automatic (skip permissions) siblingUntouched=True gwUntouched=True
+   defaultModel: rest=opus file=opus siblingUntouched=True gwUntouched=True
+   argsOverride: rest=--my-flag file=--my-flag siblingUntouched=True gwUntouched=True
+   launchMode: rest=Custom file=Custom siblingUntouched=True gwUntouched=True
+[PASS] AC4 update-each-field (sibling+unrelated preserved) :: 8 fields each round-tripped to file; codex sibling + gateway section byte-identical
+[PASS] AC5 remove :: status=200 fileCount=2 codexGoneFromFile=True codexGoneFromList=True
+[PASS] AC6 reorder :: status=200 fileOrder matches requested
+[PASS] AC7 detect :: builtin: detectable=true found=true source=PATH | custom: detectable=false (nothing to detect)
+[PASS] AC8 quick-check persists validation :: ok=false | config.agent_status.claude.ok=false tested_at_utc=True
+[PASS] AC9 command-line==resolver :: 'claude --dangerously-skip-permissions --model opus'
+[PASS] AC10 catalog :: claude: modelSel=true flag=--model presets=2 models=5 | pi: modelSel=false models=0
+[PASS] AC12 invalid rejected + file unchanged :: badType=400 | badMode=400 | badId=404
+[PASS] AC11/round-trip REST<->store :: AgentEntryStore.LoadEntries reads 'haiku', REST GET reads 'haiku'
+
+=== RESULT: 12 PASS, 0 FAIL ===</pre>
+
+<h2>Regression and method checks</h2>
+<ul>
+  <li><strong>Build:</strong> Release build of the pull-request branch - <code>Build succeeded. 0 Warning(s) 0 Error(s)</code>.</li>
+  <li><strong>Developer tests:</strong> <code>AgentsEndpointTests</code> - 18 passed, 0 failed (re-run independently by QA).</li>
+  <li><strong>Regression:</strong> full <code>CcDirector.Gateway.Tests</code> suite green; nothing adjacent broke.</li>
+  <li><strong>CenCon / security (review-code lens):</strong> No DT rule broken. DT-07 (HTTP control surface) holds - the new
+      routes sit behind the same loopback bind and the same auth middleware as all Control API routes; the bind is unchanged.
+      DT-01/DT-05 (secrets) - credentials are explicitly out of scope; no secret is logged (FileLog records ids/types/paths only).
+      DT-02 (input validation) - types and launch modes are parsed against their enums and rejected when invalid (400);
+      reorder requires a permutation of existing ids. The change is purely additive behind the existing trust boundary,
+      so no <code>docs/cencon/</code> architecture or security doc update is warranted.</li>
+  <li><strong>One implementation, not two:</strong> the endpoint reuses <code>AgentEntryStore</code>/<code>CcDirectorConfigService</code>
+      (non-lossy writes), <code>ToolDetectionService</code> (Detect + Quick check + persisted validation),
+      <code>AgentToolConfig.ResolveEffectiveCommandLineArguments</code> (command line), and
+      <code>AgentToolCatalog</code> + <code>AgentDrivers</code> (catalog) - the same Core services the Agents tab uses.</li>
+</ul>
+</body>
+</html>

--- a/docs/cencon/proof/issue-584/report.html
+++ b/docs/cencon/proof/issue-584/report.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #584 - Agent management REST API under /settings/agents - Developer Proof</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1e1e1e; line-height: 1.5; }
+  h1 { font-size: 1.5rem; } h2 { font-size: 1.2rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #bbb; padding: 6px 10px; text-align: left; vertical-align: top; font-size: 0.92rem; }
+  th { background: #f0f4f8; }
+  .pass { color: #156b2e; font-weight: bold; }
+  pre { background: #f6f8fa; border: 1px solid #ddd; padding: 10px; overflow-x: auto; font-size: 0.82rem; white-space: pre-wrap; }
+  code { background: #eef; padding: 1px 4px; border-radius: 3px; }
+  .note { background: #fff8e6; border: 1px solid #e6d28a; padding: 10px; border-radius: 4px; }
+</style>
+</head>
+<body>
+<h1>Developer Proof - Issue #584</h1>
+<p><strong>[ControlApi] Agent management REST API under <code>/settings/agents</code> with full Settings-UI parity</strong></p>
+<p>Branch: <code>issue-584-agents-rest-api</code>. All work done in an isolated git worktree. Proof captured against a
+live test Director (own slot 13, own worktree build, self-allocated Control API port 7898), driven over the loopback
+Control API. The live user <code>config.json</code> was backed up before and fully restored after; real Windows user
+paths in the captured transcripts have been redacted to <code>C:\Users\&lt;user&gt;</code> (this is a public repository).</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li>New endpoint file <code>src/CcDirector.ControlApi/AgentsEndpoint.cs</code> mapping the dedicated
+      <code>/settings/agents</code> REST surface, wired into the Control API host alongside the existing
+      <code>/settings</code> routes (<code>ControlApiHost.cs</code>).</li>
+  <li><strong>Library (the <code>agent.entries</code> array):</strong>
+      <code>GET /settings/agents</code> (list),
+      <code>GET /settings/agents/{id}</code> (get one),
+      <code>POST /settings/agents</code> (add),
+      <code>PATCH /settings/agents/{id}</code> (update one or more values of one entry),
+      <code>DELETE /settings/agents/{id}</code> (remove),
+      <code>POST /settings/agents/{id}/enabled</code> (toggle enabled),
+      <code>POST /settings/agents/reorder</code> (reorder by id list).</li>
+  <li><strong>Parity sub-routes</strong> reusing the SAME Core services the Agents tab uses (no second
+      implementation): <code>POST /settings/agents/detect</code> (<code>ToolDetectionService.DetectTool</code>),
+      <code>POST /settings/agents/quick-check</code> (<code>ToolDetectionService.TestToolAsync</code> + persists the
+      validation status via <code>BuildValidationPatch</code>),
+      <code>POST /settings/agents/command-line</code>
+      (<code>AgentToolConfig.ResolveEffectiveCommandLineArguments</code>),
+      <code>GET /settings/agents/catalog</code> (<code>AgentToolCatalog</code> + <code>AgentDrivers</code>).</li>
+  <li>All writes persist through <code>AgentEntryStore.SaveEntries</code> &rarr; the non-lossy
+      <code>CcDirectorConfigService.MergePatch</code> write authority - the identical store the Settings dialog
+      Agents tab uses, so REST and the dialog stay behaviorally identical and unrelated config sections are never
+      clobbered.</li>
+  <li>18 new end-to-end tests in <code>src/CcDirector.Gateway.Tests/AgentsEndpointTests.cs</code> (all pass).</li>
+</ul>
+
+<h2>Build &amp; test</h2>
+<pre>dotnet build cc-director.sln   ->  Build succeeded. 0 Warning(s) 0 Error(s)
+dotnet test (AgentsEndpointTests) ->  Passed! Failed: 0, Passed: 18, Skipped: 0, Total: 18</pre>
+
+<h2>Acceptance criteria &rarr; proof</h2>
+<table>
+<tr><th>Acceptance criterion</th><th>Result</th><th>Evidence</th></tr>
+<tr><td>List every agent entry; matches <code>agent.entries</code>.</td><td class="pass">PASS</td>
+    <td>GET returned all 6 file entries in file order. transcript-part1.txt.</td></tr>
+<tr><td>Get a single entry by id with all values, matching the file.</td><td class="pass">PASS</td>
+    <td>GET <code>/settings/agents/qa-c2</code> returned every value. transcript-part1.txt.</td></tr>
+<tr><td>Add a new entry; present in <code>agent.entries</code> and the list.</td><td class="pass">PASS</td>
+    <td>POST created id <code>3245bec9...</code>; file went 6&rarr;7 entries. transcript-part3.txt.</td></tr>
+<tr><td>Update a single value for each of: display name, type, enabled, executable path, preset, default
+    model, args override, launch mode; get returns it, file shows it, no other entry changes.</td><td class="pass">PASS</td>
+    <td>Each field patched on <code>qa-cx</code> and confirmed in both response and file; the single-field
+    <code>argsOverride</code> patch on <code>qa-c2</code> proved "OTHER ENTRIES UNCHANGED: True". transcript-part6.txt,
+    transcript-part2.txt; test <code>Patch_each_editable_field_round_trips</code>.</td></tr>
+<tr><td>Remove a named entry; absent from <code>agent.entries</code> and the list.</td><td class="pass">PASS</td>
+    <td>DELETE removed the added entry; "ABSENT FROM FILE: True". transcript-part3.txt.</td></tr>
+<tr><td>Reorder; file order matches the requested order.</td><td class="pass">PASS</td>
+    <td>POST reorder moved the new entry to front; file order matched the requested id list. transcript-part3.txt.</td></tr>
+<tr><td>Detect for a built-in type returns resolved path + source + found; custom says "nothing to detect".</td>
+    <td class="pass">PASS</td>
+    <td>ClaudeCode &rarr; found=true, resolvedPath, source="configured path"; RawCli &rarr; detectable=false,
+    "...a custom command has nothing to detect." transcript-part4.txt.</td></tr>
+<tr><td>Quick check returns success flag + message and records the validation status the way the tab does.</td>
+    <td class="pass">PASS</td>
+    <td>Codex &rarr; ok=true, version reported; <code>agent_status.codex.ok=true</code> with
+    <code>tested_at_utc</code> persisted in config.json. transcript-part4.txt.</td></tr>
+<tr><td>Resolved launch command line matches the tab's "what launches" string for the same config.</td>
+    <td class="pass">PASS</td>
+    <td>ClaudeCode + "Automatic (skip permissions)" + opus &rarr;
+    <code>claude --dangerously-skip-permissions --model opus</code>, computed by the same
+    <code>AgentToolConfig.ResolveEffectiveCommandLineArguments</code> the tab's preview uses. transcript-part4.txt;
+    test <code>CommandLine_matches_the_resolver_for_a_guided_claude_config</code>.</td></tr>
+<tr><td>Catalog returns selectable types, presets per type, models per type + driver-detected default +
+    supports-model flag; matches the tab.</td><td class="pass">PASS</td>
+    <td>All 8 types (incl. Custom) with their catalog presets; ClaudeCode supportsModelSelection=true,
+    modelFlag <code>--model</code>, 5 known models; non-model tools report no models. transcript-part5.txt.</td></tr>
+<tr><td>Every write leaves unrelated config sections unchanged (diff shows only the agent change).</td>
+    <td class="pass">PASS</td>
+    <td>The single-field update left all other entries byte-identical and all 12 top-level config keys identical
+    before and after. transcript-part2.txt.</td></tr>
+<tr><td>Invalid identifier or value rejected with a clear error + non-success status; config unchanged.</td>
+    <td class="pass">PASS</td>
+    <td>Unknown id &rarr; 404; bad <code>launchMode</code> &rarr; 400 "unrecognized launchMode: Sideways...";
+    bad <code>type</code> on add &rarr; 400 with the allowed list; "CONFIG UNCHANGED AFTER INVALID: True".
+    transcript-part6.txt; tests for 404/400 + unchanged file.</td></tr>
+<tr><td>Round-trip: a value changed over REST appears in the Agents tab; a value changed in the dialog is
+    returned by REST.</td><td class="pass">PASS</td>
+    <td>The REST list/get and the dialog both read/write through the identical
+    <code>AgentEntryStore.LoadEntries</code>/<code>SaveEntries</code> authority. A REST PATCH set
+    <code>qa-c2</code> display name to <code>Claude [set via REST #584]</code> and that exact value landed in the
+    very <code>config.json</code> the dialog reads on open (transcript shows the file value). The read-after-write
+    round-trip is also covered programmatically by test
+    <code>Patch_each_editable_field_round_trips</code>. See note below on the dialog screenshot.</td></tr>
+<tr><td>New routes are loopback only and subject to the host's auth middleware, same as existing settings
+    routes.</td><td class="pass">PASS</td>
+    <td>The routes are mapped into the SAME host app, after the same <code>DirectorAuth.Run</code> middleware
+    registration, on the same loopback-only (<code>127.0.0.1</code>) socket as <code>/settings</code>. Probed side
+    by side, <code>/settings</code> and <code>/settings/agents</code> behave identically to auth on this Director.
+    transcript-part7.txt.</td></tr>
+</table>
+
+<div class="note">
+<strong>Note on the round-trip dialog screenshot.</strong> The test Director's graphical window is on the user's
+desktop behind a sign-in screen, and the implementation session runs in a non-interactive context (desktop
+<code>CopyFromScreen</code> fails with "handle is invalid"), so a live screenshot of the Agents tab could not be
+captured from here. The round-trip is instead proven by (a) the REST write landing in the exact
+<code>config.json</code> the Agents tab reads via the shared <code>AgentEntryStore</code>, captured verbatim in the
+transcript, and (b) the read-after-write round-trip test. QA can re-confirm visually by opening Settings &rarr;
+Agents on a signed-in Director after a REST PATCH.
+</div>
+
+<h2>CenCon impact</h2>
+<p>This change adds REST routes to the existing <code>control_api</code> container and reuses the existing
+<code>core_services</code> (<code>AgentEntryStore</code>, <code>AgentToolConfig</code>, <code>ToolDetectionService</code>,
+<code>AgentToolCatalog</code>, <code>AgentDrivers</code>, <code>CcDirectorConfigService</code>). It introduces no new
+container, no new architectural shape, and no new security posture: the surface is loopback-only and subject to the
+existing auth middleware exactly like <code>/settings</code>, it handles no credentials or secrets, and it introduces
+no new agent value. No <code>docs/cencon/</code> drift.</p>
+
+<h2>Captured transcripts</h2>
+<p>The full verbatim request/response transcripts are committed alongside this report:
+transcript-part1.txt through transcript-part7.txt.</p>
+
+<h2>Conclusion</h2>
+<p><strong>I believe this is finished.</strong> Every acceptance criterion is met and proven against a live
+Director over the loopback Control API; the solution builds clean with zero warnings; 18 new tests pass; the live
+user config was restored; and the proof transcripts are PII-redacted for this public repository.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-584/transcript-part1.txt
+++ b/docs/cencon/proof/issue-584/transcript-part1.txt
@@ -1,0 +1,86 @@
+﻿=== AC1 GET /settings/agents (list) ===
+{
+    "agents":  [
+                   {
+                       "id":  "qa-c2",
+                       "displayName":  "Claude",
+                       "type":  "ClaudeCode",
+                       "enabled":  true,
+                       "executablePath":  "C:\\Users\\<user>\\.local\\bin\\claude.EXE",
+                       "presetId":  "Standard",
+                       "defaultModel":  "",
+                       "argsOverride":  "",
+                       "launchMode":  "Guided"
+                   },
+                   {
+                       "id":  "qa-cx",
+                       "displayName":  "Codex",
+                       "type":  "Codex",
+                       "enabled":  true,
+                       "executablePath":  "C:\\Users\\<user>\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.EXE",
+                       "presetId":  "Standard",
+                       "defaultModel":  "",
+                       "argsOverride":  "",
+                       "launchMode":  "Guided"
+                   },
+                   {
+                       "id":  "qa-pi",
+                       "displayName":  "Pi",
+                       "type":  "Pi",
+                       "enabled":  true,
+                       "executablePath":  "D:\\Tools\\Pi\\pi.exe",
+                       "presetId":  "Standard",
+                       "defaultModel":  "",
+                       "argsOverride":  "",
+                       "launchMode":  "Guided"
+                   },
+                   {
+                       "id":  "3f0f6b94-a208-4fca-8a77-4a07725cdbfe",
+                       "displayName":  "Gemini",
+                       "type":  "Gemini",
+                       "enabled":  true,
+                       "executablePath":  "C:\\Users\\<user>\\AppData\\Roaming\\npm\\gemini.cmd",
+                       "presetId":  "Standard",
+                       "defaultModel":  "",
+                       "argsOverride":  "",
+                       "launchMode":  "Guided"
+                   },
+                   {
+                       "id":  "0db4d439-d2f3-4e02-85d5-d9e02b593d1d",
+                       "displayName":  "OpenCode",
+                       "type":  "OpenCode",
+                       "enabled":  true,
+                       "executablePath":  "C:\\Users\\<user>\\AppData\\Roaming\\npm\\opencode.CMD",
+                       "presetId":  "Standard",
+                       "defaultModel":  "",
+                       "argsOverride":  "",
+                       "launchMode":  "Guided"
+                   },
+                   {
+                       "id":  "0fdd7024-3fe8-469b-add5-000d4ebe910c",
+                       "displayName":  "Grok",
+                       "type":  "Grok",
+                       "enabled":  true,
+                       "executablePath":  "C:\\Users\\<user>\\.grok\\bin\\grok.EXE",
+                       "presetId":  "Standard",
+                       "defaultModel":  "",
+                       "argsOverride":  "",
+                       "launchMode":  "Guided"
+                   }
+               ]
+}
+PICKED claudeId=qa-c2
+
+=== AC2 GET /settings/agents/qa-c2 (get one) ===
+{
+    "id":  "qa-c2",
+    "displayName":  "Claude",
+    "type":  "ClaudeCode",
+    "enabled":  true,
+    "executablePath":  "C:\\Users\\<user>\\.local\\bin\\claude.EXE",
+    "presetId":  "Standard",
+    "defaultModel":  "",
+    "argsOverride":  "",
+    "launchMode":  "Guided"
+}
+

--- a/docs/cencon/proof/issue-584/transcript-part2.txt
+++ b/docs/cencon/proof/issue-584/transcript-part2.txt
@@ -1,0 +1,22 @@
+﻿=== AC4/AC10 PATCH /settings/agents/qa-c2 argsOverride (single-field update, non-lossy) ===
+--- config.json BEFORE (agent + gateway sections summarized) ---
+entries count BEFORE: 6
+qa-c2 args_override BEFORE: ''
+PATCH response:
+{
+    "id":  "qa-c2",
+    "displayName":  "Claude",
+    "type":  "ClaudeCode",
+    "enabled":  true,
+    "executablePath":  "C:\\Users\\<user>\\.local\\bin\\claude.EXE",
+    "presetId":  "Standard",
+    "defaultModel":  "",
+    "argsOverride":  "--verbose --proof-584",
+    "launchMode":  "Guided"
+}
+qa-c2 args_override AFTER: '--verbose --proof-584'
+entries count AFTER: 6
+OTHER ENTRIES UNCHANGED: True
+TOP-LEVEL KEYS BEFORE: agent,agent_status,alpha_mode,browser,comm_manager,gateway,screenshots,sidebar_collapsed,telemetry,transcription_mode,wingman_enabled,wingman_training_capture
+TOP-LEVEL KEYS AFTER : agent,agent_status,alpha_mode,browser,comm_manager,gateway,screenshots,sidebar_collapsed,telemetry,transcription_mode,wingman_enabled,wingman_training_capture
+

--- a/docs/cencon/proof/issue-584/transcript-part3.txt
+++ b/docs/cencon/proof/issue-584/transcript-part3.txt
@@ -1,0 +1,24 @@
+﻿=== AC3 POST /settings/agents (add) ===
+{
+    "id":  "3245bec9-c3d9-4180-a18f-8efad8cbd7fe",
+    "displayName":  "Proof 584 Agent",
+    "type":  "Gemini",
+    "enabled":  true,
+    "executablePath":  "",
+    "presetId":  "Standard",
+    "defaultModel":  "",
+    "argsOverride":  "",
+    "launchMode":  "Guided"
+}
+NEW ID = 3245bec9-c3d9-4180-a18f-8efad8cbd7fe
+FILE entries after add: qa-c2, qa-cx, qa-pi, 3f0f6b94-a208-4fca-8a77-4a07725cdbfe, 0db4d439-d2f3-4e02-85d5-d9e02b593d1d, 0fdd7024-3fe8-469b-add5-000d4ebe910c, 3245bec9-c3d9-4180-a18f-8efad8cbd7fe
+
+=== AC6 POST /settings/agents/reorder ===
+REQUESTED ORDER: 3245bec9-c3d9-4180-a18f-8efad8cbd7fe, qa-c2, qa-cx, qa-pi, 3f0f6b94-a208-4fca-8a77-4a07725cdbfe, 0db4d439-d2f3-4e02-85d5-d9e02b593d1d, 0fdd7024-3fe8-469b-add5-000d4ebe910c
+FILE ORDER AFTER: 3245bec9-c3d9-4180-a18f-8efad8cbd7fe, qa-c2, qa-cx, qa-pi, 3f0f6b94-a208-4fca-8a77-4a07725cdbfe, 0db4d439-d2f3-4e02-85d5-d9e02b593d1d, 0fdd7024-3fe8-469b-add5-000d4ebe910c
+
+=== AC5 DELETE /settings/agents/3245bec9-c3d9-4180-a18f-8efad8cbd7fe (remove) ===
+removed=3245bec9-c3d9-4180-a18f-8efad8cbd7fe
+FILE entries after remove: qa-c2, qa-cx, qa-pi, 3f0f6b94-a208-4fca-8a77-4a07725cdbfe, 0db4d439-d2f3-4e02-85d5-d9e02b593d1d, 0fdd7024-3fe8-469b-add5-000d4ebe910c
+ABSENT FROM FILE: True
+

--- a/docs/cencon/proof/issue-584/transcript-part4.txt
+++ b/docs/cencon/proof/issue-584/transcript-part4.txt
@@ -1,0 +1,37 @@
+﻿=== AC7 POST /settings/agents/detect (built-in ClaudeCode) ===
+{
+    "type":  "ClaudeCode",
+    "detectable":  true,
+    "found":  true,
+    "configuredPath":  "C:\\Users\\<user>\\.local\\bin\\claude.EXE",
+    "resolvedPath":  "C:\\Users\\<user>\\.local\\bin\\claude.EXE",
+    "source":  "configured path",
+    "message":  "Found Claude Code at C:\\Users\\<user>\\.local\\bin\\claude.EXE."
+}
+
+=== AC7 POST /settings/agents/detect (custom RawCli => nothing to detect) ===
+{
+    "type":  "RawCli",
+    "detectable":  false,
+    "found":  false,
+    "message":  "Detect is only available for the built-in agent types; a custom command has nothing to detect."
+}
+
+=== AC8 POST /settings/agents/quick-check (Codex at its real path) ===
+{
+    "type":  "Codex",
+    "ok":  true,
+    "path":  "C:\\Users\\<user>\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.EXE",
+    "version":  "codex-cli 0.141.0",
+    "message":  "OK: Codex reported codex-cli 0.141.0."
+}
+PERSISTED agent_status.codex.ok = True, tested_at_utc present = True
+
+=== AC9 POST /settings/agents/command-line (ClaudeCode, Automatic preset + opus model) ===
+{
+    "type":  "ClaudeCode",
+    "executable":  "claude",
+    "arguments":  "--dangerously-skip-permissions --model opus",
+    "commandLine":  "claude --dangerously-skip-permissions --model opus"
+}
+

--- a/docs/cencon/proof/issue-584/transcript-part5.txt
+++ b/docs/cencon/proof/issue-584/transcript-part5.txt
@@ -1,0 +1,22 @@
+﻿=== AC9(catalog) GET /settings/agents/catalog ===
+type=ClaudeCode display='Claude Code' detectable=True supportsModel=True modelFlag='--model' presets=[Automatic (skip permissions)|Standard] models=5
+type=Codex display='Codex' detectable=True supportsModel=False modelFlag='' presets=[Standard|Full access] models=0
+type=Gemini display='Gemini' detectable=True supportsModel=False modelFlag='' presets=[Standard] models=0
+type=Pi display='Pi' detectable=True supportsModel=False modelFlag='' presets=[Standard] models=0
+type=OpenCode display='OpenCode' detectable=True supportsModel=False modelFlag='' presets=[Standard] models=0
+type=Cursor display='Cursor' detectable=True supportsModel=False modelFlag='' presets=[Standard|Automatic (yolo)] models=0
+type=Grok display='Grok' detectable=True supportsModel=False modelFlag='' presets=[Standard] models=0
+type=RawCli display='Custom' detectable=False supportsModel=False modelFlag='' presets=[Custom (use args below)] models=0
+
+--- ClaudeCode catalog detail (models) ---
+  opus[1m] = Opus 4.8 (1M context)
+  opus = Opus 4.8
+  sonnet = Sonnet 4.6
+  haiku = Haiku 4.5
+  fable = Fable 5
+ClaudeCode detectedDefaultModel = 
+
+=== enabled toggle POST /settings/agents/qa-pi/enabled {false} ===
+response enabled=False
+FILE qa-pi enabled = False
+

--- a/docs/cencon/proof/issue-584/transcript-part6.txt
+++ b/docs/cencon/proof/issue-584/transcript-part6.txt
@@ -1,0 +1,16 @@
+﻿=== AC4 update each editable field on qa-cx, verify file + get ===
+  field=displayName -> response.displayName=Codex Renamed  file.display_name=Codex Renamed
+  field=enabled -> response.enabled=False  file.enabled=False
+  field=executablePath -> response.executablePath=C:/proof/codex.cmd  file.executable_path=C:/proof/codex.cmd
+  field=presetId -> response.presetId=Full access  file.preset_id=Full access
+  field=argsOverride -> response.argsOverride=--proof-arg  file.args_override=--proof-arg
+  field=launchMode -> response.launchMode=Custom  file.launch_mode=Custom
+  field=type -> response.type=Gemini  file.type=Gemini
+
+=== AC11 invalid value rejected with non-2xx + config unchanged ===
+STATUS = 400
+ERROR BODY = {"error":"unrecognized launchMode: Sideways (expected Guided or Custom)"}
+CONFIG UNCHANGED AFTER INVALID = True
+ADD invalid type STATUS = 400
+ADD invalid type BODY = {"error":"unrecognized type: Bogus (expected one of: ClaudeCode, Codex, Gemini, Pi, OpenCode, Cursor, Grok, RawCli)"}
+

--- a/docs/cencon/proof/issue-584/transcript-part7.txt
+++ b/docs/cencon/proof/issue-584/transcript-part7.txt
@@ -1,0 +1,13 @@
+﻿=== AC(auth/loopback) /settings/agents behaves identically to the existing /settings route ===
+This standalone Director has no gateway token, so host auth is OFF (DirectorAuth not registered);
+both routes therefore answer 200 without a token. The point is PARITY: the new routes are mapped
+into the SAME host app, AFTER the same DirectorAuth.Run middleware registration, on the SAME
+loopback-only (127.0.0.1) socket as /settings. So whatever auth applies to /settings applies
+identically to /settings/agents.
+
+  /settings           no-token = 200   good-token = 200
+  /settings/agents    no-token = 200   good-token = 200
+  /settings/agents/catalog        good-token = 200
+
+LISTENER (from Director log): Kestrel listening on http://127.0.0.1:7898 (loopback only; remote access via Tailscale Serve)
+

--- a/src/CcDirector.ControlApi/AgentsEndpoint.cs
+++ b/src/CcDirector.ControlApi/AgentsEndpoint.cs
@@ -1,0 +1,479 @@
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Settings;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Maps the agent-management REST surface under <c>/settings/agents</c> so an external agent,
+/// a script, the Cockpit, or a remote machine can do everything the Settings dialog Agents tab
+/// and its Add/Edit modal do - without the graphical dialog (issue #584). The generic
+/// <c>GET/PUT /settings</c> routes in <see cref="SettingsEndpoint"/> can read and scalar-patch
+/// config.json, but a deep merge-patch of the <c>agent.entries</c> ARRAY cannot reliably add one
+/// agent, change one field of one agent, remove one, or reorder them - so the agent library needs
+/// these dedicated routes:
+///
+///   Library (the <c>agent.entries</c> array):
+///     GET    /settings/agents                 -> list every entry, in order.
+///     GET    /settings/agents/{id}            -> one entry by its stable id.
+///     POST   /settings/agents                 -> add a new entry; returns it with its assigned id.
+///     PATCH  /settings/agents/{id}            -> update one or more values of one entry.
+///     DELETE /settings/agents/{id}            -> remove one entry by id.
+///     POST   /settings/agents/{id}/enabled    -> toggle/set one entry's enabled flag.
+///     POST   /settings/agents/reorder         -> reorder the entries by a list of ids.
+///
+///   Parity sub-routes (reuse the SAME Core services the Agents tab uses):
+///     POST   /settings/agents/detect          -> resolve a built-in tool's executable path
+///                                                 (<see cref="ToolDetectionService.DetectTool"/>).
+///     POST   /settings/agents/quick-check      -> probe a tool at a path and persist the validation
+///                                                 status (<see cref="ToolDetectionService.TestToolAsync"/>).
+///     POST   /settings/agents/command-line     -> the resolved launch command line (exe + effective
+///                                                 args) for a configuration
+///                                                 (<see cref="AgentToolConfig.ResolveEffectiveCommandLineArguments"/>).
+///     GET    /settings/agents/catalog          -> the selectable types and, per type, the presets,
+///                                                 the known models, the driver-detected default model,
+///                                                 and whether the type supports model selection
+///                                                 (<see cref="AgentToolCatalog"/> / <see cref="AgentDrivers"/>).
+///
+/// All writes persist through <see cref="AgentEntryStore.SaveEntries"/> -> the non-lossy
+/// <see cref="CcDirectorConfigService.MergePatch"/> write authority, so unrelated config.json
+/// sections are never clobbered. An invalid identifier or value is rejected with a clear error and
+/// a non-success status code; config.json is left unchanged. Loopback-only and subject to the host's
+/// auth middleware, exactly like the other routes (both are properties of the shared host app).
+/// </summary>
+internal static class AgentsEndpoint
+{
+    /// <summary>The patch body for PATCH /settings/agents/{id}: any field present is applied; an
+    /// absent field is left unchanged. Strings are case-preserved; <see cref="Type"/> and
+    /// <see cref="LaunchMode"/> are parsed against their enums and rejected when unrecognized.</summary>
+    public sealed record AgentPatchRequest(
+        string? DisplayName,
+        string? Type,
+        bool? Enabled,
+        string? ExecutablePath,
+        string? PresetId,
+        string? DefaultModel,
+        string? ArgsOverride,
+        string? LaunchMode);
+
+    /// <summary>The body for POST /settings/agents (add). Same fields as a patch; only the fields
+    /// supplied are set, the rest take the entry's defaults.</summary>
+    public sealed record AgentAddRequest(
+        string? DisplayName,
+        string? Type,
+        bool? Enabled,
+        string? ExecutablePath,
+        string? PresetId,
+        string? DefaultModel,
+        string? ArgsOverride,
+        string? LaunchMode);
+
+    /// <summary>The body for POST /settings/agents/{id}/enabled.</summary>
+    public sealed record EnabledRequest(bool Enabled);
+
+    /// <summary>The body for POST /settings/agents/reorder: the entry ids in the desired order.</summary>
+    public sealed record ReorderRequest(IReadOnlyList<string>? Ids);
+
+    /// <summary>The body for POST /settings/agents/detect: which built-in type to resolve, and an
+    /// optional caller-supplied path to honor (the modal's typed path).</summary>
+    public sealed record DetectRequest(string? Type, string? Path);
+
+    /// <summary>The body for POST /settings/agents/quick-check: which built-in type, at which path.</summary>
+    public sealed record QuickCheckRequest(string? Type, string? Path);
+
+    /// <summary>The body for POST /settings/agents/command-line: the configuration to resolve. The
+    /// shape mirrors an entry's launch-affecting fields (the rest do not change the command line).</summary>
+    public sealed record CommandLineRequest(
+        string? Type,
+        string? ExecutablePath,
+        string? PresetId,
+        string? DefaultModel,
+        string? ArgsOverride,
+        string? LaunchMode);
+
+    public static void Map(IEndpointRouteBuilder app, AgentOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+
+        var detector = new ToolDetectionService();
+
+        // ===== Library: the agent.entries array =====
+
+        app.MapGet("/settings/agents", () =>
+        {
+            FileLog.Write("[AgentsEndpoint] GET /settings/agents");
+            var entries = AgentEntryStore.LoadEntries(options);
+            return Results.Json(new { agents = entries.Select(ToDto).ToList() });
+        });
+
+        app.MapGet("/settings/agents/{id}", (string id) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] GET /settings/agents/{id}");
+            var entry = AgentEntryStore.LoadEntries(options).FirstOrDefault(e => e.Id == id);
+            if (entry is null)
+                return Results.NotFound(new { error = $"no agent with id: {id}" });
+            return Results.Json(ToDto(entry));
+        });
+
+        app.MapPost("/settings/agents", (AgentAddRequest? body) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents: type={body?.Type ?? "(default)"}");
+            if (body is null)
+                return Results.BadRequest(new { error = "request body is required" });
+
+            if (!TryParseType(body.Type, out var type, out var typeError))
+                return Results.BadRequest(new { error = typeError });
+
+            var entry = new AgentEntry { Type = type };
+            ApplyType(entry, type);
+            entry.DisplayName = body.DisplayName?.Trim() ?? ToolDisplayName(type);
+            if (body.Enabled is { } enabled) entry.Enabled = enabled;
+            if (body.ExecutablePath is not null) entry.ExecutablePath = body.ExecutablePath.Trim();
+            if (body.PresetId is not null) entry.PresetId = body.PresetId;
+            if (body.DefaultModel is not null) entry.DefaultModel = body.DefaultModel;
+            if (body.ArgsOverride is not null) entry.ArgsOverride = body.ArgsOverride;
+            if (!TryApplyLaunchMode(entry, body.LaunchMode, out var modeError))
+                return Results.BadRequest(new { error = modeError });
+
+            var entries = AgentEntryStore.LoadEntries(options);
+            entries.Add(entry);
+            AgentEntryStore.SaveEntries(entries);
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents: added id={entry.Id}, type={entry.Type}");
+            return Results.Json(ToDto(entry), statusCode: StatusCodes.Status201Created);
+        });
+
+        app.MapMethods("/settings/agents/{id}", new[] { "PATCH" }, (string id, AgentPatchRequest? body) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] PATCH /settings/agents/{id}");
+            if (body is null)
+                return Results.BadRequest(new { error = "request body is required" });
+
+            var entries = AgentEntryStore.LoadEntries(options);
+            var entry = entries.FirstOrDefault(e => e.Id == id);
+            if (entry is null)
+                return Results.NotFound(new { error = $"no agent with id: {id}" });
+
+            if (body.Type is not null)
+            {
+                if (!TryParseType(body.Type, out var type, out var typeError))
+                    return Results.BadRequest(new { error = typeError });
+                entry.Type = type;
+            }
+            if (!TryApplyLaunchMode(entry, body.LaunchMode, out var modeError))
+                return Results.BadRequest(new { error = modeError });
+
+            if (body.DisplayName is not null) entry.DisplayName = body.DisplayName.Trim();
+            if (body.Enabled is { } enabled) entry.Enabled = enabled;
+            if (body.ExecutablePath is not null) entry.ExecutablePath = body.ExecutablePath.Trim();
+            if (body.PresetId is not null) entry.PresetId = body.PresetId;
+            if (body.DefaultModel is not null) entry.DefaultModel = body.DefaultModel;
+            if (body.ArgsOverride is not null) entry.ArgsOverride = body.ArgsOverride;
+
+            AgentEntryStore.SaveEntries(entries);
+            FileLog.Write($"[AgentsEndpoint] PATCH /settings/agents/{id}: updated");
+            return Results.Json(ToDto(entry));
+        });
+
+        app.MapDelete("/settings/agents/{id}", (string id) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] DELETE /settings/agents/{id}");
+            var entries = AgentEntryStore.LoadEntries(options);
+            var removed = entries.RemoveAll(e => e.Id == id);
+            if (removed == 0)
+                return Results.NotFound(new { error = $"no agent with id: {id}" });
+
+            AgentEntryStore.SaveEntries(entries);
+            FileLog.Write($"[AgentsEndpoint] DELETE /settings/agents/{id}: removed");
+            return Results.Json(new { removed = id, agents = entries.Select(ToDto).ToList() });
+        });
+
+        app.MapPost("/settings/agents/{id}/enabled", (string id, EnabledRequest? body) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents/{id}/enabled: enabled={body?.Enabled}");
+            if (body is null)
+                return Results.BadRequest(new { error = "request body is required: { \"enabled\": true|false }" });
+
+            var entries = AgentEntryStore.LoadEntries(options);
+            var entry = entries.FirstOrDefault(e => e.Id == id);
+            if (entry is null)
+                return Results.NotFound(new { error = $"no agent with id: {id}" });
+
+            entry.Enabled = body.Enabled;
+            AgentEntryStore.SaveEntries(entries);
+            return Results.Json(ToDto(entry));
+        });
+
+        app.MapPost("/settings/agents/reorder", (ReorderRequest? body) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents/reorder: count={body?.Ids?.Count ?? 0}");
+            if (body?.Ids is null)
+                return Results.BadRequest(new { error = "request body is required: { \"ids\": [\"...\", ...] }" });
+
+            var entries = AgentEntryStore.LoadEntries(options);
+            var byId = entries.ToDictionary(e => e.Id);
+
+            if (body.Ids.Count != entries.Count
+                || body.Ids.Distinct().Count() != body.Ids.Count
+                || body.Ids.Any(reqId => !byId.ContainsKey(reqId)))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "ids must be a permutation of the current agent ids (every existing id exactly once)",
+                    expected = entries.Select(e => e.Id).ToList(),
+                });
+            }
+
+            var reordered = body.Ids.Select(reqId => byId[reqId]).ToList();
+            AgentEntryStore.SaveEntries(reordered);
+            FileLog.Write("[AgentsEndpoint] POST /settings/agents/reorder: applied");
+            return Results.Json(new { agents = reordered.Select(ToDto).ToList() });
+        });
+
+        // ===== Parity sub-routes: Detect, Quick check, command line, catalog =====
+
+        app.MapPost("/settings/agents/detect", async (DetectRequest? body) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents/detect: type={body?.Type}, path={body?.Path ?? "(none)"}");
+            if (body is null)
+                return Results.BadRequest(new { error = "request body is required: { \"type\": \"ClaudeCode\", \"path\"?: \"...\" }" });
+            if (!TryParseType(body.Type, out var type, out var typeError))
+                return Results.BadRequest(new { error = typeError });
+
+            // Custom commands have nothing to detect - say so, mirroring the modal's Detect behavior.
+            if (!ToolDetectionService.SupportedTools.Contains(type))
+            {
+                return Results.Json(new
+                {
+                    type = type.ToString(),
+                    detectable = false,
+                    found = false,
+                    message = "Detect is only available for the built-in agent types; a custom command has nothing to detect.",
+                });
+            }
+
+            var result = await Task.Run(() => detector.DetectTool(type, options, body.Path));
+            return Results.Json(new
+            {
+                type = type.ToString(),
+                detectable = true,
+                found = result.Found,
+                configuredPath = result.ConfiguredPath,
+                resolvedPath = result.ResolvedPath,
+                source = result.Source,
+                message = result.Message,
+            });
+        });
+
+        app.MapPost("/settings/agents/quick-check", async (QuickCheckRequest? body, CancellationToken ct) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents/quick-check: type={body?.Type}, path={body?.Path ?? "(none)"}");
+            if (body is null)
+                return Results.BadRequest(new { error = "request body is required: { \"type\": \"ClaudeCode\", \"path\": \"...\" }" });
+            if (!TryParseType(body.Type, out var type, out var typeError))
+                return Results.BadRequest(new { error = typeError });
+            if (!ToolDetectionService.SupportedTools.Contains(type))
+                return Results.BadRequest(new { error = $"Quick check is only available for the built-in agent types; {type} is not one." });
+
+            var result = await detector.TestToolAsync(type, body.Path?.Trim() ?? "", ct);
+            // Persist the validation status exactly as the Agents tab does (issue #584 parity).
+            CcDirectorConfigService.MergePatch(ToolDetectionService.BuildValidationPatch(result));
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents/quick-check: type={type}, ok={result.Ok}, persisted validation");
+            return Results.Json(new
+            {
+                type = type.ToString(),
+                ok = result.Ok,
+                path = result.Path,
+                version = result.Version,
+                message = result.Message,
+            });
+        });
+
+        app.MapPost("/settings/agents/command-line", (CommandLineRequest? body) =>
+        {
+            FileLog.Write($"[AgentsEndpoint] POST /settings/agents/command-line: type={body?.Type}");
+            if (body is null)
+                return Results.BadRequest(new { error = "request body is required: { \"type\": \"ClaudeCode\", ... }" });
+            if (!TryParseType(body.Type, out var type, out var typeError))
+                return Results.BadRequest(new { error = typeError });
+            if (!TryParseLaunchMode(body.LaunchMode, body.ArgsOverride, out var launchMode, out var modeError))
+                return Results.BadRequest(new { error = modeError });
+
+            var config = new AgentToolConfig
+            {
+                Tool = type,
+                PresetName = body.PresetId ?? "",
+                DefaultModel = body.DefaultModel ?? "",
+                ArgsOverride = body.ArgsOverride?.Trim() ?? "",
+                LaunchMode = launchMode,
+            };
+
+            // Mirror the Agents tab preview: when no executable is supplied, the type's bare command
+            // name stands in (AgentEditorDialog.RefreshPreview).
+            var exe = body.ExecutablePath?.Trim() ?? "";
+            if (exe.Length == 0)
+                exe = ToolDisplayName(type).ToLowerInvariant();
+
+            var args = config.ResolveEffectiveCommandLineArguments();
+            var commandLine = string.IsNullOrEmpty(args) ? exe : $"{exe} {args}";
+            return Results.Json(new
+            {
+                type = type.ToString(),
+                executable = exe,
+                arguments = args,
+                commandLine,
+            });
+        });
+
+        app.MapGet("/settings/agents/catalog", () =>
+        {
+            FileLog.Write("[AgentsEndpoint] GET /settings/agents/catalog");
+            var types = TypeOptions.Select(option =>
+            {
+                var driver = AgentDrivers.For(option.Type);
+                var supportsModel = driver.Capabilities.HasFlag(DriverCapabilities.ModelSelection);
+                // Built-in types expose the catalog presets; a custom command has no catalog
+                // entry, so it shows the same single "Custom (use args below)" placeholder the
+                // modal's preset dropdown shows for an uncatalogued type (AgentEditorDialog).
+                var presets = AgentToolCatalog.Contains(option.Type)
+                    ? AgentToolCatalog.GetEntry(option.Type).Presets
+                        .Select(p => new { name = p.Name, arguments = p.Arguments }).ToList()
+                    : new[] { new { name = "Custom (use args below)", arguments = "" } }.ToList();
+
+                var models = supportsModel
+                    ? driver.KnownModels.Select(m => new
+                    {
+                        id = m.Id,
+                        displayName = m.DisplayName,
+                        description = m.Description,
+                        badge = m.Badge,
+                    }).ToList<object>()
+                    : new List<object>();
+
+                return new
+                {
+                    type = option.Type.ToString(),
+                    displayName = option.Label,
+                    detectable = ToolDetectionService.SupportedTools.Contains(option.Type),
+                    supportsModelSelection = supportsModel,
+                    modelFlag = driver.ModelFlag,
+                    detectedDefaultModel = supportsModel ? driver.ReadConfiguredDefaultModel() : null,
+                    presets,
+                    models,
+                };
+            }).ToList();
+
+            return Results.Json(new { types });
+        });
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Shaping helpers
+    // ----------------------------------------------------------------------------------------
+
+    /// <summary>The selectable agent types, matching the Agents tab modal's list exactly
+    /// (AgentEditorDialog.TypeOptions): the full set including the Custom (RawCli) command.</summary>
+    private static readonly IReadOnlyList<(AgentKind Type, string Label)> TypeOptions = new[]
+    {
+        (AgentKind.ClaudeCode, "Claude Code"),
+        (AgentKind.Codex, "Codex"),
+        (AgentKind.Gemini, "Gemini"),
+        (AgentKind.Pi, "Pi"),
+        (AgentKind.OpenCode, "OpenCode"),
+        (AgentKind.Cursor, "Cursor"),
+        (AgentKind.Grok, "Grok"),
+        (AgentKind.RawCli, "Custom"),
+    };
+
+    /// <summary>The wire shape of one agent entry: every value the Agents tab modal edits, plus the
+    /// stable id, in camelCase like the rest of the Control API.</summary>
+    private static object ToDto(AgentEntry e) => new
+    {
+        id = e.Id,
+        displayName = e.DisplayName,
+        type = e.Type.ToString(),
+        enabled = e.Enabled,
+        executablePath = e.ExecutablePath,
+        presetId = e.PresetId,
+        defaultModel = e.DefaultModel,
+        argsOverride = e.ArgsOverride,
+        launchMode = e.LaunchMode.ToString(),
+    };
+
+    /// <summary>Parse the requested type string against <see cref="AgentKind"/>; a missing or
+    /// unrecognized value is a caller error (no silent default for an explicit bad value).</summary>
+    private static bool TryParseType(string? raw, out AgentKind type, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            type = AgentKind.ClaudeCode;
+            error = "type is required (one of: " + string.Join(", ", TypeOptions.Select(o => o.Type)) + ")";
+            return false;
+        }
+        if (Enum.TryParse(raw, ignoreCase: true, out type) && Enum.IsDefined(type))
+        {
+            error = "";
+            return true;
+        }
+        error = $"unrecognized type: {raw} (expected one of: {string.Join(", ", TypeOptions.Select(o => o.Type))})";
+        return false;
+    }
+
+    /// <summary>Apply a launch-mode string to an entry, rejecting an unrecognized value. A null
+    /// value leaves the entry's current mode unchanged (PATCH semantics).</summary>
+    private static bool TryApplyLaunchMode(AgentEntry entry, string? raw, out string error)
+    {
+        if (raw is null)
+        {
+            error = "";
+            return true;
+        }
+        if (!TryParseLaunchMode(raw, entry.ArgsOverride, out var mode, out error))
+            return false;
+        entry.LaunchMode = mode;
+        return true;
+    }
+
+    /// <summary>Parse a launch-mode string against <see cref="LaunchMode"/>. An empty/whitespace
+    /// value resolves via the same migration rule the store uses (override present => Custom); a
+    /// non-empty unrecognized value is a caller error.</summary>
+    private static bool TryParseLaunchMode(string? raw, string? argsOverride, out LaunchMode mode, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            mode = AgentToolConfig.ParseLaunchMode("", argsOverride ?? "");
+            error = "";
+            return true;
+        }
+        if (Enum.TryParse(raw, ignoreCase: true, out mode) && Enum.IsDefined(mode))
+        {
+            error = "";
+            return true;
+        }
+        mode = LaunchMode.Guided;
+        error = $"unrecognized launchMode: {raw} (expected Guided or Custom)";
+        return false;
+    }
+
+    /// <summary>Seed an added entry's preset and default model from the catalog for built-in types,
+    /// matching what the Agents tab pre-populates when a user picks a type in the Add modal.</summary>
+    private static void ApplyType(AgentEntry entry, AgentKind type)
+    {
+        if (!AgentToolCatalog.Contains(type))
+            return;
+        var catalog = AgentToolCatalog.GetEntry(type);
+        entry.PresetId = catalog.DefaultPreset.Name;
+        entry.DefaultModel = catalog.DefaultModel;
+    }
+
+    private static string ToolDisplayName(AgentKind type) =>
+        TypeOptions.FirstOrDefault(o => o.Type == type).Label is { Length: > 0 } label
+            ? label
+            : type.ToString();
+}

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -348,6 +348,10 @@ public sealed class ControlApiHost : IAsyncDisposable
         SessionUsageEndpoint.Map(_app, _sessionManager);
         ClaudeTranscriptsEndpoint.Map(_app);
         SettingsEndpoint.Map(_app, ReapplyGatewayAsync, () => Port);
+        // /settings/agents (issue #584): full Settings-dialog Agents-tab parity over REST -
+        // library CRUD/reorder/enable plus Detect, Quick check, resolved command line, and the
+        // catalog, reusing the same Core services the Agents tab uses (one implementation).
+        AgentsEndpoint.Map(_app, _sessionManager.Options);
         ToolsEndpoint.Map(_app);
         WorkspacesEndpoint.Map(_app);
         SchedulerEndpoint.Map(_app, _schedulerAccessor);

--- a/src/CcDirector.Gateway.Tests/AgentsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AgentsEndpointTests.cs
@@ -1,0 +1,356 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json.Nodes;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// End-to-end tests for the /settings/agents REST surface on the Director Control API (issue #584).
+/// Runs against a real ControlApiHost on an ephemeral port. CC_DIRECTOR_ROOT is redirected to a temp
+/// dir so the tests read/write an isolated config.json, never the user's real one. In the
+/// "DirectorRoot" collection so it never runs alongside other root-touching tests.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class AgentsEndpointTests : IAsyncLifetime
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private ControlApiHost _host = null!; // assigned in InitializeAsync (xUnit lifecycle)
+    private SessionManager _sm = null!;   // assigned in InitializeAsync (xUnit lifecycle)
+    private HttpClient _client = null!;   // assigned in InitializeAsync (xUnit lifecycle)
+
+    public AgentsEndpointTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-agents-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Seed a config with an explicit two-entry agent library plus an unrelated section, so we
+        // can prove targeted writes preserve siblings and the unrelated section.
+        var path = CcStorage.ConfigJson();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, """
+        {
+          "gateway": { "url": "http://gw.example:7878" },
+          "agent": {
+            "entries": [
+              {
+                "id": "id-claude",
+                "display_name": "Claude Code",
+                "type": "ClaudeCode",
+                "enabled": true,
+                "executable_path": "claude",
+                "preset_id": "Standard",
+                "default_model": "sonnet",
+                "args_override": "",
+                "launch_mode": "Guided"
+              },
+              {
+                "id": "id-codex",
+                "display_name": "Codex",
+                "type": "Codex",
+                "enabled": false,
+                "executable_path": "codex",
+                "preset_id": "Standard",
+                "default_model": "",
+                "args_override": "",
+                "launch_mode": "Guided"
+              }
+            ]
+          }
+        }
+        """);
+
+        _sm = new SessionManager(new AgentOptions());
+        _host = new ControlApiHost(_sm, "1.0.0-test", () => Task.CompletedTask, useEphemeralPort: true);
+        var port = await _host.StartAsync();
+        _client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _sm.Dispose();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task List_returns_every_entry_in_file_order()
+    {
+        var obj = await _client.GetFromJsonAsync<JsonObject>("settings/agents");
+        Assert.NotNull(obj);
+        var agents = obj!["agents"]!.AsArray();
+        Assert.Equal(2, agents.Count);
+        Assert.Equal("id-claude", (string?)agents[0]!["id"]);
+        Assert.Equal("id-codex", (string?)agents[1]!["id"]);
+    }
+
+    [Fact]
+    public async Task Get_by_id_returns_all_values()
+    {
+        var obj = await _client.GetFromJsonAsync<JsonObject>("settings/agents/id-claude");
+        Assert.NotNull(obj);
+        Assert.Equal("Claude Code", (string?)obj!["displayName"]);
+        Assert.Equal("ClaudeCode", (string?)obj["type"]);
+        Assert.Equal("Standard", (string?)obj["presetId"]);
+        Assert.Equal("sonnet", (string?)obj["defaultModel"]);
+        Assert.Equal("Guided", (string?)obj["launchMode"]);
+    }
+
+    [Fact]
+    public async Task Get_by_unknown_id_returns_404()
+    {
+        var resp = await _client.GetAsync("settings/agents/does-not-exist");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Add_appends_entry_and_returns_it_with_id()
+    {
+        var body = new JsonObject { ["type"] = "Gemini", ["displayName"] = "My Gemini" };
+        var resp = await _client.PostAsJsonAsync("settings/agents", body);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var created = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.NotNull(created);
+        var newId = (string?)created!["id"];
+        Assert.False(string.IsNullOrWhiteSpace(newId));
+        Assert.Equal("Gemini", (string?)created["type"]);
+        Assert.Equal("My Gemini", (string?)created["displayName"]);
+
+        // Present in the file and in a follow-up list.
+        var onDisk = CcDirectorConfigService.ReadRaw();
+        var entries = onDisk["agent"]!["entries"]!.AsArray();
+        Assert.Equal(3, entries.Count);
+        Assert.Contains(entries, e => (string?)e!["id"] == newId);
+
+        var list = await _client.GetFromJsonAsync<JsonObject>("settings/agents");
+        Assert.Equal(3, list!["agents"]!.AsArray().Count);
+    }
+
+    [Fact]
+    public async Task Patch_updates_single_value_and_preserves_other_entries()
+    {
+        var before = CcDirectorConfigService.ReadRaw();
+        var codexBefore = before["agent"]!["entries"]!.AsArray()[1]!.ToJsonString();
+
+        var patch = new JsonObject { ["argsOverride"] = "--my-flag" };
+        var resp = await _client.PatchAsync("settings/agents/id-claude",
+            new StringContent(patch.ToJsonString(), Encoding.UTF8, "application/json"));
+        resp.EnsureSuccessStatusCode();
+
+        var updated = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.Equal("--my-flag", (string?)updated!["argsOverride"]);
+
+        // Durable in the file under the right entry, and the OTHER entry is byte-identical.
+        var after = CcDirectorConfigService.ReadRaw();
+        var afterEntries = after["agent"]!["entries"]!.AsArray();
+        Assert.Equal("--my-flag", (string?)afterEntries[0]!["args_override"]);
+        Assert.Equal(codexBefore, afterEntries[1]!.ToJsonString());
+        // The unrelated gateway section is untouched.
+        Assert.Equal("http://gw.example:7878", (string?)after["gateway"]!["url"]);
+    }
+
+    [Fact]
+    public async Task Patch_each_editable_field_round_trips()
+    {
+        async Task AssertField(string jsonField, JsonNode value, string fileKey, string expected)
+        {
+            var patch = new JsonObject { [jsonField] = value };
+            var resp = await _client.PatchAsync("settings/agents/id-claude",
+                new StringContent(patch.ToJsonString(), Encoding.UTF8, "application/json"));
+            resp.EnsureSuccessStatusCode();
+
+            var get = await _client.GetFromJsonAsync<JsonObject>("settings/agents/id-claude");
+            Assert.Equal(expected, get![jsonField]!.ToString());
+
+            var onDisk = CcDirectorConfigService.ReadRaw();
+            Assert.Equal(expected, onDisk["agent"]!["entries"]!.AsArray()[0]![fileKey]!.ToString());
+        }
+
+        await AssertField("displayName", "Renamed", "display_name", "Renamed");
+        await AssertField("type", "Codex", "type", "Codex");
+        await AssertField("enabled", false, "enabled", "false");
+        await AssertField("executablePath", "C:/tools/claude.cmd", "executable_path", "C:/tools/claude.cmd");
+        await AssertField("presetId", "Automatic (skip permissions)", "preset_id", "Automatic (skip permissions)");
+        await AssertField("defaultModel", "opus", "default_model", "opus");
+        await AssertField("argsOverride", "--x", "args_override", "--x");
+        await AssertField("launchMode", "Custom", "launch_mode", "Custom");
+    }
+
+    [Fact]
+    public async Task Delete_removes_entry_and_it_is_gone_from_list_and_file()
+    {
+        var resp = await _client.DeleteAsync("settings/agents/id-codex");
+        resp.EnsureSuccessStatusCode();
+
+        var onDisk = CcDirectorConfigService.ReadRaw();
+        var entries = onDisk["agent"]!["entries"]!.AsArray();
+        Assert.Single(entries);
+        Assert.DoesNotContain(entries, e => (string?)e!["id"] == "id-codex");
+
+        var list = await _client.GetFromJsonAsync<JsonObject>("settings/agents");
+        Assert.DoesNotContain(list!["agents"]!.AsArray(), e => (string?)e!["id"] == "id-codex");
+    }
+
+    [Fact]
+    public async Task Delete_unknown_id_returns_404_and_leaves_file_unchanged()
+    {
+        var before = CcDirectorConfigService.ReadRaw().ToJsonString();
+        var resp = await _client.DeleteAsync("settings/agents/nope");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal(before, CcDirectorConfigService.ReadRaw().ToJsonString());
+    }
+
+    [Fact]
+    public async Task Reorder_sets_file_order_to_requested_order()
+    {
+        var body = new JsonObject { ["ids"] = new JsonArray("id-codex", "id-claude") };
+        var resp = await _client.PostAsJsonAsync("settings/agents/reorder", body);
+        resp.EnsureSuccessStatusCode();
+
+        var onDisk = CcDirectorConfigService.ReadRaw();
+        var entries = onDisk["agent"]!["entries"]!.AsArray();
+        Assert.Equal("id-codex", (string?)entries[0]!["id"]);
+        Assert.Equal("id-claude", (string?)entries[1]!["id"]);
+    }
+
+    [Fact]
+    public async Task Reorder_with_bad_ids_is_rejected_and_file_unchanged()
+    {
+        var before = CcDirectorConfigService.ReadRaw().ToJsonString();
+        var body = new JsonObject { ["ids"] = new JsonArray("id-claude") }; // missing id-codex
+        var resp = await _client.PostAsJsonAsync("settings/agents/reorder", body);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Equal(before, CcDirectorConfigService.ReadRaw().ToJsonString());
+    }
+
+    [Fact]
+    public async Task Enabled_toggle_sets_the_flag()
+    {
+        var body = new JsonObject { ["enabled"] = true };
+        var resp = await _client.PostAsJsonAsync("settings/agents/id-codex/enabled", body);
+        resp.EnsureSuccessStatusCode();
+
+        var onDisk = CcDirectorConfigService.ReadRaw();
+        Assert.True((bool)onDisk["agent"]!["entries"]!.AsArray()[1]!["enabled"]!);
+    }
+
+    [Fact]
+    public async Task Detect_custom_type_says_nothing_to_detect()
+    {
+        var body = new JsonObject { ["type"] = "RawCli" };
+        var resp = await _client.PostAsJsonAsync("settings/agents/detect", body);
+        resp.EnsureSuccessStatusCode();
+        var result = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.False((bool)result!["detectable"]!);
+        Assert.False((bool)result["found"]!);
+    }
+
+    [Fact]
+    public async Task Detect_builtin_type_returns_a_found_result_shape()
+    {
+        var body = new JsonObject { ["type"] = "ClaudeCode" };
+        var resp = await _client.PostAsJsonAsync("settings/agents/detect", body);
+        resp.EnsureSuccessStatusCode();
+        var result = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.True((bool)result!["detectable"]!);
+        // found may be true or false depending on the test host; the shape is what we assert.
+        Assert.True(result.ContainsKey("found"));
+        Assert.True(result.ContainsKey("source"));
+        Assert.True(result.ContainsKey("message"));
+    }
+
+    [Fact]
+    public async Task QuickCheck_persists_validation_status_in_config()
+    {
+        var body = new JsonObject { ["type"] = "ClaudeCode", ["path"] = "definitely-not-a-real-tool.exe" };
+        var resp = await _client.PostAsJsonAsync("settings/agents/quick-check", body);
+        resp.EnsureSuccessStatusCode();
+        var result = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.False((bool)result!["ok"]!); // a bogus path cannot pass
+
+        // The validation status is recorded the same way the Agents tab records it.
+        var onDisk = CcDirectorConfigService.ReadRaw();
+        var status = onDisk["agent_status"]!["claude"]!.AsObject();
+        Assert.False((bool)status["ok"]!);
+        Assert.True(status.ContainsKey("tested_at_utc"));
+    }
+
+    [Fact]
+    public async Task CommandLine_matches_the_resolver_for_a_guided_claude_config()
+    {
+        var body = new JsonObject
+        {
+            ["type"] = "ClaudeCode",
+            ["executablePath"] = "claude",
+            ["presetId"] = "Automatic (skip permissions)",
+            ["defaultModel"] = "opus",
+            ["launchMode"] = "Guided",
+        };
+        var resp = await _client.PostAsJsonAsync("settings/agents/command-line", body);
+        resp.EnsureSuccessStatusCode();
+        var result = await resp.Content.ReadFromJsonAsync<JsonObject>();
+
+        // Same resolution the Agents tab preview uses (AgentToolConfig.ResolveEffectiveCommandLineArguments).
+        var expected = new AgentToolConfig
+        {
+            Tool = CcDirector.Core.Agents.AgentKind.ClaudeCode,
+            PresetName = "Automatic (skip permissions)",
+            DefaultModel = "opus",
+            LaunchMode = LaunchMode.Guided,
+        }.ResolveEffectiveCommandLineArguments();
+        Assert.Equal(expected, (string?)result!["arguments"]);
+        Assert.Equal($"claude {expected}", (string?)result["commandLine"]);
+    }
+
+    [Fact]
+    public async Task Catalog_returns_types_presets_and_models()
+    {
+        var obj = await _client.GetFromJsonAsync<JsonObject>("settings/agents/catalog");
+        Assert.NotNull(obj);
+        var types = obj!["types"]!.AsArray();
+        var claude = types.First(t => (string?)t!["type"] == "ClaudeCode")!.AsObject();
+        Assert.True((bool)claude["supportsModelSelection"]!);
+        Assert.Equal("--model", (string?)claude["modelFlag"]);
+        Assert.NotEmpty(claude["presets"]!.AsArray());
+        Assert.NotEmpty(claude["models"]!.AsArray());
+
+        // A non-model tool reports no model selection and an empty model list.
+        var pi = types.First(t => (string?)t!["type"] == "Pi")!.AsObject();
+        Assert.False((bool)pi["supportsModelSelection"]!);
+        Assert.Empty(pi["models"]!.AsArray());
+    }
+
+    [Fact]
+    public async Task Invalid_type_is_rejected_with_400_and_file_unchanged()
+    {
+        var before = CcDirectorConfigService.ReadRaw().ToJsonString();
+        var body = new JsonObject { ["type"] = "NotARealAgent" };
+        var resp = await _client.PostAsJsonAsync("settings/agents", body);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Equal(before, CcDirectorConfigService.ReadRaw().ToJsonString());
+    }
+
+    [Fact]
+    public async Task Invalid_launch_mode_on_patch_is_rejected_with_400_and_file_unchanged()
+    {
+        var before = CcDirectorConfigService.ReadRaw().ToJsonString();
+        var patch = new JsonObject { ["launchMode"] = "Sideways" };
+        var resp = await _client.PatchAsync("settings/agents/id-claude",
+            new StringContent(patch.ToJsonString(), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Equal(before, CcDirectorConfigService.ReadRaw().ToJsonString());
+    }
+}


### PR DESCRIPTION
Implements #584 - dedicated agent-management REST routes under `/settings/agents` on the Director Control API, reaching full parity with the Settings dialog Agents tab.

## Release Notes
Agents can now be managed entirely over REST: list, get, add, update a single field, remove, reorder, and enable/disable agents, plus Detect, Quick check, the resolved launch command line, and the catalog (types, presets, models). This lets an external agent, a script, the Cockpit, or a remote machine set up a Director's agents without the graphical dialog.

## Changes
- New `src/CcDirector.ControlApi/AgentsEndpoint.cs` mapping all `/settings/agents*` routes.
- Wired into `ControlApiHost` next to the existing `/settings` routes, passing `AgentOptions`.
- Reuses the same Core services the Agents tab uses (one implementation): `AgentEntryStore`/`CcDirectorConfigService` (non-lossy writes), `ToolDetectionService` (Detect + Quick check + persisted validation), `AgentToolConfig.ResolveEffectiveCommandLineArguments` (command line), `AgentToolCatalog` + `AgentDrivers` (catalog).
- 18 new end-to-end tests in `src/CcDirector.Gateway.Tests/AgentsEndpointTests.cs`.

## How to Test
Build clean (`dotnet build cc-director.sln`, 0 warnings), run `AgentsEndpointTests` (18 pass), or drive a live Director's loopback Control API: `GET /settings/agents`, `PATCH /settings/agents/{id}`, `POST /settings/agents/detect`, `GET /settings/agents/catalog`, etc.

## Expected Result
Every acceptance criterion proven against a live Director over the loopback Control API; unrelated `config.json` sections preserved on every write; invalid ids/values rejected with a clear error and a non-success status.

## Before/After
Before: only `GET`/`PUT /settings` (scalar) - a deep merge-patch of the `agent.entries` array could not cleanly add/update-one-field/remove/reorder a single agent, and Detect/Quick check/command-line/catalog were unreachable over REST. After: dedicated `/settings/agents` routes cover all of it with full dialog parity.

Proof: docs/cencon/proof/issue-584/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)