### PR TITLE
[Voice] TtsService per-request timeout, retry-once, and overall budget (#389)

### DIFF
--- a/docs/cencon/proof/issue-389/qa-report.html
+++ b/docs/cencon/proof/issue-389/qa-report.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #389 (TTS per-request timeout, retry-once, overall budget)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #2b6cb0; padding-bottom: .4rem; }
+  h2 { color: #2b6cb0; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cbd5e0; padding: .55rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #edf2f7; }
+  .pass { color: #22863a; font-weight: bold; }
+  .verdict { background: #f0fff4; border: 2px solid #22863a; padding: 1rem; margin-top: 2rem; font-size: 1.1rem; }
+  code { background: #f6f8fa; padding: .1rem .35rem; border-radius: 3px; font-family: Consolas, monospace; }
+  pre { background: #f6f8fa; padding: .8rem; border-radius: 5px; overflow-x: auto; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #389</h1>
+<p><strong>Issue:</strong> [Voice] TTS stalls up to 180s and returns no audio when an OpenAI request hangs (no per-request timeout/retry)</p>
+<p><strong>Pull request:</strong> #612 - branch <code>issue-389-tts-per-request-timeout</code></p>
+<p><strong>QA identity:</strong> independent QA Agent (separate from Developer). Verified in an isolated worktree built from the PR branch.</p>
+<p><strong>Date:</strong> 2026-06-21</p>
+
+<h2>Verification method</h2>
+<p>Because this is a backend resilience fix in <code>TtsService</code> (no UI surface), verification was performed by independently building and running the unit suite against the PR branch in a clean worktree, plus reading the diff against <code>main</code> and the upstream caller paths. The unit tests exercise the <em>real</em> per-request (30s) and overall-budget (60s) <code>CancellationTokenSource</code> deadlines via a scripted <code>HttpMessageHandler</code> - the observed test wall-clock timings are the proof, not the dev's claim.</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (my evidence)</th><th>Result</th></tr>
+<tr>
+  <td>1</td>
+  <td>A stalled/slow OpenAI request no longer blocks a turn 180s; worst-case TTS wall-time &lt;= ~60s</td>
+  <td>Worst case bounded by the 60s overall budget, never 180s</td>
+  <td><code>GenerateAsync_PersistentStall_FailsFast_WithinBudget</code> ran in <strong>1m 00s</strong> (the 60s <code>OverallBudget</code> ceiling), then returned failure. Code: <code>budgetCts.CancelAfter(OverallBudget=60s)</code> at line 108. No 180s anywhere; the shared client uses <code>Timeout.InfiniteTimeSpan</code> with linked CTS deadlines.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>A transient single-chunk failure (timeout or 5xx) is retried once before audio is abandoned</td>
+  <td>One retry on timeout / 5xx / empty body; CallCount == 2</td>
+  <td><code>FirstChunkStalls_PerRequestTimeoutFires_ThenRetries</code> (timeout, 30s then retry OK, CallCount=2), <code>TransientServerError_RetriesOnce_AndSucceeds</code> (5xx -> OK, CallCount=2), <code>EmptyBody_IsTransient_AndRetried</code> (empty -> OK, CallCount=2). Code: <code>CallWithRetryAsync</code> retries only when <code>Transient</code>.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>When TTS still fails after retry, reply is text-only within a few seconds; log records elapsed + failing chunk index + reason</td>
+  <td>Fast permanent failure; log line with ms + chunk i/N + reason; caller falls back to text</td>
+  <td><code>PermanentFailure_ReturnsErrorQuickly_NotAfter180s</code> (both 5xx) returned in <strong>&lt;1ms</strong>; <code>ClientError_IsPermanent_NotRetried</code> (4xx, CallCount=1, no retry). Log at TtsService.cs:125/144 emits <code>FAILED after {ms}ms: chunk i/N reason=...</code>. Caller <code>VoiceTurnEndpoint.cs:287-289</code> routes any non-success status to empty-audio (text-only) fallback - all new statuses (timeout, tts_budget_exceeded, openai_failed) handled generically.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>4</td>
+  <td>Success path (single- and multi-chunk) byte-identical concatenation, unchanged</td>
+  <td>Single chunk returns its bytes; multi-chunk = per-chunk MP3 concatenated in order</td>
+  <td><code>GenerateAsync_SingleChunk_ReturnsBytesUnchanged</code> asserts byte-identical single chunk; <code>GenerateAsync_MultiChunk_ConcatenatesBytesInOrder</code> asserts exact ordered concatenation. Diff vs main: split logic (<code>SplitIntoChunks/SplitIntoSentences/FindSafeBreak</code>) untouched; concatenation refactored into <code>Concatenate()</code> but byte logic identical (<code>Buffer.BlockCopy</code> in order).</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>5</td>
+  <td>Unit tests cover (a) timeout+retry, (b) retry succeeds on 2nd attempt, (c) permanent failure returns quickly, (d) happy path unchanged</td>
+  <td>All four behaviours genuinely tested against real deadlines</td>
+  <td>All 9 tests present and passing. Observed timings prove they hit the real CTS: stall+retry = 30s, persistent stall = 60s, permanent failure = &lt;1ms. Not mocked-away timing.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Independent test run (my build, my worktree)</h2>
+<pre>dotnet test --filter "FullyQualifiedName~TtsServiceTests" --no-build
+Passed!  - Failed: 0, Passed: 9, Skipped: 0, Total: 9, Duration: 1m 30s
+
+Per-test timings (proof the real deadlines fire):
+  PermanentFailure_ReturnsErrorQuickly_NotAfter180s   [<1ms]
+  ClientError_IsPermanent_NotRetried                  [28ms]
+  EmptyBody_IsTransient_AndRetried                    [<1ms]
+  TransientServerError_RetriesOnce_AndSucceeds        [1ms]
+  SingleChunk_ReturnsBytesUnchanged                   [<1ms]
+  MultiChunk_ConcatenatesBytesInOrder                 [1ms]
+  FirstChunkStalls_PerRequestTimeoutFires_ThenRetries [30s]   <- one per-request timeout, then retry
+  PersistentStall_FailsFast_WithinBudget              [1m]    <- 60s overall budget cap
+  EmptyText_ReturnsError_WithoutCallingOpenAi         [<1ms]</pre>
+
+<h2>Regression sweep</h2>
+<pre>dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj
+Passed!  - Failed: 0, Passed: 2224, Skipped: 6, Total: 2230, Duration: 3m 02s</pre>
+<p>Nothing adjacent broke. The 6 skips are pre-existing environment-gated tests, unrelated to this change.</p>
+
+<h2>Build gate</h2>
+<pre>dotnet build cc-director.sln
+Build succeeded. 0 Warning(s) 0 Error(s)</pre>
+
+<h2>CenCon method check</h2>
+<p>No architecture or security drift: the change is a behavioral resilience fix with no new external dependency, no new public surface beyond an injectable test seam, and no DT security rule implicated. No <code>docs/cencon/</code> architecture/security manifest update required. The injectable <code>HttpMessageHandler</code> constructor is test-only and does not change runtime behaviour.</p>
+
+<div class="verdict">VERIFIED - all acceptance criteria met. PASS.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-389/report.html
+++ b/docs/cencon/proof/issue-389/report.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #389 - Developer Agent Proof Report</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1d1d1d; }
+  h1 { border-bottom: 3px solid #007ACC; padding-bottom: .3rem; }
+  h2 { margin-top: 2rem; color: #007ACC; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0f6fb; }
+  code, pre { background: #f5f5f5; font-family: Consolas, monospace; }
+  pre { padding: .8rem; overflow-x: auto; border-left: 4px solid #007ACC; }
+  .pass { color: #1a7f37; font-weight: bold; }
+  .ac { background: #fafafa; }
+</style>
+</head>
+<body>
+
+<h1>Issue #389 - TTS per-request timeout, retry, and overall budget</h1>
+<p><strong>Title:</strong> [Voice] TTS stalls up to 180s and returns no audio when an OpenAI request hangs (no per-request timeout/retry)</p>
+<p><strong>Branch:</strong> <code>issue-389-tts-per-request-timeout</code></p>
+<p><strong>Type:</strong> Backend resilience fix in <code>CcDirector.Core</code>. Proof target (per the issue's acceptance criteria) is unit tests.</p>
+
+<h2>What was implemented</h2>
+<p>The root cause was that <code>TtsService.GenerateAsync</code> relied solely on the shared
+<code>HttpClient.Timeout = 180s</code> with no retry, so one stalled OpenAI
+<code>/v1/audio/speech</code> chunk blocked the whole voice turn for up to 180 seconds and then
+returned empty audio. The fix, in <code>src/CcDirector.Core/Voice/TtsService.cs</code>:</p>
+<ul>
+  <li><strong>Per-request timeout (~30s/chunk):</strong> each chunk runs under a
+      <code>CancellationTokenSource.CreateLinkedTokenSource(ct)</code> + <code>CancelAfter(PerRequestTimeout)</code>.
+      The shared client no longer carries the 180s ceiling (its timeout is
+      <code>Timeout.InfiniteTimeSpan</code>; the linked tokens are the only deadlines).</li>
+  <li><strong>Retry once on transient failure:</strong> a per-request timeout, a 5xx, or an empty body
+      is flagged transient and retried a single time. A 4xx is permanent and is not retried.</li>
+  <li><strong>Overall TTS budget (~60s):</strong> a second linked CTS with
+      <code>CancelAfter(OverallBudget)</code> spans all chunks (including the retry), so a reply can
+      never block for minutes.</li>
+  <li><strong>Fail fast to text with logging:</strong> on final failure the call returns promptly and
+      <code>FileLog</code> records elapsed milliseconds + failing chunk index + reason. The upstream
+      text-only fallback (in <code>VoiceTurnEndpoint</code>) is unchanged.</li>
+  <li><strong>Injectable HttpMessageHandler:</strong> a second constructor
+      <code>TtsService(AgentOptions, HttpMessageHandler)</code> makes the timeout/retry behaviour
+      unit-testable without the network. The existing <code>TtsService(AgentOptions)</code> constructor
+      and all five call sites are unchanged.</li>
+  <li><strong>Success path byte-identical:</strong> the MP3 chunk concatenation logic is unchanged
+      (the null-forgiving <code>!</code> in the old loop was replaced with explicit null checks per
+      CodingStyle.md).</li>
+</ul>
+
+<h2>Acceptance criteria - how each is met and verified</h2>
+<table>
+  <tr><th>Criterion</th><th>How the code satisfies it</th><th>Verifying test (Passed)</th></tr>
+  <tr class="ac">
+    <td>A stalled/slow request no longer blocks a turn for 180s; worst-case TTS wall-time &le; ~60s.</td>
+    <td>Per-request <code>CancelAfter(30s)</code> ends a stalled chunk; overall <code>CancelAfter(60s)</code> caps the whole reply.</td>
+    <td><code>GenerateAsync_FirstChunkStalls_PerRequestTimeoutFires_ThenRetries</code> [30s]<br>
+        <code>GenerateAsync_PersistentStall_FailsFast_WithinBudget</code> [60s, &lt; 70s assert]</td>
+  </tr>
+  <tr class="ac">
+    <td>A transient single-chunk failure (timeout or 5xx) is retried once before audio is abandoned.</td>
+    <td>Retry-once wrapper treats timeout / 5xx / empty body as transient.</td>
+    <td><code>GenerateAsync_TransientServerError_RetriesOnce_AndSucceeds</code><br>
+        <code>GenerateAsync_EmptyBody_IsTransient_AndRetried</code></td>
+  </tr>
+  <tr class="ac">
+    <td>When TTS still fails after retry, the reply is delivered (text-only) within a few seconds; the log records elapsed time + failing chunk index + reason.</td>
+    <td>Permanent failure returns immediately after one retry; <code>FileLog</code> logs elapsed ms + chunk index + reason.</td>
+    <td><code>GenerateAsync_PermanentFailure_ReturnsErrorQuickly_NotAfter180s</code> (asserts &lt; 30s)<br>
+        <code>GenerateAsync_ClientError_IsPermanent_NotRetried</code> (4xx, single call)</td>
+  </tr>
+  <tr class="ac">
+    <td>The success path (single- and multi-chunk) is unchanged in output (byte-identical concatenation).</td>
+    <td>Concatenation logic unchanged; explicit null checks instead of <code>!</code>.</td>
+    <td><code>GenerateAsync_SingleChunk_ReturnsBytesUnchanged</code><br>
+        <code>GenerateAsync_MultiChunk_ConcatenatesBytesInOrder</code></td>
+  </tr>
+  <tr class="ac">
+    <td>Unit tests cover (a) per-request timeout triggers and retries, (b) retry succeeds on second attempt, (c) permanent failure returns an error quickly (not after 180s), (d) happy path unchanged.</td>
+    <td>New <code>TtsServiceTests.cs</code> with an injectable scripted HttpMessageHandler covers all four.</td>
+    <td>All 9 tests Passed (see run below).</td>
+  </tr>
+</table>
+
+<h2>Test run (proof)</h2>
+<p>Solution build: <span class="pass">Build succeeded. 0 Warning(s), 0 Error(s).</span></p>
+<p>Per-test timing demonstrates the behaviour: the stall tests consume the real 30s/60s deadlines
+(proving the per-request timeout and overall budget actually fire), while permanent-failure paths
+return in under a millisecond (proving fail-fast, not a 180s block).</p>
+<pre>
+$ dotnet test --filter "FullyQualifiedName~TtsServiceTests" --no-build
+
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_ClientError_IsPermanent_NotRetried [28 ms]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_EmptyBody_IsTransient_AndRetried [&lt; 1 ms]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_EmptyText_ReturnsError_WithoutCallingOpenAi [&lt; 1 ms]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_PermanentFailure_ReturnsErrorQuickly_NotAfter180s [&lt; 1 ms]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_PersistentStall_FailsFast_WithinBudget [1 m]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_TransientServerError_RetriesOnce_AndSucceeds [&lt; 1 ms]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_FirstChunkStalls_PerRequestTimeoutFires_ThenRetries [30 s]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_MultiChunk_ConcatenatesBytesInOrder [1 ms]
+  Passed CcDirector.Core.Tests.Voice.TtsServiceTests.GenerateAsync_SingleChunk_ReturnsBytesUnchanged [&lt; 1 ms]
+
+Passed!  - Failed: 0, Passed: 9, Skipped: 0, Total: 9 - CcDirector.Core.Tests.dll (net10.0)
+</pre>
+
+<h2>CenCon impact</h2>
+<p>No drift. This is a behaviour-only resilience change inside an existing container. The external
+dependency (OpenAI <code>/v1/audio/speech</code>) and the security posture (same endpoint, same
+Bearer-key handling, no new network egress, key never logged) are unchanged, so
+<code>architecture_manifest.yaml</code> and <code>security_profile.yaml</code> do not change.</p>
+
+<h2>Files changed</h2>
+<ul>
+  <li><code>src/CcDirector.Core/Voice/TtsService.cs</code> - per-request timeout, retry-once, overall budget, injectable handler, elapsed/chunk logging.</li>
+  <li><code>src/CcDirector.Core.Tests/Voice/TtsServiceTests.cs</code> - new; 9 tests covering the acceptance criteria via a scripted HttpMessageHandler.</li>
+</ul>
+
+<p><strong>I believe this is finished.</strong></p>
+
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/Voice/TtsServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Voice/TtsServiceTests.cs
@@ -1,0 +1,262 @@
+using System.Diagnostics;
+using System.Net;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Voice;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Voice;
+
+/// <summary>
+/// Resilience coverage for <see cref="TtsService"/> (issue #389).
+///
+/// The bug: a single stalled OpenAI /v1/audio/speech request blocked the whole
+/// voice turn on the shared 180 s HttpClient.Timeout, then returned empty audio.
+/// These tests drive TtsService through an injected <see cref="HttpMessageHandler"/>
+/// (no network) and prove the new per-request timeout, retry-once, fast permanent
+/// failure, and a byte-identical success path.
+///
+/// To keep the suite fast the tests do NOT wait the real 30 s per-request timeout;
+/// the "stall" double cancels itself as soon as the per-request token fires, which
+/// is exactly the observable behaviour the production CancellationTokenSource +
+/// CancelAfter produces - the chunk fails on cancellation, not on a wall clock.
+/// </summary>
+public sealed class TtsServiceTests
+{
+    private static readonly byte[] Mp3A = { 1, 2, 3, 4 };
+    private static readonly byte[] Mp3B = { 9, 8, 7 };
+
+    private static AgentOptions OptionsWithKey() =>
+        new() { OpenAiKey = "sk-test-key" };
+
+    // ===== test double =====================================================
+
+    /// <summary>
+    /// Programmable OpenAI stand-in. Each call pops the next scripted behaviour
+    /// from <see cref="Behaviours"/>; if the queue is exhausted it returns the
+    /// last one. Records how many times it was invoked.
+    /// </summary>
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        public enum Kind { Ok, ServerError, ClientError, Empty, Stall }
+
+        private readonly Queue<Kind> _behaviours;
+        private Kind _last;
+        public int CallCount { get; private set; }
+        public byte[] OkBytes { get; init; } = Mp3A;
+
+        public ScriptedHandler(params Kind[] behaviours)
+        {
+            if (behaviours.Length == 0)
+                throw new ArgumentException("At least one behaviour is required", nameof(behaviours));
+            _behaviours = new Queue<Kind>(behaviours);
+            _last = behaviours[^1];
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            CallCount++;
+            var kind = _behaviours.Count > 0 ? _behaviours.Dequeue() : _last;
+
+            switch (kind)
+            {
+                case Kind.Ok:
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(OkBytes),
+                    };
+                case Kind.ServerError:
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    {
+                        Content = new StringContent("upstream stalled"),
+                    };
+                case Kind.ClientError:
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        Content = new StringContent("bad voice"),
+                    };
+                case Kind.Empty:
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(Array.Empty<byte>()),
+                    };
+                case Kind.Stall:
+                    // Model a hung request: never complete on our own, just wait
+                    // for the per-request cancellation token to fire (which the
+                    // production CancelAfter triggers). This is what the 180 s
+                    // hang looked like, minus the 180 s wall time.
+                    await Task.Delay(Timeout.Infinite, ct);
+                    throw new InvalidOperationException("unreachable: Task.Delay(Infinite) always throws on cancel");
+                default:
+                    throw new InvalidOperationException($"Unhandled behaviour {kind}");
+            }
+        }
+    }
+
+    // ===== (a) per-request timeout triggers and retries ====================
+
+    [Fact]
+    public async Task GenerateAsync_FirstChunkStalls_PerRequestTimeoutFires_ThenRetries()
+    {
+        // First attempt stalls (per-request timeout fires); the retry succeeds.
+        // Proves the per-request timeout is what ends the stalled call AND that a
+        // timeout is treated as transient (retried), not propagated.
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.Stall, ScriptedHandler.Kind.Ok);
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var result = await svc.GenerateAsync("Hello world.", null, null);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, handler.CallCount); // one stalled attempt + one retry
+        Assert.NotNull(result.AudioBytes);
+        Assert.Equal(Mp3A, result.AudioBytes);
+    }
+
+    // ===== (b) retry succeeds on second attempt ============================
+
+    [Fact]
+    public async Task GenerateAsync_TransientServerError_RetriesOnce_AndSucceeds()
+    {
+        // A 5xx on the first attempt is transient; the second attempt returns audio.
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.ServerError, ScriptedHandler.Kind.Ok);
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var result = await svc.GenerateAsync("Hello world.", null, null);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, handler.CallCount);
+        Assert.Equal(Mp3A, result.AudioBytes);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_EmptyBody_IsTransient_AndRetried()
+    {
+        // An empty body (the exact "audio_bytes=0" symptom) is transient and retried.
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.Empty, ScriptedHandler.Kind.Ok);
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var result = await svc.GenerateAsync("Hello world.", null, null);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    // ===== (c) permanent failure returns quickly (NOT after 180 s) =========
+
+    [Fact]
+    public async Task GenerateAsync_PermanentFailure_ReturnsErrorQuickly_NotAfter180s()
+    {
+        // Both attempts 5xx -> permanent failure after exactly one retry. The key
+        // assertion: it returns fast (well under the old 180 s), proving no chunk
+        // can block the turn.
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.ServerError, ScriptedHandler.Kind.ServerError);
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var sw = Stopwatch.StartNew();
+        var result = await svc.GenerateAsync("Hello world.", null, null);
+        sw.Stop();
+
+        Assert.False(result.Success);
+        Assert.Equal(2, handler.CallCount); // attempt + single retry, then give up
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30), $"Took {sw.Elapsed.TotalSeconds:0.0}s - must fail fast, not block for 180s");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ClientError_IsPermanent_NotRetried()
+    {
+        // A 4xx is a permanent request error - it must NOT be retried (would waste
+        // a call and delay the text-only fallback).
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.ClientError);
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var result = await svc.GenerateAsync("Hello world.", null, null);
+
+        Assert.False(result.Success);
+        Assert.Equal(1, handler.CallCount); // no retry on a 4xx
+    }
+
+    [Fact]
+    public async Task GenerateAsync_PersistentStall_FailsFast_WithinBudget()
+    {
+        // Every attempt stalls. The per-request timeout ends each attempt, the
+        // single retry also stalls, and the call returns an error - it never
+        // waits the old 180 s ceiling.
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.Stall);
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var sw = Stopwatch.StartNew();
+        var result = await svc.GenerateAsync("Hello world.", null, null);
+        sw.Stop();
+
+        Assert.False(result.Success);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(70), $"Took {sw.Elapsed.TotalSeconds:0.0}s - must stay within the overall budget, not block for 180s");
+    }
+
+    // ===== (d) happy path unchanged (byte-identical concatenation) =========
+
+    [Fact]
+    public async Task GenerateAsync_SingleChunk_ReturnsBytesUnchanged()
+    {
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.Ok) { OkBytes = Mp3A };
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var result = await svc.GenerateAsync("Short reply.", null, null);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, handler.CallCount);
+        Assert.Equal(Mp3A, result.AudioBytes); // byte-identical, single chunk
+        Assert.Equal("audio/mpeg", result.ContentType);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_MultiChunk_ConcatenatesBytesInOrder()
+    {
+        // Build text guaranteed to split into multiple chunks, then prove the
+        // returned bytes are the per-chunk MP3s concatenated in order. Every
+        // chunk gets the same Ok bytes from the handler, so N chunks -> N copies.
+        var text = BuildMultiChunkText(out int expectedChunks);
+        Assert.True(expectedChunks >= 2, "test text must split into at least 2 chunks");
+
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.Ok) { OkBytes = Mp3B };
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var result = await svc.GenerateAsync(text, null, null);
+
+        Assert.True(result.Success);
+        Assert.Equal(expectedChunks, handler.CallCount);
+        Assert.NotNull(result.AudioBytes);
+
+        // Expected = Mp3B repeated once per chunk, in order.
+        var expected = new byte[Mp3B.Length * expectedChunks];
+        for (int i = 0; i < expectedChunks; i++)
+            Buffer.BlockCopy(Mp3B, 0, expected, i * Mp3B.Length, Mp3B.Length);
+        Assert.Equal(expected, result.AudioBytes);
+    }
+
+    /// <summary>
+    /// Build a body that splits into &gt;= 2 chunks at the real chunk size, and
+    /// report how many chunks the splitter produces so the test can assert the
+    /// exact concatenation.
+    /// </summary>
+    private static string BuildMultiChunkText(out int chunkCount)
+    {
+        var sentence = new string('a', 300) + ". ";
+        var text = string.Concat(Enumerable.Repeat(sentence, 8)); // ~2400 chars
+        chunkCount = TtsService.SplitIntoChunks(text, TtsService.MaxChunkChars).Count;
+        return text;
+    }
+
+    // ===== guards ==========================================================
+
+    [Fact]
+    public async Task GenerateAsync_EmptyText_ReturnsError_WithoutCallingOpenAi()
+    {
+        var handler = new ScriptedHandler(ScriptedHandler.Kind.Ok);
+        var svc = new TtsService(OptionsWithKey(), handler);
+
+        var result = await svc.GenerateAsync("", null, null);
+
+        Assert.False(result.Success);
+        Assert.Equal("empty_text", result.Status);
+        Assert.Equal(0, handler.CallCount);
+    }
+}

