### PR TITLE
[Voice] Playback observability + no-mic voice-turn test harness (#394 Phase 1)

### DIFF
--- a/docs/cencon/proof/issue-394/harness-passrate-run.txt
+++ b/docs/cencon/proof/issue-394/harness-passrate-run.txt
@@ -1,0 +1,4 @@
+  Passed CcDirector.Gateway.Tests.VoiceTurnNoMicE2EHarnessTests.NoMicTextTurn_SingleIteration_ReachesReplyWithPlausibleAudio [239 ms]
+  Passed CcDirector.Gateway.Tests.VoiceTurnNoMicE2EHarnessTests.NoMicTextTurn_TenIterations_ReportsPassRate [2 s]
+ [no-mic E2E harness] pass rate: 10/10 = 100.0%
+Total tests: 2

--- a/docs/cencon/proof/issue-394/qa-report.html
+++ b/docs/cencon/proof/issue-394/qa-report.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue 394 (Voice playback observability + voice-turn test harness)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1b1f23; }
+  h1 { border-bottom: 3px solid #5319e7; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #5319e7; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .55rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f6f8fa; }
+  .pass { color: #1a7f37; font-weight: 700; }
+  .verdict { background: #dafbe1; border: 1px solid #1a7f37; padding: 1rem; border-radius: 6px; font-size: 1.1rem; }
+  code { background: #f6f8fa; padding: .1rem .3rem; border-radius: 4px; font-family: Consolas, monospace; }
+  pre { background: #0d1117; color: #e6edf3; padding: 1rem; border-radius: 6px; overflow-x: auto; font-size: .85rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue 394 (Phase 1)</h1>
+<p><strong>Issue:</strong> [Voice] Playback observability + voice-turn test harness (so cutouts are measurable)<br>
+<strong>Pull request:</strong> 613 (branch <code>issue-394-voice-observability</code>)<br>
+<strong>Verifier:</strong> QA Agent (independent verification, own git worktree off the pull-request branch)<br>
+<strong>Build:</strong> <code>dotnet build cc-director.sln</code> -> Build succeeded, 0 Warning(s), 0 Error(s)<br>
+<strong>Scope note:</strong> Only Phase 1 is in scope. Phases 2 and 3 are explicit follow-ons and were NOT held against this issue.</p>
+
+<h2>Acceptance criteria - independently verified</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (verified by QA)</th><th>Result</th></tr>
+
+<tr>
+<td>1</td>
+<td>From the phone client log alone, one can tell for any turn whether playback finished, errored (with code), or was interrupted, plus bytes and played-versus-expected duration.</td>
+<td>Three distinguishable terminal outcomes with byte count and played-vs-estimated duration on one log line.</td>
+<td>AndroidReplySpeaker records the actual terminal path (Completed / Error with what+extra / Interrupted) rather than inferring it from the identical MediaPlayer.Completion event. PlaybackLog.Terminal emits <code>result=...</code>, <code>bytes=...</code>, <code>played=X/Ys</code>, and error codes. VoiceConversation's done line carries the same. The Android MediaPlayer cannot run headless, so the wording (PlaybackLog) and the duration maths (Mp3Duration) are unit-tested off-device: 13/13 pass. The committed sample-playback-log.txt shows all three outcomes distinguishable from the log alone.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>TtsServiceTests cover single-chunk, multi-chunk join (byte-exact), stalled-chunk, and 5xx-chunk paths via an injected fake handler.</td>
+<td>Tests present on main (from issue 389 / pull request 612), covering all four paths with an injected HttpMessageHandler, no live network.</td>
+<td>src/CcDirector.Core.Tests/Voice/TtsServiceTests.cs present. Single-chunk (returns bytes unchanged), multi-chunk (asserts byte-exact concatenation in order), stalled-chunk (per-request timeout fires; persistent stall fails fast), 5xx (transient retry succeeds; permanent failure fast). All via the injected ScriptedHandler fake. 9/9 pass. Confirmed present, not duplicated, per the cross-issue note.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>The no-mic end-to-end harness submits a text voice-turn through the Gateway and asserts a non-empty audio reply, and can run N iterations reporting a pass rate.</td>
+<td>A host test drives the Gateway submit/poll/audio pipeline with the text field, asserts non-empty plausible audio, and reports a pass-rate number over N runs.</td>
+<td>VoiceTurnNoMicE2EHarnessTests stands up the real Gateway plus an in-process stub Director; submits a text voice-turn, polls to stage=reply, fetches audio through the dedicated endpoint, asserts non-empty audio of plausible size (>=1000 bytes, equal to advertised length). Ran independently: 2/2 pass, output line "[no-mic E2E harness] pass rate: 10/10 = 100.0%". The pass-rate number is emitted.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>No behavior change to the shipping voice path beyond added logging and the test seam.</td>
+<td>Diff shows only added logging and the IReplySpeaker return-type seam; play/stop/focus behavior unchanged.</td>
+<td>Diff of the two shipping-path files confirms: IReplySpeaker.PlayAsync return type changed Task -> Task&lt;PlaybackOutcome&gt; (test seam, still awaited identically); VoiceConversation's done line enriched with playback result and durations; the <code>if (mp3.Length &gt; 0)</code> guard and return value unchanged. AndroidReplySpeaker adds logging and an outcome record; audio focus is "Logged, not acted on" - existing duck/abandon behavior unchanged. AndroidReplySpeaker is the only IReplySpeaker implementer; all callers compile (phone project built clean).</td>
+<td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Regression sweep and method checks</h2>
+<ul>
+<li>Full solution build: Build succeeded, 0 Warning(s), 0 Error(s).</li>
+<li>Phone observability tests (Mp3Duration + PlaybackLog): 13/13 pass.</li>
+<li>TtsServiceTests: 9/9 pass.</li>
+<li>No-mic E2E harness: 2/2 pass, pass rate 10/10 = 100.0%.</li>
+<li>Full Gateway VoiceTurn regression suite: 49/49 pass.</li>
+<li>CenCon lens: change is added logging plus host/phone tests; no new external surface, no new secrets, no architecture or security-profile change, so no docs/cencon/ update was required. All log lines are ASCII-only (asserted by PlaybackLogTests).</li>
+</ul>
+
+<h2>Sample observability log (committed proof, criterion 1)</h2>
+<pre>
+Turn A: clean finish
+  PlayAsync: bytes=128000, estimatedDuration=8.0s
+  PlayAsync done: result=Completed, bytes=128000, played=7.9s/8.0s
+
+Turn B: decoder error mid-stream
+  PlayAsync: bytes=64000, estimatedDuration=4.0s
+  PlayAsync done: result=Error, bytes=64000, played=1.2s/4.0s, what=1, extra=-2147483648
+
+Turn C: interrupted / cut off
+  PlayAsync: bytes=128000, estimatedDuration=8.0s
+  audio focus change: loss-transient-can-duck
+  PlayAsync done: result=Interrupted, bytes=128000, played=3.1s/8.0s
+</pre>
+
+<div class="verdict">VERIFIED - all Phase 1 acceptance criteria met. 4 of 4 criteria PASS with independent proof; full solution builds clean; regression suite green.</div>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-394/report.html
+++ b/docs/cencon/proof/issue-394/report.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #394 - Voice playback observability + no-mic test harness (Phase 1)</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1d1d1f; line-height: 1.55; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid #007acc; padding-bottom: .4rem; }
+  h2 { font-size: 1.2rem; margin-top: 2rem; color: #005a9e; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d0d0; padding: .5rem .6rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: #f0f6fb; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #f6f8fa; border: 1px solid #e1e4e8; border-radius: 6px; padding: .8rem; overflow-x: auto; font-size: .85rem; }
+  .ok { color: #1a7f37; font-weight: 600; }
+  .file { font-family: Consolas, monospace; font-size: .88rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #394 - Voice playback observability + no-mic voice-turn test harness (Phase 1)</h1>
+
+<p><strong>Branch:</strong> <code>issue-394-voice-observability</code> &nbsp;|&nbsp;
+   <strong>Scope:</strong> Phase 1 only (Phases 2 and 3 are explicit follow-ons, out of scope).</p>
+
+<p>The voice path "cuts out" intermittently and was hard to diagnose because the two places it
+breaks - server-side TTS reliability and on-device playback - had almost no observability or
+automated coverage. This change adds the observability and the automated no-microphone harness so
+the failure modes are measurable and regression-protected. <strong>No behaviour change to the
+shipping voice path beyond added logging and a test seam.</strong></p>
+
+<h2>Reconciliation with #389 (merged minutes earlier, PR #612)</h2>
+<p>Issue #389 already made <code>TtsService</code>'s <code>HttpMessageHandler</code> injectable and
+added <span class="file">src/CcDirector.Core.Tests/Voice/TtsServiceTests.cs</span> covering the
+single-chunk, multi-chunk byte-exact join, stalled-chunk, and 5xx-chunk paths via an injected fake
+handler. The #394 "Host-side TtsService tests" acceptance criterion is therefore <strong>already
+satisfied by #389</strong>; this change does NOT duplicate that seam or those tests. I re-ran them
+as evidence: <span class="ok">9/9 passed</span>. (Per the issue note, the obsolete "assert the old
+180s stall" regression target was intentionally NOT reintroduced - #389 changed that behaviour and
+the new timeout/retry behaviour is what is tested.)</p>
+
+<h2>What was implemented (the genuinely novel Phase 1 work)</h2>
+
+<h3>1. Android playback observability</h3>
+<ul>
+  <li><span class="file">phone/CcDirectorClient/Platforms/Android/AndroidReplySpeaker.cs</span> - on
+      <code>PlayAsync</code> logs byte count AND an estimated duration; logs the TERMINAL outcome
+      with elapsed wall time and played-vs-estimated duration, distinguishing
+      <code>Completed</code> (played to end) / <code>Error</code> (with MediaPlayer
+      <code>what</code>/<code>extra</code>) / <code>Interrupted</code> (Stop or cancel); registers an
+      audio-focus-change listener and logs gain/loss/duck during playback.</li>
+  <li><span class="file">phone/CcDirectorClient/Voice/IReplySpeaker.cs</span> - <code>PlayAsync</code>
+      now returns <code>Task&lt;PlaybackOutcome&gt;</code> so the caller can record the result.</li>
+  <li><span class="file">phone/CcDirectorClient/Voice/VoiceConversation.cs</span> - the existing
+      <code>PollAndSpeak done</code> line now carries <code>audioBytes</code>, the playback result,
+      and played-vs-estimated seconds.</li>
+  <li>New pure, dependency-free helpers so the wording and the duration maths are testable
+      off-device (the real Android MediaPlayer cannot run headless):
+      <span class="file">PlaybackOutcome.cs</span>, <span class="file">Mp3Duration.cs</span>
+      (estimates a CBR MP3's length from its frame headers),
+      <span class="file">PlaybackLog.cs</span> (the ASCII-only log-line formatter).</li>
+</ul>
+
+<h3>2. No-microphone end-to-end harness</h3>
+<ul>
+  <li><span class="file">src/CcDirector.Gateway.Tests/VoiceTurnNoMicE2EHarnessTests.cs</span> - drives
+      the Gateway's real <code>voice-turn/submit</code> + poll + audio-fetch pipeline using the TEXT
+      field (no microphone, no transcription, no live key). A small in-process STUB Director the
+      Gateway discovers and dials answers the SSE turn with a reply event carrying non-empty MP3
+      bytes, so everything from the Gateway's submit route through <code>RunTurnAsync</code>, the
+      slim poll, and the dedicated audio endpoint is the real shipping code. Asserts the poll reaches
+      <code>stage=reply</code> with non-empty audio of a plausible size, and runs N=10 iterations
+      reporting a pass rate so multi-chunk flakiness would show up as a number.</li>
+</ul>
+
+<h2>Acceptance criteria - how each is met and verified</h2>
+<table>
+<tr><th>Criterion (Phase 1)</th><th>How met</th><th>Verification</th></tr>
+<tr>
+  <td>From the phone log alone, tell for any turn whether playback finished, errored (with code), or
+      was interrupted, plus bytes and played-vs-expected duration.</td>
+  <td>New START line (bytes + estimatedDuration), TERMINAL line (result + bytes +
+      played/estimated + error codes), focus-change lines, and the enriched VoiceConversation done
+      line.</td>
+  <td><span class="ok">PASS</span> - <span class="file">PlaybackLogTests</span> (6) pin the exact
+      wording for Completed/Error/Interrupted; sample log in
+      <span class="file">sample-playback-log.txt</span>.</td>
+</tr>
+<tr>
+  <td>TtsServiceTests cover single-chunk, multi-chunk join (byte-exact), stalled-chunk, and
+      5xx-chunk paths via an injected fake handler.</td>
+  <td>Already delivered by #389 (PR #612); not duplicated.</td>
+  <td><span class="ok">PASS</span> - re-ran the existing 9 TtsService tests: 9/9 passed.</td>
+</tr>
+<tr>
+  <td>No-mic harness submits a text voice-turn through the Gateway, asserts a non-empty audio reply,
+      and can run N iterations reporting a pass rate.</td>
+  <td><span class="file">VoiceTurnNoMicE2EHarnessTests</span> - text submit -> poll to reply ->
+      audio fetch, asserted non-empty + plausible size, 10x with pass-rate output.</td>
+  <td><span class="ok">PASS</span> - 2/2 tests pass; reported pass rate 10/10 = 100.0% (see
+      <span class="file">harness-passrate-run.txt</span>).</td>
+</tr>
+<tr>
+  <td>No behaviour change to the shipping voice path beyond added logging and the test seam.</td>
+  <td>Only logging was added; the duck/abandon focus behaviour is unchanged (the listener logs, does
+      not act); the interface returns extra data callers may ignore.</td>
+  <td><span class="ok">PASS</span> - all 49 Gateway VoiceTurn tests still pass; phone app + solution
+      build clean.</td>
+</tr>
+</table>
+
+<h2>Build and test results</h2>
+<ul>
+  <li><span class="ok">Solution build clean</span>: <code>dotnet build cc-director.sln</code> -
+      0 Warning(s), 0 Error(s).</li>
+  <li><span class="ok">Phone Android app builds</span>:
+      <code>dotnet build phone/CcDirectorClient/CcDirectorClient.csproj</code> - 0 Error(s)
+      (pre-existing MAUI/XAML warnings only; none in the changed files).</li>
+  <li><span class="ok">Phone observability tests</span>: Mp3DurationTests + PlaybackLogTests =
+      13/13 passed.</li>
+  <li><span class="ok">No-mic harness</span>: VoiceTurnNoMicE2EHarnessTests = 2/2 passed, pass rate
+      10/10 = 100.0%.</li>
+  <li><span class="ok">Regression</span>: all 49 Gateway VoiceTurn tests pass; TtsServiceTests (#389)
+      9/9 pass.</li>
+  <li>Note: 5 pre-existing <code>ConductorStateTests</code> failures exist on clean
+      <code>main</code> too (a missing linked source file unrelated to this issue) - this change does
+      not add any new failure.</li>
+</ul>
+
+<h2>Sample playback log (the three terminal outcomes)</h2>
+<pre>
+[AndroidReplySpeaker] PlayAsync: bytes=128000, estimatedDuration=8.0s
+[AndroidReplySpeaker] PlayAsync done: result=Completed, bytes=128000, played=7.9s/8.0s
+
+[AndroidReplySpeaker] PlayAsync: bytes=64000, estimatedDuration=4.0s
+[AndroidReplySpeaker] PlayAsync done: result=Error, bytes=64000, played=1.2s/4.0s, what=1, extra=-2147483648
+
+[AndroidReplySpeaker] PlayAsync: bytes=128000, estimatedDuration=8.0s
+[AndroidReplySpeaker] audio focus change: loss-transient-can-duck
+[AndroidReplySpeaker] PlayAsync done: result=Interrupted, bytes=128000, played=3.1s/8.0s
+</pre>
+<p>The <code>played=3.1s/8.0s</code> on the last turn is the cutout this issue makes measurable;
+before this change only the START "bytes=N" line existed and a cutout was invisible.</p>
+
+<h2>CenCon impact</h2>
+<p><strong>No architecture or security drift.</strong> No container boundaries change, no new external
+calls, no new data flows, no security-profile rule touched. The change is additive logging on the
+phone client plus an integration test in an existing test project.</p>
+
+<h2>Conclusion</h2>
+<p>All Phase 1 acceptance criteria are met (the TtsService-tests criterion verified as
+satisfied-by-#389). The build is clean, the new tests pass, and there is no behaviour change to the
+shipping voice path beyond added logging and the test seam. <strong>I believe this is finished.</strong></p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-394/sample-playback-log.txt
+++ b/docs/cencon/proof/issue-394/sample-playback-log.txt
@@ -1,0 +1,29 @@
+Sample phone client log (issue #394) - the exact lines AndroidReplySpeaker now writes,
+produced by PlaybackLog (the formatter under unit test). Three turns shown: a clean
+finish, a decoder error, and a mid-playback cutout. From these lines ALONE one can tell,
+for any turn, whether playback finished, errored (with code), or was interrupted, plus the
+bytes and the played-versus-estimated duration.
+
+--- Turn A: clean finish (played to the end) ---
+2026-06-21 12:00:01.100Z [AndroidReplySpeaker] PlayAsync: bytes=128000, estimatedDuration=8.0s
+2026-06-21 12:00:09.050Z [AndroidReplySpeaker] PlayAsync done: result=Completed, bytes=128000, played=7.9s/8.0s
+2026-06-21 12:00:09.060Z [VoiceConversation] PollAndSpeak done: turnId=abc-1, summaryChars=42, audioBytes=128000, playback=Completed, playedSeconds=7.9, estimatedSeconds=8.0
+
+--- Turn B: decoder error mid-stream (MediaPlayer.Error) ---
+2026-06-21 12:01:02.200Z [AndroidReplySpeaker] PlayAsync: bytes=64000, estimatedDuration=4.0s
+2026-06-21 12:01:03.400Z [AndroidReplySpeaker] PlayAsync done: result=Error, bytes=64000, played=1.2s/4.0s, what=1, extra=-2147483648
+2026-06-21 12:01:03.410Z [VoiceConversation] PollAndSpeak done: turnId=abc-2, summaryChars=30, audioBytes=64000, playback=Error, playedSeconds=1.2, estimatedSeconds=4.0
+
+--- Turn C: interrupted/cut off (Stop() or cancellation; also note a focus loss) ---
+2026-06-21 12:02:05.300Z [AndroidReplySpeaker] PlayAsync: bytes=128000, estimatedDuration=8.0s
+2026-06-21 12:02:07.350Z [AndroidReplySpeaker] audio focus change: loss-transient-can-duck
+2026-06-21 12:02:08.400Z [AndroidReplySpeaker] PlayAsync done: result=Interrupted, bytes=128000, played=3.1s/8.0s
+2026-06-21 12:02:08.410Z [VoiceConversation] PollAndSpeak done: turnId=abc-3, summaryChars=42, audioBytes=128000, playback=Interrupted, playedSeconds=3.1, estimatedSeconds=8.0
+
+Key: Turn C's played=3.1s against estimatedDuration=8.0s is the cutout this issue makes
+measurable. Before this change the only log line was "PlayAsync: bytes=N" at the START, and
+MediaPlayer.Completion fired identically for A and C, so C was invisible.
+
+The exact wording above is pinned by PlaybackLogTests; the estimated durations are computed
+by Mp3Duration (pinned by Mp3DurationTests). Both run off-device because the real Android
+MediaPlayer cannot run headless.

--- a/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
+++ b/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
@@ -41,6 +41,13 @@
     <Compile Include="..\CcDirectorClient\Voice\TurnBrief.cs" Link="Voice\TurnBrief.cs" />
     <Compile Include="..\CcDirectorClient\Voice\OfflineGuard.cs" Link="Voice\OfflineGuard.cs" />
     <Compile Include="..\CcDirectorClient\Voice\PlaybackSignal.cs" Link="Voice\PlaybackSignal.cs" />
+    <!-- Playback observability (issue #394): the outcome record, the off-device MP3
+         duration estimator, and the ASCII-only log-line formatter. All dependency-free
+         (no MAUI/Android) so the wording and the duration maths are testable headless,
+         where the real Android MediaPlayer cannot run. -->
+    <Compile Include="..\CcDirectorClient\Voice\PlaybackOutcome.cs" Link="Voice\PlaybackOutcome.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\Mp3Duration.cs" Link="Voice\Mp3Duration.cs" />
+    <Compile Include="..\CcDirectorClient\Voice\PlaybackLog.cs" Link="Voice\PlaybackLog.cs" />
     <Compile Include="..\CcDirectorClient\Voice\LastClipCache.cs" Link="Voice\LastClipCache.cs" />
     <Compile Include="..\CcDirectorClient\Voice\IAudioCue.cs" Link="Voice\IAudioCue.cs" />
     <Compile Include="..\CcDirectorClient\Voice\NullAudioCue.cs" Link="Voice\NullAudioCue.cs" />

--- a/phone/CcDirectorClient.Tests/Mp3DurationTests.cs
+++ b/phone/CcDirectorClient.Tests/Mp3DurationTests.cs
@@ -1,0 +1,114 @@
+using CcDirectorClient.Voice;
+using Xunit;
+
+namespace CcDirectorClient.Tests;
+
+/// <summary>
+/// Issue #394: the playback log compares the duration a clip was ESTIMATED to run with
+/// the time it actually played, which is what makes a truncated playback measurable.
+/// The estimate comes from <see cref="Mp3Duration"/>, which must derive a CBR MP3's
+/// length from its frame headers off-device (the real Android decoder cannot run here).
+/// </summary>
+public class Mp3DurationTests
+{
+    // A valid MPEG-1 Layer III frame header for the given bitrate/sample-rate fields.
+    // Byte 0: 0xFF sync. Byte 1: 0xFB = sync(111) + MPEG-1(11) + Layer III(01) + no-CRC(1).
+    // Byte 2: bitrateIndex<<4 | sampleRateIndex<<2. Byte 3: 0x00 (channel/flags, unused here).
+    private static byte[] FrameHeader(int bitrateIndex, int sampleRateIndex)
+        => new byte[] { 0xFF, 0xFB, (byte)((bitrateIndex << 4) | (sampleRateIndex << 2)), 0x00 };
+
+    /// <summary>Build a synthetic CBR MP3: one real frame header followed by padding so the
+    /// stream is a known total length. The estimator treats the whole stream from the first
+    /// frame as audio, which is the CBR duration = totalBytes * 8 / bitrate.</summary>
+    private static byte[] CbrClip(int bitrateIndex, int sampleRateIndex, int totalBytes)
+    {
+        var clip = new byte[totalBytes];
+        var header = FrameHeader(bitrateIndex, sampleRateIndex);
+        System.Array.Copy(header, clip, header.Length);
+        return clip;
+    }
+
+    [Fact]
+    public void Estimate_128kbpsClip_ReturnsBytesTimesEightOverBitrate()
+    {
+        // 128 kbps = bitrate index 9. 16000 bytes -> 16000*8 / 128000 = 1.0 second.
+        var clip = CbrClip(bitrateIndex: 9, sampleRateIndex: 0, totalBytes: 16_000);
+
+        var d = Mp3Duration.Estimate(clip);
+
+        Assert.Equal(1.0, d.TotalSeconds, precision: 2);
+    }
+
+    [Fact]
+    public void Estimate_LongerClip_ScalesWithByteCount()
+    {
+        // Same 128 kbps, 8x the bytes -> 8x the duration (8.0 s). This is the "expected ~8s"
+        // a clean finish is measured against in the playback log.
+        var clip = CbrClip(bitrateIndex: 9, sampleRateIndex: 0, totalBytes: 128_000);
+
+        var d = Mp3Duration.Estimate(clip);
+
+        Assert.Equal(8.0, d.TotalSeconds, precision: 2);
+    }
+
+    [Fact]
+    public void Estimate_64kbpsClip_IsTwiceAsLongAsAt128kbps()
+    {
+        // 64 kbps = bitrate index 5. Half the bitrate -> twice the duration for the same bytes.
+        var clip = CbrClip(bitrateIndex: 5, sampleRateIndex: 0, totalBytes: 16_000);
+
+        var d = Mp3Duration.Estimate(clip);
+
+        Assert.Equal(2.0, d.TotalSeconds, precision: 2);
+    }
+
+    [Fact]
+    public void Estimate_SkipsLeadingNonFrameBytes()
+    {
+        // Garbage before the first frame must not derail the search; the duration is computed
+        // from the first valid header onward.
+        var clip = CbrClip(bitrateIndex: 9, sampleRateIndex: 0, totalBytes: 16_000);
+        var withJunk = new byte[5 + clip.Length];
+        for (int i = 0; i < 5; i++) withJunk[i] = 0x55; // arbitrary non-sync bytes
+        System.Array.Copy(clip, 0, withJunk, 5, clip.Length);
+
+        var d = Mp3Duration.Estimate(withJunk);
+
+        // The frame starts at offset 5, so audio bytes = 16000, duration = 1.0 s.
+        Assert.Equal(1.0, d.TotalSeconds, precision: 2);
+    }
+
+    [Fact]
+    public void Estimate_SkipsId3v2Tag()
+    {
+        // "ID3" + version(2) + flags(1) + 4 synch-safe size bytes (size = 8), then 8 tag bytes,
+        // then the real frame. The estimator must skip the tag and find the frame after it.
+        var frame = CbrClip(bitrateIndex: 9, sampleRateIndex: 0, totalBytes: 16_000);
+        var id3 = new byte[10 + 8];
+        id3[0] = 0x49; id3[1] = 0x44; id3[2] = 0x33; // "ID3"
+        id3[9] = 0x08; // synch-safe size = 8 -> tag body is 8 bytes
+        var clip = new byte[id3.Length + frame.Length];
+        System.Array.Copy(id3, clip, id3.Length);
+        System.Array.Copy(frame, 0, clip, id3.Length, frame.Length);
+
+        var d = Mp3Duration.Estimate(clip);
+
+        Assert.Equal(1.0, d.TotalSeconds, precision: 2);
+    }
+
+    [Fact]
+    public void Estimate_NullOrEmpty_ReturnsZero()
+    {
+        Assert.Equal(System.TimeSpan.Zero, Mp3Duration.Estimate(null));
+        Assert.Equal(System.TimeSpan.Zero, Mp3Duration.Estimate(System.Array.Empty<byte>()));
+    }
+
+    [Fact]
+    public void Estimate_NoValidFrameHeader_ReturnsZero()
+    {
+        // A buffer with no MPEG-1 Layer III sync is reported as unknown (zero), never a wrong number.
+        var notMp3 = new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 };
+
+        Assert.Equal(System.TimeSpan.Zero, Mp3Duration.Estimate(notMp3));
+    }
+}

--- a/phone/CcDirectorClient.Tests/PlaybackLogTests.cs
+++ b/phone/CcDirectorClient.Tests/PlaybackLogTests.cs
@@ -1,0 +1,100 @@
+using System;
+using CcDirectorClient.Voice;
+using Xunit;
+
+namespace CcDirectorClient.Tests;
+
+/// <summary>
+/// Issue #394 acceptance: from the phone client log ALONE one can tell, for any turn,
+/// whether playback (a) finished, (b) errored (with code), or (c) was interrupted, plus
+/// the bytes and the played-versus-estimated duration. The exact wording is built by
+/// <see cref="PlaybackLog"/>, so these tests pin that wording (the Android MediaPlayer
+/// that drives it cannot run headless). They also confirm the lines are ASCII-only, which
+/// CC Director requires of all log output.
+/// </summary>
+public class PlaybackLogTests
+{
+    private static void AssertAscii(string s)
+        => Assert.All(s, c => Assert.True(c < 128, $"non-ASCII char U+{(int)c:X4} in log line: {s}"));
+
+    [Fact]
+    public void Start_CarriesBytesAndEstimatedDuration()
+    {
+        var line = PlaybackLog.Start(audioBytes: 128_000, estimatedDuration: TimeSpan.FromSeconds(8));
+
+        Assert.Contains("bytes=128000", line);
+        Assert.Contains("estimatedDuration=8.0s", line);
+        AssertAscii(line);
+    }
+
+    [Fact]
+    public void Terminal_Completed_ReadsAsACleanFinish()
+    {
+        // A clip estimated at ~8.0s that played ~8.0s and ended Completed: a clean finish.
+        var outcome = new PlaybackOutcome(PlaybackResult.Completed, 128_000,
+            EstimatedDuration: TimeSpan.FromSeconds(8.0), PlayedDuration: TimeSpan.FromSeconds(7.9));
+
+        var line = PlaybackLog.Terminal(outcome);
+
+        Assert.Contains("result=Completed", line);
+        Assert.Contains("bytes=128000", line);
+        Assert.Contains("played=7.9s/8.0s", line);
+        // No decoder codes on a non-error outcome.
+        Assert.DoesNotContain("what=", line);
+        AssertAscii(line);
+    }
+
+    [Fact]
+    public void Terminal_Interrupted_IsDistinguishableFromCleanFinish()
+    {
+        // The cutout case: estimated 8.0s but only 3.1s played, ended Interrupted. This is what
+        // a user means by "the voice cut out", and it is now visible in the log as a number.
+        var outcome = new PlaybackOutcome(PlaybackResult.Interrupted, 128_000,
+            EstimatedDuration: TimeSpan.FromSeconds(8.0), PlayedDuration: TimeSpan.FromSeconds(3.1));
+
+        var line = PlaybackLog.Terminal(outcome);
+
+        Assert.Contains("result=Interrupted", line);
+        Assert.Contains("played=3.1s/8.0s", line);
+        AssertAscii(line);
+    }
+
+    [Fact]
+    public void Terminal_Error_CarriesWhatAndExtraCodes()
+    {
+        var outcome = new PlaybackOutcome(PlaybackResult.Error, 64_000,
+            EstimatedDuration: TimeSpan.FromSeconds(4.0), PlayedDuration: TimeSpan.FromSeconds(1.2));
+
+        var line = PlaybackLog.Terminal(outcome, errorWhat: 1, errorExtra: -2147483648);
+
+        Assert.Contains("result=Error", line);
+        Assert.Contains("what=1", line);
+        Assert.Contains("extra=-2147483648", line);
+        AssertAscii(line);
+    }
+
+    [Fact]
+    public void Terminal_Error_WithoutCodes_SaysNotAvailable()
+    {
+        // An Error outcome with no codes captured still reads as an error, with explicit n/a
+        // markers rather than a misleading 0.
+        var outcome = new PlaybackOutcome(PlaybackResult.Error, 0,
+            EstimatedDuration: TimeSpan.Zero, PlayedDuration: TimeSpan.Zero);
+
+        var line = PlaybackLog.Terminal(outcome);
+
+        Assert.Contains("result=Error", line);
+        Assert.Contains("what=n/a", line);
+        Assert.Contains("extra=n/a", line);
+        AssertAscii(line);
+    }
+
+    [Fact]
+    public void FocusChange_IsLoggedAsciiOnly()
+    {
+        var line = PlaybackLog.FocusChange("loss-transient-can-duck");
+
+        Assert.Contains("audio focus change: loss-transient-can-duck", line);
+        AssertAscii(line);
+    }
+}

--- a/phone/CcDirectorClient/Platforms/Android/AndroidReplySpeaker.cs
+++ b/phone/CcDirectorClient/Platforms/Android/AndroidReplySpeaker.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Android.Media;
+using Android.OS;
 using CcDirectorClient.Voice;
 using AndroidApp = Android.App.Application;
 
@@ -12,8 +14,17 @@ namespace CcDirectorClient.Platforms.Android;
 /// transient audio focus with "may duck" so any music dips under the voice
 /// instead of stopping, then the focus is abandoned so the music returns to full
 /// volume (Phase 3 ducking, preserved from the old native speaker).
+///
+/// OBSERVABILITY (issue #394): every playback logs its START (bytes + estimated
+/// duration), every audio-focus change while it plays, and its TERMINAL outcome
+/// with elapsed wall time and the played-versus-estimated duration - so a truncated
+/// playback (Interrupted, stopped well short of the estimate) is distinguishable in
+/// the log from a clean finish (Completed) and from a decoder failure (Error, with
+/// MediaPlayer what/extra codes). The Android <c>MediaPlayer.Completion</c> event
+/// fires identically whether playback finished or was cut off, so this class records
+/// which terminal path it actually took rather than inferring it from the event.
 /// </summary>
-public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
+public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker, AudioManager.IOnAudioFocusChangeListener
 {
     private readonly object _gate = new();
     private MediaPlayer? _player;
@@ -32,9 +43,9 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
         remove => _signal.Changed -= value;
     }
 
-    public async Task PlayAsync(byte[] audio, CancellationToken ct = default)
+    public async Task<PlaybackOutcome> PlayAsync(byte[] audio, CancellationToken ct = default)
     {
-        if (audio is null || audio.Length == 0) return;
+        if (audio is null || audio.Length == 0) return PlaybackOutcome.None;
 
         // Stop anything currently playing before starting the next clip.
         StopInternal();
@@ -46,6 +57,16 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
             $"ccd-tts-{Guid.NewGuid():N}.mp3");
         await System.IO.File.WriteAllBytesAsync(path, audio, ct);
 
+        // Estimate how long this clip should run (issue #394). The terminal line compares
+        // this with the wall-clock time actually played, which is what makes a cutout visible.
+        var estimated = Mp3Duration.Estimate(audio);
+
+        // The terminal result starts Completed and is overwritten by the FIRST terminal
+        // signal: Error (decoder failure) or Interrupted (Stop/cancel). MediaPlayer.Completion
+        // resolves the await without changing the result, so a natural finish stays Completed.
+        var result = PlaybackResult.Completed;
+        int? errorWhat = null, errorExtra = null;
+
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var player = new MediaPlayer();
         lock (_gate) { _player = player; }
@@ -53,7 +74,10 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
         player.Completion += (_, _) => tcs.TrySetResult(true);
         player.Error += (_, e) =>
         {
-            ClientLog.Write($"[AndroidReplySpeaker] MediaPlayer error: what={e.What}, extra={e.Extra}");
+            // Record the decoder's codes so the terminal line carries them, then end the await.
+            errorWhat = (int)e.What;
+            errorExtra = e.Extra;
+            result = PlaybackResult.Error;
             e.Handled = true; // we handle it; suppress the follow-up Completion event
             tcs.TrySetResult(false);
         };
@@ -70,13 +94,22 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
         }
 
         RequestAudioFocus();
-        ClientLog.Write($"[AndroidReplySpeaker] PlayAsync: bytes={audio.Length}");
+        ClientLog.Write(PlaybackLog.Start(audio.Length, estimated));
 
+        var stopwatch = Stopwatch.StartNew();
         try
         {
             player.SetDataSource(path);
             player.Prepare();
-            using (ct.Register(() => { try { player.Stop(); } catch { } tcs.TrySetResult(false); }))
+            // The cancellation token firing is an interruption (cut off mid-playback), distinct
+            // from a clean Completion. Record it before resolving the await so the terminal line
+            // reads Interrupted, not Completed.
+            using (ct.Register(() =>
+            {
+                result = PlaybackResult.Interrupted;
+                try { player.Stop(); } catch { }
+                tcs.TrySetResult(false);
+            }))
             {
                 player.Start();
                 _signal.Begin();   // playing now: any visible screen shows its Stop-talking control
@@ -85,6 +118,7 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
         }
         finally
         {
+            stopwatch.Stop();
             lock (_gate) { if (_player == player) _player = null; }
             try { player.Release(); } catch { }
             try { player.Dispose(); } catch { }
@@ -92,6 +126,13 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
             _signal.End();         // playback ended (finished, stopped, or cancelled)
             try { System.IO.File.Delete(path); } catch { }
         }
+
+        // result is Completed only if MediaPlayer.Completion resolved the await; the Error handler
+        // and the cancellation registration each overwrite it to Error / Interrupted before
+        // resolving, so the terminal line reflects the path actually taken (issue #394).
+        var outcome = new PlaybackOutcome(result, audio.Length, estimated, stopwatch.Elapsed);
+        ClientLog.Write(PlaybackLog.Terminal(outcome, errorWhat, errorExtra));
+        return outcome;
     }
 
     public void Stop()
@@ -113,6 +154,25 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
 
     // ===== audio focus (Phase 3: duck music under the voice) ================
 
+    /// <summary>
+    /// Audio-focus changes observed while a reply plays (issue #394): a transient
+    /// loss/duck means the system pulled focus (e.g. a call, an alarm) and the voice
+    /// may have been ducked or paused under it - one more reason a turn can sound cut
+    /// off. Logged, not acted on: the existing duck/abandon behaviour is unchanged.
+    /// </summary>
+    public void OnAudioFocusChange(AudioFocus focusChange)
+    {
+        var change = focusChange switch
+        {
+            AudioFocus.Gain => "gain",
+            AudioFocus.Loss => "loss",
+            AudioFocus.LossTransient => "loss-transient",
+            AudioFocus.LossTransientCanDuck => "loss-transient-can-duck",
+            _ => focusChange.ToString(),
+        };
+        ClientLog.Write(PlaybackLog.FocusChange(change));
+    }
+
     private void RequestAudioFocus()
     {
         try
@@ -128,13 +188,16 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
                     .Build();
                 _focusRequest = new AudioFocusRequestClass.Builder(AudioFocus.GainTransientMayDuck)!
                     .SetAudioAttributes(attrs!)!
+                    // Register for focus-change callbacks so gain/loss/duck is observable in the
+                    // log during playback (issue #394). A Handler on the main looper delivers them.
+                    .SetOnAudioFocusChangeListener(this, new Handler(Looper.MainLooper!))!
                     .Build();
                 _audioManager.RequestAudioFocus(_focusRequest!);
             }
             else
             {
 #pragma warning disable CA1422 // legacy overload only on pre-26 devices
-                _audioManager.RequestAudioFocus(null, global::Android.Media.Stream.Music, AudioFocus.GainTransientMayDuck);
+                _audioManager.RequestAudioFocus(this, global::Android.Media.Stream.Music, AudioFocus.GainTransientMayDuck);
 #pragma warning restore CA1422
             }
         }
@@ -156,7 +219,7 @@ public sealed class AndroidReplySpeaker : Java.Lang.Object, IReplySpeaker
             else
             {
 #pragma warning disable CA1422
-                _audioManager.AbandonAudioFocus(null);
+                _audioManager.AbandonAudioFocus(this);
 #pragma warning restore CA1422
             }
         }

--- a/phone/CcDirectorClient/Voice/IReplySpeaker.cs
+++ b/phone/CcDirectorClient/Voice/IReplySpeaker.cs
@@ -14,8 +14,12 @@ public interface IReplySpeaker
     /// Play <paramref name="audio"/> (MP3 bytes from the Director's /tts endpoint)
     /// and complete when playback finishes (or is stopped/cancelled). No-op for
     /// empty audio. While playing, music is ducked under the voice on Android.
+    /// Returns the measurable <see cref="PlaybackOutcome"/> (issue #394): how it
+    /// ended, the byte count, and the estimated-versus-played duration, so the
+    /// caller can record on its turn-done line whether playback finished cleanly
+    /// or was cut short. Empty audio returns <see cref="PlaybackOutcome.None"/>.
     /// </summary>
-    Task PlayAsync(byte[] audio, CancellationToken ct = default);
+    Task<PlaybackOutcome> PlayAsync(byte[] audio, CancellationToken ct = default);
 
     /// <summary>Stop any in-progress playback immediately.</summary>
     void Stop();

--- a/phone/CcDirectorClient/Voice/Mp3Duration.cs
+++ b/phone/CcDirectorClient/Voice/Mp3Duration.cs
@@ -1,0 +1,73 @@
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// Estimates the playing time of an MP3 byte stream by walking its frame headers
+/// (issue #394). The Director's OpenAI tts-1 voice returns MPEG-1 Layer III audio;
+/// for a constant-bitrate stream (what tts-1 emits) the duration is simply
+/// totalAudioBytes * 8 / bitrate. Rather than trust a single header we read the
+/// first valid frame's bitrate + sample rate, which is stable across a CBR clip,
+/// and divide the audio byte count by the byte rate.
+///
+/// This is an ESTIMATE, not a decode: it exists so a log line can say "expected
+/// ~8.0s" next to "played 3.1s" and make a truncated playback measurable. It is
+/// pure and MAUI/Android-free so it can be unit-tested off-device, where the real
+/// MediaPlayer cannot run.
+/// </summary>
+public static class Mp3Duration
+{
+    // MPEG-1 Layer III bitrate table (kbps), indexed by the 4-bit bitrate field.
+    // Index 0 = "free", 15 = "bad" - both are invalid and treated as no frame.
+    private static readonly int[] Mpeg1Layer3BitrateKbps =
+        { 0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0 };
+
+    // MPEG-1 sample-rate table (Hz), indexed by the 2-bit sample-rate field.
+    private static readonly int[] Mpeg1SampleRateHz = { 44100, 48000, 32000, 0 };
+
+    /// <summary>
+    /// Estimate the playing time of <paramref name="audio"/>. Returns
+    /// <see cref="TimeSpan.Zero"/> for empty input or when no valid MPEG-1 Layer III
+    /// frame header can be found (an unexpected format is reported as "unknown
+    /// duration" by the caller rather than a wrong number).
+    /// </summary>
+    public static TimeSpan Estimate(byte[]? audio)
+    {
+        if (audio is null || audio.Length < 4) return TimeSpan.Zero;
+
+        // Skip an ID3v2 tag if present ("ID3" + version + flags + 4 synch-safe size bytes),
+        // so the first frame search starts at the audio, not the metadata.
+        int start = 0;
+        if (audio.Length >= 10 && audio[0] == 0x49 && audio[1] == 0x44 && audio[2] == 0x33) // "ID3"
+        {
+            int tagSize = (audio[6] & 0x7F) << 21 | (audio[7] & 0x7F) << 14
+                          | (audio[8] & 0x7F) << 7 | (audio[9] & 0x7F);
+            start = 10 + tagSize;
+            if (start >= audio.Length) return TimeSpan.Zero;
+        }
+
+        for (int i = start; i + 3 < audio.Length; i++)
+        {
+            // Frame sync: 11 set bits (0xFF then top 3 bits of next byte).
+            if (audio[i] != 0xFF || (audio[i + 1] & 0xE0) != 0xE0) continue;
+
+            // MPEG Audio version (bits 4-3 of byte 1): 0b11 = MPEG-1. Layer (bits 2-1):
+            // 0b01 = Layer III. We only model the tts-1 case (MPEG-1 Layer III).
+            int versionBits = (audio[i + 1] >> 3) & 0x03;
+            int layerBits = (audio[i + 1] >> 1) & 0x03;
+            if (versionBits != 0x03 || layerBits != 0x01) continue;
+
+            int bitrateIndex = (audio[i + 2] >> 4) & 0x0F;
+            int sampleRateIndex = (audio[i + 2] >> 2) & 0x03;
+            int bitrateKbps = Mpeg1Layer3BitrateKbps[bitrateIndex];
+            int sampleRateHz = Mpeg1SampleRateHz[sampleRateIndex];
+            if (bitrateKbps == 0 || sampleRateHz == 0) continue; // free/bad - keep scanning
+
+            // The audio payload starts at this first frame; everything from here to the
+            // end is sound. For CBR, duration = audioBytes * 8 / bitrate(bits per second).
+            long audioBytes = audio.Length - i;
+            double seconds = audioBytes * 8.0 / (bitrateKbps * 1000.0);
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        return TimeSpan.Zero;
+    }
+}

--- a/phone/CcDirectorClient/Voice/PlaybackLog.cs
+++ b/phone/CcDirectorClient/Voice/PlaybackLog.cs
@@ -1,0 +1,44 @@
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// Builds the ASCII-only diagnostic log lines for reply playback (issue #394). Kept
+/// as a pure formatter, separate from the Android MediaPlayer plumbing, so the exact
+/// wording - which is what a person reads to tell a clean finish from a cutout - is
+/// unit-tested off-device, where the real MediaPlayer cannot run.
+///
+/// The lines deliberately put the terminal outcome, the bytes, and the
+/// played-vs-estimated duration on one line so that, from the phone log ALONE, one
+/// turn can be classified:
+///   - "result=Completed" near the estimated time  -> played to the end
+///   - "result=Error code=..."                      -> the decoder failed
+///   - "result=Interrupted played=3.1s/8.0s"        -> cut off mid-playback
+/// </summary>
+public static class PlaybackLog
+{
+    /// <summary>The start-of-playback line: byte count and the estimated clip duration.</summary>
+    public static string Start(int audioBytes, TimeSpan estimatedDuration)
+        => $"[AndroidReplySpeaker] PlayAsync: bytes={audioBytes}, estimatedDuration={Secs(estimatedDuration)}";
+
+    /// <summary>
+    /// The terminal-outcome line. For an <see cref="PlaybackResult.Error"/> the
+    /// MediaPlayer what/extra codes are included; for the others they are absent.
+    /// Always carries bytes and played-vs-estimated wall time so a truncated
+    /// playback is distinguishable from a clean finish.
+    /// </summary>
+    public static string Terminal(PlaybackOutcome outcome, int? errorWhat = null, int? errorExtra = null)
+    {
+        var codes = outcome.Result == PlaybackResult.Error
+            ? $", what={errorWhat?.ToString() ?? "n/a"}, extra={errorExtra?.ToString() ?? "n/a"}"
+            : "";
+        return $"[AndroidReplySpeaker] PlayAsync done: result={outcome.Result}, bytes={outcome.AudioBytes}, "
+             + $"played={Secs(outcome.PlayedDuration)}/{Secs(outcome.EstimatedDuration)}{codes}";
+    }
+
+    /// <summary>An audio-focus change observed during playback (gain/loss/duck).</summary>
+    public static string FocusChange(string change)
+        => $"[AndroidReplySpeaker] audio focus change: {change}";
+
+    /// <summary>One decimal second, ASCII only and culture-invariant (no locale comma).</summary>
+    private static string Secs(TimeSpan t)
+        => t.TotalSeconds.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture) + "s";
+}

--- a/phone/CcDirectorClient/Voice/PlaybackOutcome.cs
+++ b/phone/CcDirectorClient/Voice/PlaybackOutcome.cs
@@ -1,0 +1,40 @@
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// How a single reply playback ended. A truncated playback (the symptom issue #394
+/// is built to catch) is distinguishable from a clean finish ONLY because these are
+/// three separate terminal states - the underlying Android MediaPlayer.Completion
+/// event fires identically whether playback finished or was cut short, so the speaker
+/// records which terminal path it actually took rather than inferring it from the event.
+/// </summary>
+public enum PlaybackResult
+{
+    /// <summary>Playback ran to the end of the clip (MediaPlayer.Completion with no prior Stop/Error).</summary>
+    Completed,
+
+    /// <summary>The decoder raised MediaPlayer.Error mid-stream; the clip did not finish.</summary>
+    Error,
+
+    /// <summary>Playback was interrupted before the end (Stop() or the cancellation token fired).</summary>
+    Interrupted,
+}
+
+/// <summary>
+/// The measurable result of playing one reply clip (issue #394). Carries the byte
+/// count, the duration the clip was ESTIMATED to run (decoded from the MP3 headers
+/// off-device), the wall-clock time playback actually ran, and the terminal
+/// <see cref="PlaybackResult"/>. The estimated-versus-played gap is what makes a
+/// mid-playback cutout visible: a clip estimated at 8.0s that stops at 3.1s with
+/// result Interrupted is a cutout, whereas Completed at ~8.0s is a clean finish.
+/// Pure data with no MAUI/Android dependency so callers and tests can use it off-device.
+/// </summary>
+public sealed record PlaybackOutcome(
+    PlaybackResult Result,
+    int AudioBytes,
+    TimeSpan EstimatedDuration,
+    TimeSpan PlayedDuration)
+{
+    /// <summary>An empty/no-op playback (no audio was supplied).</summary>
+    public static PlaybackOutcome None { get; } =
+        new(PlaybackResult.Completed, 0, TimeSpan.Zero, TimeSpan.Zero);
+}

--- a/phone/CcDirectorClient/Voice/VoiceConversation.cs
+++ b/phone/CcDirectorClient/Voice/VoiceConversation.cs
@@ -237,10 +237,18 @@ public sealed class VoiceConversation
             mp3 = await runner.FetchAudioToCompletionAsync(_gatewayBaseUrl, sessionId, turnId, ct);
         }
 
+        // Play the reply and capture the measurable outcome (issue #394) so the done line
+        // records audio bytes AND the duration actually played versus the estimate - a
+        // played time far short of the estimate is the cutout this issue makes visible.
+        PlaybackOutcome playback = PlaybackOutcome.None;
         if (mp3.Length > 0)
-            await _tts.PlayAsync(mp3, ct);
+            playback = await _tts.PlayAsync(mp3, ct);
 
-        ClientLog.Write($"[VoiceConversation] PollAndSpeak done: turnId={turnId}, summaryChars={summary.Length}, audioBytes={mp3.Length}");
+        ClientLog.Write(
+            $"[VoiceConversation] PollAndSpeak done: turnId={turnId}, summaryChars={summary.Length}, "
+            + $"audioBytes={mp3.Length}, playback={playback.Result}, "
+            + $"playedSeconds={playback.PlayedDuration.TotalSeconds.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)}, "
+            + $"estimatedSeconds={playback.EstimatedDuration.TotalSeconds.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)}");
         return summary;
     }
 

--- a/src/CcDirector.Gateway.Tests/VoiceTurnNoMicE2EHarnessTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTurnNoMicE2EHarnessTests.cs
@@ -1,0 +1,263 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The no-microphone end-to-end voice-turn harness (issue #394, Phase 1).
+///
+/// It drives the Gateway's real async voice-turn pipeline using the TEXT field - no
+/// microphone, no transcription, no live OpenAI key - and asserts that one full turn
+/// reaches stage=reply with NON-EMPTY audio of a plausible size, then fetches that audio
+/// back through the dedicated audio endpoint. Crucially it runs the turn N times and
+/// reports a PASS RATE, so multi-chunk flakiness (the symptom #389 fixed and this issue
+/// makes measurable) shows up as a number rather than a silent intermittent failure.
+///
+/// To produce real audio bytes deterministically without a live key, the harness stands up
+/// a STUB Director (a tiny in-process Kestrel app) that the Gateway discovers and dials just
+/// like a real one: it answers GET /sessions/{sid} so the Gateway accepts it as the owner,
+/// and its POST /sessions/{sid}/voice-turn emits the same Server-Sent-Events the real
+/// Director does, ending with a reply event carrying non-empty MP3 bytes. Everything from
+/// the Gateway's submit route through RunTurnAsync, the slim poll, and the audio fetch is the
+/// real shipping code; only the Director's own TTS call is replaced by canned bytes.
+///
+/// Acceptance covered:
+///   - submits a text voice-turn through the Gateway,
+///   - asserts a non-empty audio reply of a plausible size,
+///   - runs N iterations and reports a pass rate.
+/// </summary>
+public sealed class VoiceTurnNoMicE2EHarnessTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    // A canned MP3 payload of a plausible reply size (a real one-sentence tts-1 reply is a
+    // few kilobytes). Deterministic so every iteration asserts the exact same byte-exact reply.
+    private const int StubAudioBytes = 6_000;
+
+    private readonly ITestOutputHelper _output;
+
+    private WebApplication _stubDirector = null!;
+    private string _stubEndpoint = null!;
+    private string _stubDirectorId = null!;
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string? _originalRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-instances-" + Guid.NewGuid().ToString("N"));
+
+    public VoiceTurnNoMicE2EHarnessTests(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        _originalRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        // ---- stub Director ---------------------------------------------------
+        var stubPort = AllocateFreePort();
+        _stubEndpoint = $"http://127.0.0.1:{stubPort}";
+        _stubDirectorId = Guid.NewGuid().ToString();
+        _stubDirector = BuildStubDirector(stubPort);
+        await _stubDirector.StartAsync();
+
+        // ---- real Gateway ----------------------------------------------------
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: GatewayToken, authEnabled: false,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        _http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        _http.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GatewayToken);
+
+        // Register the stub Director with the Gateway over HTTP (the same path a remote
+        // Director uses), so the Gateway dials our stub for the voice-turn.
+        var register = await _http.PostAsJsonAsync("directors/register", new DirectorRegistrationRequest
+        {
+            DirectorId = _stubDirectorId,
+            TailnetEndpoint = _stubEndpoint,
+            MachineName = "stub-director-no-mic-harness",
+        });
+        Assert.Equal(HttpStatusCode.Created, register.StatusCode);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        await _stubDirector.StopAsync();
+        await _stubDirector.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _originalRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== the harness =========================================================
+
+    [Fact]
+    public async Task NoMicTextTurn_SingleIteration_ReachesReplyWithPlausibleAudio()
+    {
+        var (passed, summary, audioLen) = await RunOneTextTurnAsync();
+
+        Assert.True(passed, "single no-mic text turn did not reach reply with plausible audio");
+        Assert.False(string.IsNullOrEmpty(summary), "reply summary must be non-empty");
+        Assert.Equal(StubAudioBytes, audioLen);
+    }
+
+    [Fact]
+    public async Task NoMicTextTurn_TenIterations_ReportsPassRate()
+    {
+        // The headline harness: run the whole text -> reply -> audio loop N times and report the
+        // pass rate. A flaky multi-chunk failure would show up here as a rate below 100%.
+        const int iterations = 10;
+        var passes = 0;
+        for (var i = 0; i < iterations; i++)
+        {
+            var (passed, _, _) = await RunOneTextTurnAsync();
+            if (passed) passes++;
+        }
+
+        var rate = passes * 100.0 / iterations;
+        _output.WriteLine($"[no-mic E2E harness] pass rate: {passes}/{iterations} = {rate:0.0}%");
+
+        // In the deterministic stub environment a healthy pipeline is 100%. The harness exists to
+        // turn flakiness into this number; if it ever drops, this assertion makes the loop fail loudly.
+        Assert.Equal(iterations, passes);
+    }
+
+    /// <summary>
+    /// One full no-mic turn: submit text through the Gateway, poll to a terminal stage, and fetch
+    /// the reply audio. Returns whether the turn passed the acceptance bar (reply stage + non-empty
+    /// audio of plausible size), plus the summary and the fetched audio length for the assertions.
+    /// </summary>
+    private async Task<(bool passed, string? summary, int audioLen)> RunOneTextTurnAsync()
+    {
+        var sid = Guid.NewGuid().ToString();
+        // Prime the owner cache so the Gateway dials our stub directly (mirrors a warm fleet).
+        _gateway.SessionOwners.Remember(sid, _stubDirectorId);
+
+        // 1. Submit a TEXT voice-turn (no audio file).
+        var submit = await _http.PostAsJsonAsync($"sessions/{sid}/voice-turn/submit", new { text = "What is 2 + 2?" });
+        if (submit.StatusCode != HttpStatusCode.Accepted) return (false, null, 0);
+        using var submitDoc = JsonDocument.Parse(await submit.Content.ReadAsStringAsync());
+        var turnId = submitDoc.RootElement.GetProperty("turn_id").GetString();
+        if (string.IsNullOrEmpty(turnId)) return (false, null, 0);
+
+        // 2. Poll to a terminal stage.
+        var deadline = DateTime.UtcNow.AddSeconds(20);
+        string? stage = null, summary = null;
+        var audioReady = false;
+        var audioLength = 0;
+        while (DateTime.UtcNow < deadline)
+        {
+            var poll = await _http.GetAsync($"sessions/{sid}/voice-turn/{turnId}");
+            if (poll.StatusCode != HttpStatusCode.OK) { await Task.Delay(200); continue; }
+            using var doc = JsonDocument.Parse(await poll.Content.ReadAsStringAsync());
+            stage = doc.RootElement.GetProperty("stage").GetString();
+            if (stage is "reply" or "error")
+            {
+                summary = doc.RootElement.GetProperty("summary").GetString();
+                audioReady = doc.RootElement.GetProperty("audioReady").GetBoolean();
+                audioLength = doc.RootElement.GetProperty("audioLength").GetInt32();
+                break;
+            }
+            await Task.Delay(200);
+        }
+
+        if (stage != "reply" || !audioReady) return (false, summary, 0);
+
+        // 3. Fetch the reply audio through the dedicated endpoint and assert it is non-empty and
+        //    of the plausible size the slim poll advertised.
+        var audioResp = await _http.GetAsync($"sessions/{sid}/voice-turn/{turnId}/audio");
+        if (audioResp.StatusCode != HttpStatusCode.OK) return (false, summary, 0);
+        var bytes = await audioResp.Content.ReadAsByteArrayAsync();
+
+        var plausible = bytes.Length > 0 && bytes.Length == audioLength && bytes.Length >= 1000;
+        return (plausible, summary, bytes.Length);
+    }
+
+    // ===== stub Director =======================================================
+
+    /// <summary>
+    /// A tiny in-process Director stand-in. It answers exactly the two routes the Gateway's
+    /// voice-turn pipeline calls: GET /sessions/{sid} (owner resolution) and POST
+    /// /sessions/{sid}/voice-turn (the SSE worker). The SSE response mirrors the real Director's
+    /// stage events and ends with a reply event carrying non-empty MP3 bytes, so the Gateway's
+    /// real submit/poll/audio path runs end-to-end without a live OpenAI key.
+    /// </summary>
+    private WebApplication BuildStubDirector(int port)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls(_stubEndpoint);
+        // Silence framework logging noise in the test output.
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+
+        // Owner resolution: report a ready (non-exited) session so the Gateway accepts this
+        // Director as the owner and dials its voice-turn route.
+        app.MapGet("/sessions/{sid}", (string sid) => Results.Json(new SessionDto
+        {
+            SessionId = sid,
+            DirectorId = _stubDirectorId,
+            Agent = "ClaudeCode",
+            RepoPath = @"C:\test\no-mic-harness",
+            Status = "Running",
+            ActivityState = "WaitingForInput",
+            CreatedAt = DateTime.UtcNow,
+            Name = "no-mic-harness",
+        }));
+
+        // The SSE voice-turn worker: emit the same stage vocabulary the real endpoint does, then
+        // a terminal reply event with non-empty audio. The audio is canned (deterministic bytes)
+        // because the real OpenAI TTS call cannot run keyless in CI.
+        app.MapPost("/sessions/{sid}/voice-turn", async (string sid, HttpContext ctx) =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status200OK;
+            ctx.Response.ContentType = "text/event-stream; charset=utf-8";
+
+            async Task EmitAsync(object payload)
+            {
+                var json = JsonSerializer.Serialize(payload);
+                await ctx.Response.WriteAsync($"data: {json}\n\n");
+                await ctx.Response.Body.FlushAsync();
+            }
+
+            await EmitAsync(new { stage = "transcript", text = "What is 2 + 2?" });
+            await EmitAsync(new { stage = "thinking" });
+            await EmitAsync(new { stage = "summarizing" });
+
+            var audio = new byte[StubAudioBytes];
+            for (var i = 0; i < audio.Length; i++) audio[i] = (byte)(i % 251);
+            var audioBase64 = Convert.ToBase64String(audio);
+            await EmitAsync(new { stage = "reply", summary = "Two plus two is four.", audioBase64 });
+
+            await ctx.Response.CompleteAsync();
+        });
+
+        return app;
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}


### PR DESCRIPTION
Closes part of #394 (Phase 1 only; Phases 2-3 remain follow-ons).

## Release Notes
Voice mode now has the observability and automated coverage to make the intermittent "cut out" measurable. The phone client logs, for every reply playback, the byte count, an estimated duration, every audio-focus change, and the terminal outcome (finished / errored-with-code / interrupted) with played-versus-estimated time - so a truncated playback is distinguishable in the log from a clean finish. A new no-microphone end-to-end harness drives the Gateway voice-turn pipeline with text and reports a pass rate over N runs. No behaviour change to the shipping voice path beyond added logging and a test seam.

## Changes
- `AndroidReplySpeaker`: START line (bytes + estimatedDuration), TERMINAL line (result + bytes + played/estimated + MediaPlayer what/extra on error), and audio-focus gain/loss/duck logging during playback.
- `IReplySpeaker.PlayAsync` returns `Task<PlaybackOutcome>`; `VoiceConversation`'s "PollAndSpeak done" line now carries audioBytes + playback result + played/estimated seconds.
- New dependency-free helpers testable off-device: `PlaybackOutcome`, `Mp3Duration` (CBR MP3 duration from frame headers), `PlaybackLog` (ASCII-only formatter), with `Mp3DurationTests` + `PlaybackLogTests`.
- `VoiceTurnNoMicE2EHarnessTests`: text-field submit -> poll -> audio-fetch through the real Gateway pipeline against an in-process stub Director, asserting non-empty plausible audio and reporting a pass rate over 10 iterations.
- Reconciliation with #389 (PR #612): the host-side TtsService-tests criterion is already satisfied there and is NOT duplicated; the obsolete 180s-stall assertion was not reintroduced.

## How to Test
- `dotnet build cc-director.sln` -> clean.
- `dotnet test phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj --filter "FullyQualifiedName~Mp3Duration|FullyQualifiedName~PlaybackLog"`
- `dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter "FullyQualifiedName~VoiceTurnNoMicE2EHarnessTests" --logger "console;verbosity=detailed"`

## Expected Result
- Solution + phone Android app build clean (0 errors).
- Phone observability tests: 13/13 pass. No-mic harness: 2/2 pass, pass rate 10/10 = 100.0%. TtsServiceTests (#389): 9/9 pass. All 49 Gateway VoiceTurn tests pass.

## Before / After
- Before: the phone logged only `PlayAsync: bytes=N` at the start, and `MediaPlayer.Completion` fired identically for a clean finish and a cutout - a mid-playback cutout was invisible.
- After: `PlayAsync done: result=Interrupted, bytes=128000, played=3.1s/8.0s` makes the cutout a number.

Proof: docs/cencon/proof/issue-394/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)