### PR TITLE
[Voice] Migrate phone push-to-talk to the shared batch pipeline (#592)

### DIFF
--- a/docs/cencon/architecture_manifest.yaml
+++ b/docs/cencon/architecture_manifest.yaml
@@ -1143,6 +1143,16 @@ data_flows:
       - "VoiceService intent parse -> SessionManager action"
       - "VoiceTurnLog records inbound/outbound for review"
 
+  - id: phone_push_to_talk_turn_flow
+    name: Phone Push-to-Talk Audio-Reply Turn Flow
+    description: Phone push-to-talk records one clip, uploads it resumably, and the server transcribes the whole clip once via the shared batch pipeline using the user-selected method (issue #592 - no hardcoded whisper-1 path, dictionary-only correction, completeness gate), then summarizes and speaks the reply back
+    path:
+      - "Phone -> Gateway /sessions/{id}/voice-turn/upload chunk PUTs (idempotent, SHA256), then /complete"
+      - "VoiceUploadStore reassembles the whole clip; completeness gate (issue #586): a missing OR zero-byte chunk is refused as 'incomplete' (409) with the indices to re-send - a truncated upload is never forwarded for transcription"
+      - "Gateway GatewayVoiceTurnEndpoint forwards the assembled whole clip to the owning Director's POST /sessions/{id}/voice-turn (VoiceTurnEndpoint, SSE)"
+      - "VoiceTurnEndpoint transcribes the whole clip ONCE through the shared BatchTranscriptionPipeline via VoiceService using the Gateway/user-selected method (issue #587 - no hardcoded whisper-1 endpoint), then dictionary-only correction (no free-text cleanup; a no-dictionary-term utterance returns byte-identical raw text)"
+      - "Send the dictionary-corrected transcript to the session -> ClaudeSummarizer -> TtsService -> reply audio streamed back as the SSE reply event"
+
   - id: wingman_state_flow
     name: Wingman Terminal-State Flow
     description: Read-only derivation of session status from the terminal (timer only, no LLM)

--- a/docs/cencon/proof/issue-592/report.html
+++ b/docs/cencon/proof/issue-592/report.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue 592 - Developer Agent Proof Report</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1.25rem; color: #1a1a1a; line-height: 1.55; }
+  h1 { border-bottom: 3px solid #2b6cb0; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #2b6cb0; }
+  code, pre { font-family: Consolas, Menlo, monospace; }
+  pre { background: #f5f7fa; border: 1px solid #dde3ea; border-radius: 6px; padding: .9rem; overflow-x: auto; font-size: .86rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cbd5e0; padding: .55rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #edf2f7; }
+  .pass { color: #22863a; font-weight: 600; }
+  .pill { display: inline-block; background: #2b6cb0; color: #fff; border-radius: 12px; padding: .12rem .6rem; font-size: .78rem; }
+  .belief { background: #f0fff4; border: 1px solid #9ae6b4; border-radius: 6px; padding: 1rem; margin-top: 2rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue 592 - Migrate phone push-to-talk to the shared batch pipeline</h1>
+<p>
+  <span class="pill">Developer Agent</span>
+  <span class="pill">CenCon Development Method</span>
+  <span class="pill">Branch: issue-592-phone-pushtotalk-shared-pipeline</span>
+</p>
+
+<h2>Release Notes</h2>
+<p>
+  Phone push-to-talk (the audio-reply walkie-talkie turn) now transcribes the whole recorded clip
+  ONCE through the one shared batch transcription pipeline using your selected transcription method
+  (bring-your-own OpenAI or DevThrottle), instead of a hardcoded whisper-1 / api.openai.com path.
+  Switching the selected method changes where the recording is transcribed, with no restart. The
+  only post-transcription change is the validated dictionary corrector - the free-text language-model
+  cleanup is not in this path, so an utterance with no dictionary term comes back byte-identical to
+  the raw transcription. The whole clip is verified complete by the completeness gate before
+  transcription: a truncated upload (a missing or zero-byte chunk) is refused, never transcribed.
+</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li>
+    <strong>CcDirector.ControlApi/VoiceTurnEndpoint.cs</strong> - the Director-side server walkie-talkie
+    turn the phone push-to-talk audio reaches (via the Gateway resumable-upload front door). Removed the
+    hardcoded <code>whisper-1</code> / <code>https://api.openai.com/v1/audio/transcriptions</code>
+    constants and the bespoke <code>TranscribeAsync</code> / <code>GuessAudioContentType</code> /
+    <code>TruncateLog</code> helpers. The audio path now transcribes the whole clip ONCE through the
+    shared <code>BatchTranscriptionPipeline</code> via <code>VoiceService.TranscribeAndCleanAsync</code>,
+    which resolves the user-selected method through the Gateway routing resolver
+    (<code>OpenAiKeyResolver.ResolveEndpointAsync</code>) and applies the dictionary corrector only -
+    no free-text cleanup. The dictionary-corrected transcript is the turn's input text.
+  </li>
+  <li>
+    <strong>CcDirector.Gateway/Voice/VoiceUploadStore.cs</strong> - the completeness gate that
+    reassembles the phone's resumable chunk upload now treats a zero-byte chunk the same as a missing
+    one (the issue #586 contract), so a truncated upload is reported "incomplete" with the indices to
+    re-send and never produces an assembled clip to transcribe.
+  </li>
+  <li>
+    <strong>docs/cencon/architecture_manifest.yaml</strong> - added the
+    <code>phone_push_to_talk_turn_flow</code> data flow describing the migrated path
+    (upload + gate -> Gateway forward -> Director shared-pipeline transcription via the selected
+    method -> dictionary-only correction -> summarize + TTS reply).
+  </li>
+  <li>
+    <strong>Tests</strong> - new <code>VoiceTurnSharedPipelineRegressionTests</code> (the endpoint no
+    longer carries the hardcoded whisper constants or the bespoke transcription helper);
+    <code>VoiceUploadStoreTests.Assemble_ZeroByteChunk_RefusedAsIncomplete</code> (truncated upload
+    refused by the gate); and <code>VoiceTurnEndpointTests.VoiceTurn_AudioInput_NoKey_EmitsNoKeyError</code>
+    hardened to isolate the routing resolver from the host machine's real config.json via
+    <code>CC_DIRECTOR_ROOT</code>.
+  </li>
+</ul>
+
+<h2>Acceptance criteria - how each is met and verified</h2>
+<table>
+  <tr><th>Criterion</th><th>How the code satisfies it</th><th>Verification</th></tr>
+  <tr>
+    <td>Phone push-to-talk transcription uses the selected method via the shared pipeline, not the hardcoded whisper-1 path. (Changing the selected method changes the base URL.)</td>
+    <td>The hardcoded whisper-1 / api.openai.com constants and bespoke transcription helper are removed; the audio path calls <code>VoiceService.TranscribeAndCleanAsync</code> -&gt; <code>BatchTranscriptionPipeline</code>, whose base URL, key, and model come entirely from the resolved selected method.</td>
+    <td class="pass">BatchTranscriptionPipelineTests.TranscribeAsync_ByoMode_/_DevThrottleMode_RoutesTo...Url (different base URL per method) PASS; VoiceTurnSharedPipelineRegressionTests (no hardcoded constants/helper) PASS.</td>
+  </tr>
+  <tr>
+    <td>The free-text cleanup is not in this path; a no-dictionary-term utterance returns byte-identical to the raw transcription.</td>
+    <td>The shared pipeline applies only the validated dictionary corrector; with no dictionary hit, corrected == raw byte-for-byte. The endpoint uses the dictionary-corrected transcript.</td>
+    <td class="pass">BatchTranscriptionPipelineTests.TranscribeAsync_NoDictionaryTerms_ReturnsRawByteIdentical PASS.</td>
+  </tr>
+  <tr>
+    <td>The whole clip is sent and verified by the gate before transcription; an incomplete (truncated) upload is refused, not transcribed.</td>
+    <td>The Gateway's <code>VoiceUploadStore.AssembleAsync</code> refuses a missing OR zero-byte chunk as "incomplete" (409) with the indices to re-send; no assembled clip is forwarded for transcription.</td>
+    <td class="pass">VoiceUploadStoreTests.Assemble_MissingChunk_ReportsIncompleteWithIndices and Assemble_ZeroByteChunk_RefusedAsIncomplete PASS.</td>
+  </tr>
+  <tr>
+    <td>The whole clip is transcribed once; there is no partial transcription.</td>
+    <td>The shared pipeline issues exactly ONE batch POST to <code>{baseUrl}/audio/transcriptions</code> for the whole clip; there is no streaming/partial path. The endpoint calls it once per turn.</td>
+    <td class="pass">BatchTranscriptionPipelineTests (single /audio/transcriptions request asserted via <code>.Single(...)</code>) PASS.</td>
+  </tr>
+</table>
+
+<h2>Build and test evidence</h2>
+<pre>
+dotnet build cc-director.sln
+  Build succeeded.  0 Warning(s)  0 Error(s)
+
+dotnet test CcDirector.Gateway.Tests (full)
+  Passed!  Failed: 0, Passed: 861, Skipped: 1 (pre-existing realtime-provider integration skip)
+
+dotnet test CcDirector.Core.Tests --filter Transcription|Voice
+  Passed!  Failed: 0, Passed: 170, Skipped: 0
+
+dotnet test CcDirector.Gateway.Tests --filter VoiceUploadStore|VoiceTurn
+  Passed!  Failed: 0, Passed: 57, Skipped: 0
+</pre>
+
+<h2>Runtime evidence (slot 13 test Director)</h2>
+<p>Built <code>cc-director13.exe</code> from this worktree and launched it via the per-slot scheduled task
+(clean svchost parentage). The Director booted clean and served the migrated voice-turn route:</p>
+<pre>
+[ControlApiHost] Kestrel listening on http://127.0.0.1:7885 (loopback only ...)
+[VoiceTurnEndpoint] POST /sessions/5ba8dfaf-.../voice-turn from 127.0.0.1
+[ControlApiHost] POST /sessions/5ba8dfaf-.../voice-turn -> 404 (unknown session, as expected)
+healthz: {"status":"ok","version":"0.9.13", ...}
+Running image: D:\ReposFred\devthrottle-wt-592\local_builds\cc-director13.exe
+</pre>
+<p>The selected-method routing, byte-identical-without-a-dictionary-hit, and single-batch-call behaviors
+are proven deterministically by the unit tests above (a stub HTTP handler records the exact URL/key/model
+and request count), since observing them end-to-end requires a live transcription provider.</p>
+
+<h2>CenCon impact</h2>
+<p>
+  Architecture: added the <code>phone_push_to_talk_turn_flow</code> data flow and the change is consistent
+  with the shared-pipeline direction already recorded for issues #587/#590/#591. No security posture change:
+  no new credential handling, no new external surface; the bring-your-own key is still only ever paired with
+  the provider's own URL by the routing resolver (the same guarantee the shared pipeline already enforces).
+  <code>architecture_manifest.yaml</code> last_updated is current (2026-06-21); security_profile last_verified
+  2026-06-09 is within the 30-day threshold.
+</p>
+
+<div class="belief">
+  <strong>I believe this is finished.</strong> The hardcoded whisper-1 / api.openai.com path is gone from the
+  phone push-to-talk turn; transcription routes through the one shared batch pipeline via the user-selected
+  method with dictionary-only correction; the whole clip is gated complete (missing or zero-byte chunk refused)
+  before a single whole-clip transcription. Build is clean (0/0), all relevant tests pass, and a slot-13 binary
+  built from this branch booted clean and served the route.
+</div>
+
+</body>
+</html>

--- a/src/CcDirector.ControlApi/VoiceTurnEndpoint.cs
+++ b/src/CcDirector.ControlApi/VoiceTurnEndpoint.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -17,7 +16,12 @@ namespace CcDirector.ControlApi;
 /// Maps POST /sessions/{id}/voice-turn - the server-side walkie-talkie turn (issue #351).
 ///
 /// One call = one complete turn:
-///   1. (optional) Transcribe raw audio via Whisper.
+///   1. (optional) Transcribe the whole audio clip ONCE through the shared batch pipeline
+///      (issue #587) using the user-selected transcription method (issue #592) - the base URL,
+///      key, and model come from the Gateway routing resolver, NOT a hardcoded whisper-1 path -
+///      then apply the validated dictionary corrector only (no free-text cleanup). The
+///      completeness gate ran upstream (the Gateway reassembles the whole clip before
+///      forwarding), so a partial upload never reaches transcription.
 ///   2. Wait until the session is ready (not mid-turn).
 ///   3. POST the text to the session via /prompt.
 ///   4. Poll until the turn is done.
@@ -41,9 +45,6 @@ internal static class VoiceTurnEndpoint
     // Max time to wait for a turn to complete after posting text.
     private static readonly TimeSpan TurnCompleteTimeout = TimeSpan.FromSeconds(120);
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
-
-    private const string WhisperEndpoint = "https://api.openai.com/v1/audio/transcriptions";
-    private const string WhisperModel = "whisper-1";
 
     public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager)
     {
@@ -119,24 +120,36 @@ internal static class VoiceTurnEndpoint
 
                         await EmitAsync(new { stage = "transcribing" });
 
-                        var key = options.ResolveOpenAiKey();
-                        if (string.IsNullOrWhiteSpace(key))
+                        // The whole clip is transcribed ONCE through the ONE shared batch pipeline
+                        // (issue #587) using the user-selected method (issue #592): the base URL,
+                        // key, and model come from the Gateway routing resolver, NOT a hardcoded
+                        // whisper-1 / api.openai.com endpoint, so changing the selected method
+                        // changes the base URL the upload is transcribed against. The only
+                        // post-transcription transform is the validated dictionary corrector -
+                        // there is NO free-text language-model cleanup - so an utterance with no
+                        // dictionary term comes back byte-identical to the raw transcription. The
+                        // completeness gate ran upstream (the Gateway reassembles the whole clip
+                        // before forwarding it here), so the bytes are already complete.
+                        await using var stream = file.OpenReadStream();
+                        var voice = new VoiceService(sessionManager, options);
+                        var transcription = await voice.TranscribeAndCleanAsync(stream, file.FileName, session.RepoPath, ct);
+
+                        if (string.Equals(transcription.Status, "no_key", StringComparison.Ordinal))
                         {
-                            await EmitAsync(new { stage = "error", message = "no_key: OpenAI API key not configured; transcription unavailable" });
+                            FileLog.Write($"[VoiceTurnEndpoint] sid={guid}: transcription routing unavailable (no key for selected method)");
+                            await EmitAsync(new { stage = "error", message = "no_key: " + (transcription.Error ?? "transcription routing unavailable") });
+                            return;
+                        }
+                        if (!string.Equals(transcription.Status, "ok", StringComparison.Ordinal))
+                        {
+                            FileLog.Write($"[VoiceTurnEndpoint] sid={guid}: transcription FAILED: {transcription.Error}");
+                            await EmitAsync(new { stage = "error", message = "transcription_failed: " + (transcription.Error ?? "unknown") });
                             return;
                         }
 
-                        try
-                        {
-                            await using var stream = file.OpenReadStream();
-                            inputText = await TranscribeAsync(stream, file.FileName, key, ct);
-                        }
-                        catch (Exception ex)
-                        {
-                            FileLog.Write($"[VoiceTurnEndpoint] Transcription FAILED: {ex.Message}");
-                            await EmitAsync(new { stage = "error", message = "transcription_failed: " + ex.Message });
-                            return;
-                        }
+                        // Use the dictionary-corrected transcript (raw text plus known dictionary
+                        // term swaps only) as the turn's input.
+                        inputText = transcription.CleanedTranscript ?? transcription.Transcript;
 
                         await EmitAsync(new { stage = "transcript", text = inputText });
                     }
@@ -320,51 +333,6 @@ internal static class VoiceTurnEndpoint
     // ===== Helpers =============================================================
 
     /// <summary>
-    /// Transcribe a raw audio file via Whisper (OpenAI audio/transcriptions).
-    /// Throws on any API error so the caller can emit a structured SSE error event.
-    /// </summary>
-    private static async Task<string> TranscribeAsync(
-        Stream audio, string fileName, string apiKey, CancellationToken ct)
-    {
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
-        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-
-        using var form = new MultipartFormDataContent();
-        var audioContent = new StreamContent(audio);
-        audioContent.Headers.ContentType = new MediaTypeHeaderValue(GuessAudioContentType(fileName));
-        form.Add(audioContent, "file", string.IsNullOrEmpty(fileName) ? "audio.webm" : fileName);
-        form.Add(new StringContent(WhisperModel), "model");
-
-        using var resp = await http.PostAsync(WhisperEndpoint, form, ct);
-        var body = await resp.Content.ReadAsStringAsync(ct);
-        if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Whisper returned {(int)resp.StatusCode}: {TruncateLog(body, 400)}");
-
-        using var doc = JsonDocument.Parse(body);
-        if (!doc.RootElement.TryGetProperty("text", out var textProp))
-            throw new InvalidOperationException("Whisper response missing 'text' field");
-
-        return (textProp.GetString() ?? "").Trim();
-    }
-
-    private static string GuessAudioContentType(string fileName)
-    {
-        var ext = Path.GetExtension(fileName).ToLowerInvariant();
-        return ext switch
-        {
-            ".webm" => "audio/webm",
-            ".ogg"  => "audio/ogg",
-            ".mp3"  => "audio/mpeg",
-            ".m4a"  => "audio/mp4",
-            ".mp4"  => "audio/mp4",
-            ".aac"  => "audio/aac",
-            ".wav"  => "audio/wav",
-            ".flac" => "audio/flac",
-            _       => "application/octet-stream",
-        };
-    }
-
-    /// <summary>
     /// Snapshot the byte length of the session's linked JSONL transcript.
     /// Taken immediately before SendTextAsync so <see cref="ReadNewAssistantText"/>
     /// can restrict the reply read to content appended during THIS turn (issue #366).
@@ -448,9 +416,6 @@ internal static class VoiceTurnEndpoint
 
         return text;
     }
-
-    private static string TruncateLog(string s, int max)
-        => s.Length <= max ? s : s[..max] + "...";
 }
 
 /// <summary>Request body for the JSON path of POST /sessions/{id}/voice-turn.</summary>

--- a/src/CcDirector.Gateway.Tests/VoiceTurnEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTurnEndpointTests.cs
@@ -142,9 +142,13 @@ public sealed class VoiceTurnEndpointTests : IAsyncLifetime
     // ===== Test 3: no OpenAI key + audio -> SSE no_key error =====
 
     /// <summary>
-    /// Verifies that VoiceTurn_AudioInput_Transcribes (the live test) falls back
-    /// correctly with a structured SSE error when no OpenAI key is present.
-    /// This covers the "no_key" guard on the audio path.
+    /// Verifies the audio path bails with a structured "no_key" SSE error when no transcription
+    /// method is resolvable. After the shared-pipeline migration (issue #592) the endpoint resolves
+    /// the user-selected method via the Gateway routing resolver, which reads the machine's
+    /// config.json; to make the "no method available" state deterministic regardless of the host
+    /// machine's real configuration, this test points CC_DIRECTOR_ROOT at an empty temp dir so
+    /// GatewayConfig.Load() finds no gateway and no key resolves -> the path emits "no_key" before
+    /// any transcription is attempted.
     /// </summary>
     [Fact]
     public async Task VoiceTurn_AudioInput_NoKey_EmitsNoKeyError()
@@ -153,26 +157,41 @@ public sealed class VoiceTurnEndpointTests : IAsyncLifetime
         _sm.AdoptSession(session);
         var sid = session.Id.ToString();
 
-        // Upload a tiny dummy audio blob - the endpoint should bail before reaching Whisper.
-        using var form = new MultipartFormDataContent();
-        var bytes = new byte[] { 0x1A, 0x45, 0xDF, 0xA3 }; // EBML magic; arbitrary audio-shaped bytes
-        var content = new ByteArrayContent(bytes);
-        content.Headers.ContentType = new MediaTypeHeaderValue("audio/webm");
-        form.Add(content, "audio", "recording.webm");
+        // Isolate the routing resolver from the host machine's real config.json: an empty root has
+        // no gateway block and no local key, so no transcription method resolves (the deterministic
+        // "no method available" state this test asserts).
+        var isolatedRoot = Path.Combine(Path.GetTempPath(), "cc-voiceturn-nokey-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(isolatedRoot);
+        var originalRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", isolatedRoot);
+        try
+        {
+            // Upload a tiny dummy audio blob - the endpoint should bail before transcription.
+            using var form = new MultipartFormDataContent();
+            var bytes = new byte[] { 0x1A, 0x45, 0xDF, 0xA3 }; // EBML magic; arbitrary audio-shaped bytes
+            var content = new ByteArrayContent(bytes);
+            content.Headers.ContentType = new MediaTypeHeaderValue("audio/webm");
+            form.Add(content, "audio", "recording.webm");
 
-        var resp = await _client.PostAsync($"sessions/{sid}/voice-turn", form);
+            var resp = await _client.PostAsync($"sessions/{sid}/voice-turn", form);
 
-        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-        Assert.Equal("text/event-stream", resp.Content.Headers.ContentType?.MediaType);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal("text/event-stream", resp.Content.Headers.ContentType?.MediaType);
 
-        var events = await ReadSseEventsAsync(resp);
+            var events = await ReadSseEventsAsync(resp);
 
-        // Should emit "transcribing" then "error" (no_key).
-        var stageNames = events.Select(e => ReadStage(e)).Where(s => s is not null).ToList();
-        Assert.Contains("transcribing", stageNames);
-        var errorEvent = events.FirstOrDefault(e => ReadStage(e) == "error");
-        Assert.NotNull(errorEvent);
-        Assert.Contains("no_key", ReadField(errorEvent!, "message"), StringComparison.OrdinalIgnoreCase);
+            // Should emit "transcribing" then "error" (no_key).
+            var stageNames = events.Select(e => ReadStage(e)).Where(s => s is not null).ToList();
+            Assert.Contains("transcribing", stageNames);
+            var errorEvent = events.FirstOrDefault(e => ReadStage(e) == "error");
+            Assert.NotNull(errorEvent);
+            Assert.Contains("no_key", ReadField(errorEvent!, "message"), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", originalRoot);
+            try { Directory.Delete(isolatedRoot, recursive: true); } catch { /* test cleanup */ }
+        }
     }
 
     // ===== Test 4: session exits before/during the turn -> structured SSE error =====

--- a/src/CcDirector.Gateway.Tests/VoiceTurnSharedPipelineRegressionTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTurnSharedPipelineRegressionTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using CcDirector.ControlApi;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Regression guard for issue #592: the phone push-to-talk turn (the Director-side
+/// <see cref="VoiceTurnEndpoint"/> reached via the Gateway's resumable-upload front door) must
+/// transcribe through the ONE shared batch pipeline (issue #587) using the user-SELECTED method,
+/// NOT the old hardcoded whisper-1 / api.openai.com path, and must apply the dictionary corrector
+/// only - no free-text language-model cleanup.
+///
+/// The pipeline's own routing, byte-identical-without-a-dictionary-hit, and one-batch-call
+/// behaviors are proven directly in <c>BatchTranscriptionPipelineTests</c>; the audio path's
+/// no-method-resolvable behavior is proven in <c>VoiceTurnEndpointTests</c>. This guard locks in
+/// the structural change so the hardcoded endpoint can never silently return: it asserts the
+/// compiled <see cref="VoiceTurnEndpoint"/> type no longer carries the legacy whisper-1 constants
+/// or its own bespoke transcription HTTP helper.
+/// </summary>
+public sealed class VoiceTurnSharedPipelineRegressionTests
+{
+    [Fact]
+    public void VoiceTurnEndpoint_HasNoHardcodedWhisperConstants()
+    {
+        var type = typeof(VoiceTurnEndpoint);
+
+        // The old path baked the URL + model in as private const string fields. After the
+        // migration the type carries neither - the route, key, and model come from the resolved
+        // method at request time.
+        var stringConstants = type
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+            .Select(f => (string?)f.GetRawConstantValue())
+            .ToList();
+
+        Assert.DoesNotContain(stringConstants, v => v is not null && v.Contains("whisper-1", StringComparison.Ordinal));
+        Assert.DoesNotContain(stringConstants, v => v is not null && v.Contains("api.openai.com", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void VoiceTurnEndpoint_HasNoBespokeTranscribeHelper()
+    {
+        var type = typeof(VoiceTurnEndpoint);
+
+        // The bespoke whisper transcription helper (and its content-type guesser) were removed: the
+        // shared pipeline owns the single transcription transport now. Their absence proves the
+        // endpoint cannot transcribe except through the shared path.
+        var methodNames = type
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public)
+            .Select(m => m.Name)
+            .ToList();
+
+        Assert.DoesNotContain("TranscribeAsync", methodNames);
+        Assert.DoesNotContain("GuessAudioContentType", methodNames);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -71,6 +71,26 @@ public sealed class VoiceUploadStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task Assemble_ZeroByteChunk_RefusedAsIncomplete()
+    {
+        // Issue #592: a TRUNCATED upload (a chunk landed but is empty/zero-byte) must be refused
+        // by the completeness gate, never transcribed. The gate treats a zero-byte chunk the same
+        // as a missing one (the #586 contract) and names the index to re-send.
+        var id = _store.Register(null);
+        await _store.StoreChunkAsync(id, 0, Bytes("AAA"), null);
+        await _store.StoreChunkAsync(id, 2, Bytes("CCC"), null);
+        // Simulate a truncated landing of chunk 1: the file exists but is empty.
+        var chunkPath = Path.Combine(_root, Guid.Parse(id).ToString("N"), "00001.part");
+        await File.WriteAllBytesAsync(chunkPath, Array.Empty<byte>());
+
+        var result = await _store.AssembleAsync(id, 3);
+
+        Assert.Equal("incomplete", result.Status);
+        Assert.Equal(new[] { 1 }, result.Missing);
+        Assert.Null(result.Audio);
+    }
+
+    [Fact]
     public async Task Assemble_ResumeAfterMissing_Succeeds()
     {
         // The whole point: a partial upload is preserved, the client re-sends only what is

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -107,9 +107,16 @@ public sealed class VoiceUploadStore
         if (totalChunks <= 0)
             throw new InvalidOperationException("totalChunks must be > 0");
 
+        // Completeness gate (issue #586 contract, applied here for the phone push-to-talk upload,
+        // issue #592): every index 0..totalChunks-1 must be present AND non-empty. A missing OR
+        // zero-byte chunk is "incomplete" - the result names the exact indices to re-send and NO
+        // assembled clip is produced, so a truncated upload is refused, never transcribed.
         var missing = new List<int>();
         for (var i = 0; i < totalChunks; i++)
-            if (!File.Exists(ChunkPath(dir, i))) missing.Add(i);
+        {
+            var path = ChunkPath(dir, i);
+            if (!File.Exists(path) || new FileInfo(path).Length == 0) missing.Add(i);
+        }
         if (missing.Count > 0)
         {
             FileLog.Write($"[VoiceUploadStore] Assemble: uploadId={uid} INCOMPLETE missing={string.Join(',', missing)}");


### PR DESCRIPTION
Closes #592. Parent #585. Builds on #586 (completeness gate), #587 (shared batch pipeline), #588 (UI component), and follows #590 (desktop voice) / #591 (phone recorder) patterns. Does NOT reimplement the shared foundations.

## Release Notes
Phone push-to-talk (the audio-reply walkie-talkie turn) now transcribes the whole recorded clip ONCE through the one shared batch transcription pipeline using your selected transcription method (bring-your-own OpenAI or DevThrottle), instead of a hardcoded whisper-1 / api.openai.com path. Switching the selected method changes where the recording is transcribed, with no restart. The only post-transcription change is the validated dictionary corrector - the free-text language-model cleanup is not in this path, so an utterance with no dictionary term comes back byte-identical to the raw transcription. The whole clip is verified complete by the completeness gate before transcription: a truncated upload (a missing or zero-byte chunk) is refused, never transcribed.

## Changes
- **CcDirector.ControlApi/VoiceTurnEndpoint.cs** - the Director-side server walkie-talkie turn the phone push-to-talk audio reaches (via the Gateway resumable-upload front door). Removed the hardcoded `whisper-1` / `https://api.openai.com/v1/audio/transcriptions` constants and the bespoke `TranscribeAsync` / `GuessAudioContentType` / `TruncateLog` helpers. The audio path now transcribes the whole clip ONCE through the shared `BatchTranscriptionPipeline` via `VoiceService.TranscribeAndCleanAsync`, which resolves the user-selected method through the Gateway routing resolver (`OpenAiKeyResolver.ResolveEndpointAsync`) and applies the dictionary corrector only. The dictionary-corrected transcript is the turn's input text; `no_key` / failure map to the existing structured SSE error stages.
- **CcDirector.Gateway/Voice/VoiceUploadStore.cs** - the completeness gate that reassembles the phone's resumable chunk upload now treats a zero-byte chunk the same as a missing one (the #586 contract), so a truncated upload is reported "incomplete" with the indices to re-send and never produces an assembled clip to transcribe.
- **docs/cencon/architecture_manifest.yaml** - added the `phone_push_to_talk_turn_flow` data flow.
- **Tests** - new `VoiceTurnSharedPipelineRegressionTests` (the endpoint no longer carries the hardcoded whisper constants or the bespoke transcription helper); `VoiceUploadStoreTests.Assemble_ZeroByteChunk_RefusedAsIncomplete`; and `VoiceTurnEndpointTests.VoiceTurn_AudioInput_NoKey_EmitsNoKeyError` hardened to isolate the routing resolver from the host machine's real config.json via `CC_DIRECTOR_ROOT`.

## How to Test
- `dotnet build cc-director.sln` (clean: 0/0).
- `dotnet test src/CcDirector.Gateway.Tests` (861 pass, 1 pre-existing skip).
- `dotnet test src/CcDirector.Core.Tests --filter Transcription|Voice` (170 pass).

## Expected Result
- Changing the selected transcription method changes the base URL the push-to-talk clip is transcribed against (BatchTranscriptionPipeline routing tests).
- A no-dictionary-term utterance returns byte-identical to the raw transcription.
- A truncated upload (missing or zero-byte chunk) is refused by the gate as "incomplete", never transcribed.
- The whole clip is transcribed once (one batch call), no partial transcription.

## Before / After
- **Before:** `VoiceTurnEndpoint.TranscribeAsync` hardcoded the OpenAI `whisper-1` endpoint and key for every phone push-to-talk turn, ignoring the selected method; the Gateway gate only checked chunk existence, not zero-byte truncation.
- **After:** the turn routes through the shared `BatchTranscriptionPipeline` via the user-selected method with dictionary-only correction, and the gate refuses a missing OR zero-byte chunk.

Proof: docs/cencon/proof/issue-592/report.html

Build clean (0/0). Gateway 861 pass (1 pre-existing skip), Core transcription/voice 170 pass. slot-13 binary booted clean and served the migrated voice-turn route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)