--- a/src/CcDirector.Core/Voice/TtsService.cs
+++ b/src/CcDirector.Core/Voice/TtsService.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using CcDirector.Core.Configuration;
@@ -19,6 +21,16 @@ namespace CcDirector.Core.Voice;
 /// so byte concatenation produces a single valid stream that plays end-to-end.
 /// Effective input limit is therefore bounded only by OpenAI's per-minute
 /// quota, not by the per-call 4096 cap.
+///
+/// RESILIENCE (issue #389): a single stalled OpenAI request used to hang the
+/// whole voice turn on the shared <c>HttpClient.Timeout</c> of 180 s, then
+/// return empty audio.  To keep the voice experience snappy this service now
+/// applies a short PER-REQUEST timeout (<see cref="PerRequestTimeout"/>) per
+/// chunk via a linked <see cref="CancellationTokenSource"/> + CancelAfter,
+/// retries a transient single-chunk failure once, and caps the whole reply at
+/// an overall budget (<see cref="OverallBudget"/>).  When TTS ultimately fails
+/// the caller is told promptly (text-only fallback already happens upstream),
+/// and the elapsed time + failing chunk index + reason are logged.
 /// </summary>
 public sealed class TtsService
 {
@@ -32,11 +44,35 @@ public sealed class TtsService
     // Kept for backwards compatibility with callers that read it.
     public const int MaxTextChars = MaxChunkChars;
 
+    // Per-request timeout for a single OpenAI /v1/audio/speech call.  An ~800-char
+    // chunk normally returns in ~3-5 s, so 30 s is generous headroom while still
+    // failing ~6x faster than the old 180 s ceiling.  Issue #389.
+    public static readonly TimeSpan PerRequestTimeout = TimeSpan.FromSeconds(30);
+
+    // Hard ceiling for generating the audio for one whole reply (all chunks,
+    // including the single retry).  Guarantees a voice turn can never block for
+    // minutes on TTS - worst case is this budget, after which we fail to text.
+    public static readonly TimeSpan OverallBudget = TimeSpan.FromSeconds(60);
+
     private readonly AgentOptions _options;
+    private readonly HttpMessageHandler? _handler;
 
     public TtsService(AgentOptions options)
     {
         _options = options;
+        _handler = null;
+    }
+
+    /// <summary>
+    /// Test seam (issue #389): inject the <see cref="HttpMessageHandler"/> the
+    /// internal <see cref="HttpClient"/> is built on, so the per-request timeout
+    /// and retry behaviour are unit-testable without hitting the network.  The
+    /// handler is owned by the caller and is NOT disposed by this service.
+    /// </summary>
+    public TtsService(AgentOptions options, HttpMessageHandler handler)
+    {
+        _options = options;
+        _handler = handler;
     }
 
     /// <summary>True when an OpenAI key is configured.</summary>
@@ -63,60 +99,136 @@ public sealed class TtsService
         var chunks = SplitIntoChunks(text, MaxChunkChars);
         FileLog.Write($"[TtsService] GenerateAsync: model={model}, voice={voice}, totalChars={text.Length}, chunks={chunks.Count}");
 
+        var stopwatch = Stopwatch.StartNew();
+
+        // Overall budget for the whole reply.  Linked to the caller's token so a
+        // caller cancel still wins, and self-cancels after OverallBudget so the
+        // turn can never block for minutes (issue #389).
+        using var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        budgetCts.CancelAfter(OverallBudget);
+
         try
         {
-            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(180) };
-            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
-
-            // Single-chunk fast path: no parallelism overhead.
-            if (chunks.Count == 1)
+            // The shared client carries NO short timeout: the per-request and
+            // overall-budget CancellationTokenSources are the only deadlines, so
+            // a stalled chunk fails in PerRequestTimeout, not the old 180 s.  We
+            // set a finite ceiling well above the overall budget purely as a
+            // backstop; the linked tokens fire long before it.
+            var client = CreateHttpClient(key);
+            try
             {
-                var single = await CallOpenAiAsync(http, model, voice, chunks[0], ct);
-                return single;
-            }
-
-            // Multi-chunk: fire all in parallel.  OpenAI's tts-1 latency is
-            // ~2 s per chunk, so 10 chunks in parallel is ~2-3 s wall-clock
-            // (vs ~20 s sequential).  If any chunk fails, propagate the
-            // first error - partial audio is worse than no audio because
-            // the listener would not know where it cut off.
-            var tasks = chunks.Select(c => CallOpenAiAsync(http, model, voice, c, ct)).ToList();
-            var results = await Task.WhenAll(tasks);
-
-            for (int i = 0; i < results.Length; i++)
-            {
-                if (!results[i].Success)
+                // Single-chunk fast path: no parallelism overhead.
+                if (chunks.Count == 1)
                 {
-                    FileLog.Write($"[TtsService] chunk {i + 1}/{results.Length} failed: {results[i].ErrorMessage}");
-                    return results[i];
+                    var single = await CallWithRetryAsync(client, model, voice, chunks[0], 0, budgetCts.Token);
+                    if (!single.Success)
+                        FileLog.Write($"[TtsService] GenerateAsync FAILED after {stopwatch.ElapsedMilliseconds}ms: chunk 0/1 reason={single.ErrorMessage}");
+                    return single;
                 }
-            }
 
-            // Concatenate MP3 byte streams in order.  MP3 is a sequence of
-            // independent frames; byte-level concatenation produces a single
-            // valid stream that browsers play as one continuous audio.
-            var total = results.Sum(r => r.AudioBytes!.Length);
-            var combined = new byte[total];
-            int offset = 0;
-            foreach (var r in results)
-            {
-                var b = r.AudioBytes!;
-                Buffer.BlockCopy(b, 0, combined, offset, b.Length);
-                offset += b.Length;
+                // Multi-chunk: fire all in parallel.  OpenAI's tts-1 latency is
+                // ~2 s per chunk, so 10 chunks in parallel is ~2-3 s wall-clock
+                // (vs ~20 s sequential).  If any chunk fails (after its single
+                // retry), propagate the first error - partial audio is worse
+                // than no audio because the listener would not know where it
+                // cut off.
+                var tasks = chunks
+                    .Select((c, i) => CallWithRetryAsync(client, model, voice, c, i, budgetCts.Token))
+                    .ToList();
+                var results = await Task.WhenAll(tasks);
+
+                for (int i = 0; i < results.Length; i++)
+                {
+                    if (!results[i].Success)
+                    {
+                        FileLog.Write($"[TtsService] GenerateAsync FAILED after {stopwatch.ElapsedMilliseconds}ms: chunk {i}/{results.Length} reason={results[i].ErrorMessage}");
+                        return results[i];
+                    }
+                }
+
+                // Concatenate MP3 byte streams in order.  MP3 is a sequence of
+                // independent frames; byte-level concatenation produces a single
+                // valid stream that browsers play as one continuous audio.
+                var combined = Concatenate(results);
+                FileLog.Write($"[TtsService] joined {results.Length} chunks into {combined.Length} bytes in {stopwatch.ElapsedMilliseconds}ms");
+                return TtsResult.Ok(combined, "audio/mpeg");
             }
-            FileLog.Write($"[TtsService] joined {results.Length} chunks into {combined.Length} bytes");
-            return TtsResult.Ok(combined, "audio/mpeg");
+            finally
+            {
+                // Only dispose a client we created.  When an external handler is
+                // injected the caller owns the handler's lifetime, so we leave it
+                // (disposing the client would dispose the handler).
+                if (_handler is null)
+                    client.Dispose();
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // The caller cancelled - surface that rather than the budget message.
+            FileLog.Write($"[TtsService] GenerateAsync cancelled by caller after {stopwatch.ElapsedMilliseconds}ms");
+            return TtsResult.Error("cancelled", "TTS cancelled");
+        }
+        catch (OperationCanceledException)
+        {
+            // The overall budget elapsed before all chunks finished.
+            FileLog.Write($"[TtsService] GenerateAsync FAILED after {stopwatch.ElapsedMilliseconds}ms: overall budget of {OverallBudget.TotalSeconds:0}s exceeded");
+            return TtsResult.Error("tts_budget_exceeded", $"TTS exceeded the {OverallBudget.TotalSeconds:0}s budget");
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[TtsService] GenerateAsync FAILED: {ex.Message}");
+            FileLog.Write($"[TtsService] GenerateAsync FAILED after {stopwatch.ElapsedMilliseconds}ms: {ex.Message}");
             return TtsResult.Error("internal_error", ex.Message);
         }
     }
 
-    /// <summary>One OpenAI /v1/audio/speech call.  Returns raw MP3 bytes.</summary>
-    private static async Task<TtsResult> CallOpenAiAsync(HttpClient http, string model, string voice, string input, CancellationToken ct)
+    /// <summary>
+    /// Build the <see cref="HttpClient"/> used for the OpenAI calls.  Uses the
+    /// injected handler when present (the unit-test seam) and never relies on a
+    /// short <c>HttpClient.Timeout</c> - cancellation is driven entirely by the
+    /// per-request and overall-budget tokens (issue #389).
+    /// </summary>
+    private HttpClient CreateHttpClient(string key)
     {
+        // Backstop timeout only - well above the overall budget so the linked
+        // tokens always fire first.  This is NOT the 180 s per-turn block the
+        // issue describes.
+        var client = _handler is null
+            ? new HttpClient()
+            : new HttpClient(_handler, disposeHandler: false);
+        client.Timeout = Timeout.InfiniteTimeSpan;
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        return client;
+    }
+
+    /// <summary>
+    /// One OpenAI chunk with a short per-request timeout and a single retry on a
+    /// transient failure (timeout, 5xx, or empty body).  Issue #389: turn 1 in
+    /// the bug report would very likely have succeeded on a second attempt.
+    /// </summary>
+    private async Task<TtsResult> CallWithRetryAsync(HttpClient client, string model, string voice, string input, int chunkIndex, CancellationToken budgetToken)
+    {
+        var first = await CallOnceAsync(client, model, voice, input, chunkIndex, attempt: 1, budgetToken);
+        if (first.Success || !first.Transient)
+            return first;
+
+        FileLog.Write($"[TtsService] chunk {chunkIndex} attempt 1 transient failure ({first.ErrorMessage}); retrying once");
+        var second = await CallOnceAsync(client, model, voice, input, chunkIndex, attempt: 2, budgetToken);
+        return second;
+    }
+
+    /// <summary>
+    /// One OpenAI /v1/audio/speech call with a per-request deadline.  Returns raw
+    /// MP3 bytes on success; on a transient failure (per-request timeout, 5xx, or
+    /// empty body) the result is flagged <see cref="TtsResult.Transient"/> so the
+    /// caller can retry once.  A 4xx is permanent (not retried).
+    /// </summary>
+    private async Task<TtsResult> CallOnceAsync(HttpClient client, string model, string voice, string input, int chunkIndex, int attempt, CancellationToken budgetToken)
+    {
+        // Per-request deadline, linked to the overall budget so whichever fires
+        // first wins.  CancelAfter is the per-chunk timeout (issue #389).
+        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(budgetToken);
+        requestCts.CancelAfter(PerRequestTimeout);
+
         var payload = JsonContent.Create(new
         {
             model,
@@ -125,19 +237,59 @@ public sealed class TtsService
             response_format = "mp3",
         });
 
-        using var resp = await http.PostAsync(Endpoint, payload, ct);
-        if (!resp.IsSuccessStatusCode)
+        try
         {
-            var body = await resp.Content.ReadAsStringAsync(ct);
-            FileLog.Write($"[TtsService] OpenAI returned {(int)resp.StatusCode}: {Truncate(body, 400)}");
-            return TtsResult.Error("openai_failed", $"OpenAI returned {(int)resp.StatusCode}: {Truncate(body, 300)}");
+            using var resp = await client.PostAsync(Endpoint, payload, requestCts.Token);
+            if (!resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadAsStringAsync(requestCts.Token);
+                var status = (int)resp.StatusCode;
+                FileLog.Write($"[TtsService] chunk {chunkIndex} attempt {attempt} OpenAI returned {status}: {Truncate(body, 400)}");
+                // 5xx is transient (server-side, worth a retry); 4xx is a
+                // permanent request error and must not be retried.
+                var transient = status >= 500;
+                return TtsResult.Error("openai_failed", $"OpenAI returned {status}: {Truncate(body, 300)}", transient);
+            }
+
+            var bytes = await resp.Content.ReadAsByteArrayAsync(requestCts.Token);
+            if (bytes.Length == 0)
+            {
+                FileLog.Write($"[TtsService] chunk {chunkIndex} attempt {attempt} OpenAI returned empty audio");
+                return TtsResult.Error("openai_failed", "OpenAI returned empty audio", transient: true);
+            }
+
+            return TtsResult.Ok(bytes, "audio/mpeg");
+        }
+        catch (OperationCanceledException) when (requestCts.IsCancellationRequested && !budgetToken.IsCancellationRequested)
+        {
+            // The per-request timeout fired (the overall budget has NOT) - this
+            // is the stalled-chunk case; transient, so the caller retries once.
+            FileLog.Write($"[TtsService] chunk {chunkIndex} attempt {attempt} timed out after {PerRequestTimeout.TotalSeconds:0}s");
+            return TtsResult.Error("timeout", $"per-request timeout of {PerRequestTimeout.TotalSeconds:0}s elapsed", transient: true);
+        }
+    }
+
+    /// <summary>Concatenate MP3 chunk byte streams in order into one buffer.</summary>
+    private static byte[] Concatenate(TtsResult[] results)
+    {
+        int total = 0;
+        foreach (var r in results)
+        {
+            if (r.AudioBytes is null)
+                throw new InvalidOperationException("Cannot concatenate a TTS result with no audio bytes");
+            total += r.AudioBytes.Length;
         }
 
-        var bytes = await resp.Content.ReadAsByteArrayAsync(ct);
-        if (bytes.Length == 0)
-            return TtsResult.Error("openai_failed", "OpenAI returned empty audio");
-
-        return TtsResult.Ok(bytes, "audio/mpeg");
+        var combined = new byte[total];
+        int offset = 0;
+        foreach (var r in results)
+        {
+            if (r.AudioBytes is null)
+                throw new InvalidOperationException("Cannot concatenate a TTS result with no audio bytes");
+            Buffer.BlockCopy(r.AudioBytes, 0, combined, offset, r.AudioBytes.Length);
+            offset += r.AudioBytes.Length;
+        }
+        return combined;
     }
 
     /// <summary>
@@ -237,6 +389,8 @@ public sealed class TtsService
 /// <summary>
 /// Result of a TTS call.  When <see cref="Status"/> is "ok", <see cref="AudioBytes"/>
 /// and <see cref="ContentType"/> are populated.  Otherwise <see cref="ErrorMessage"/> is.
+/// <see cref="Transient"/> marks a failure that is worth a single retry (timeout,
+/// 5xx, or empty body) versus a permanent one (4xx, missing key) - issue #389.
 /// </summary>
 public sealed class TtsResult
 {
@@ -245,6 +399,9 @@ public sealed class TtsResult
     public byte[]? AudioBytes { get; private init; }
     public string? ContentType { get; private init; }
 
+    /// <summary>True when this failure is transient and the caller may retry once.</summary>
+    public bool Transient { get; private init; }
+
     public bool Success => Status == "ok";
 
     public static TtsResult Ok(byte[] bytes, string contentType)
@@ -252,4 +409,7 @@ public sealed class TtsResult
 
     public static TtsResult Error(string status, string message)
         => new() { Status = status, ErrorMessage = message };
+
+    public static TtsResult Error(string status, string message, bool transient)
+        => new() { Status = status, ErrorMessage = message, Transient = transient };
 }


### PR DESCRIPTION
Closes #389.

## Release Notes
A stalled OpenAI text-to-speech request no longer blocks a voice turn for up to 180 seconds. Each audio chunk now has a short per-request timeout, a transient failure is retried once, and the whole reply is capped by an overall budget, so the user gets audio (or a prompt text-only fallback) in seconds instead of after minutes.

## Changes
- `src/CcDirector.Core/Voice/TtsService.cs`:
  - Per-request timeout of 30 seconds per chunk via a linked `CancellationTokenSource` + `CancelAfter` (the shared `HttpClient.Timeout` no longer carries the 180-second ceiling).
  - Retry once on a transient failure (per-request timeout, 5xx, or empty body); a 4xx is permanent and not retried.
  - Overall budget of 60 seconds spanning all chunks (including the retry) as a hard ceiling.
  - On final failure, return promptly and log elapsed milliseconds + failing chunk index + reason; the upstream text-only fallback is unchanged.
  - Injectable `HttpMessageHandler` constructor so the timeout/retry behaviour is unit-testable. The existing `TtsService(AgentOptions)` constructor and all five call sites are unchanged.
  - Success-path MP3 concatenation unchanged (replaced the null-forgiving `!` with explicit null checks).
- `src/CcDirector.Core.Tests/Voice/TtsServiceTests.cs` (new): 9 tests with a scripted `HttpMessageHandler`.

## How to Test
```
dotnet build cc-director.sln
dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter "FullyQualifiedName~TtsServiceTests"
```

## Expected Result
Build succeeds with 0 warnings and 0 errors; all 9 `TtsServiceTests` pass. The per-test timing shows the stalled-chunk tests consuming the real 30s/60s deadlines while permanent-failure paths return in under a millisecond (fail-fast, not a 180s block).

## Before / After
- Before: one hung chunk blocks the whole turn for up to 180 seconds, then returns empty audio (`audio_bytes=0`).
- After: a hung chunk fails in ~30 seconds and is retried once; the whole reply is capped at ~60 seconds; on permanent failure the text-only reply is delivered promptly with elapsed time + failing chunk logged.

Proof: `docs/cencon/proof/issue-389/report.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)