### PR TITLE
[Gateway] GET /account/status: local signed-in status + identity (#638)

### DIFF
--- a/docs/cencon/proof/issue-638/ac1-signedin-with-token.txt
+++ b/docs/cencon/proof/issue-638/ac1-signedin-with-token.txt
@@ -1,0 +1,8 @@
+=== AC1+AC4: GET /account/status WITH Gateway token (auth enabled) ===
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Mon, 22 Jun 2026 15:18:37 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"signedIn":true,"email":"gateway-user@example.com","provider":"github"}

--- a/docs/cencon/proof/issue-638/ac1b-signedin-no-auth.txt
+++ b/docs/cencon/proof/issue-638/ac1b-signedin-no-auth.txt
@@ -1,0 +1,8 @@
+=== AC1 (auth off): GET /account/status, valid credential -> 200 signedIn:true + identity, NO token ===
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Mon, 22 Jun 2026 15:19:42 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"signedIn":true,"email":"gateway-user@example.com","provider":"github"}

--- a/docs/cencon/proof/issue-638/ac2-signedout.txt
+++ b/docs/cencon/proof/issue-638/ac2-signedout.txt
@@ -1,0 +1,8 @@
+=== AC2: GET /account/status with NO credential -> expect 200 signedIn:false, no identity fields ===
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Mon, 22 Jun 2026 15:19:13 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"signedIn":false}

--- a/docs/cencon/proof/issue-638/ac3-unauthorized-no-token.txt
+++ b/docs/cencon/proof/issue-638/ac3-unauthorized-no-token.txt
@@ -1,0 +1,8 @@
+=== AC3: GET /account/status WITHOUT token (auth enabled) -> expect 401 ===
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+Date: Mon, 22 Jun 2026 15:18:37 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{"error":"missing or invalid token"}

--- a/docs/cencon/proof/issue-638/ac4-no-token-check.txt
+++ b/docs/cencon/proof/issue-638/ac4-no-token-check.txt
@@ -1,0 +1,4 @@
+--- AC4 check: assert the JWT and refresh marker are absent from the body ---
+Body: {"signedIn":true,"email":"gateway-user@example.com","provider":"github"}
+PASS: no refresh token in body
+PASS: no JWT/access-token in body

--- a/docs/cencon/proof/issue-638/qa-report.html
+++ b/docs/cencon/proof/issue-638/qa-report.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #638 (GET /account/status)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; color: #1a1a1a; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #2b6cb0; padding-bottom: .3rem; }
+  h2 { margin-top: 2rem; color: #2b6cb0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0f4f8; }
+  .pass { color: #1a7f37; font-weight: bold; }
+  pre { background: #1e1e1e; color: #d4d4d4; padding: .8rem; border-radius: 4px; overflow-x: auto; font-size: .85rem; }
+  .verdict { background: #e6ffed; border: 2px solid #1a7f37; padding: 1rem; border-radius: 6px; font-size: 1.1rem; }
+  code { background: #eef; padding: .1rem .3rem; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #638</h1>
+<p><strong>Title:</strong> [Gateway] GET /account/status (is the Gateway signed in, and who as)<br>
+<strong>Pull Request:</strong> #671 (branch <code>issue-638-account-status</code>)<br>
+<strong>Verifier:</strong> QA Agent (independent of the Developer Agent), CenCon Development Method<br>
+<strong>Method:</strong> Built and ran the change in a fresh worktree from the PR branch. Booted the real
+<code>AccountStatusEndpoint</code> over the real <code>DevThrottleAccountService</code> credential service
+behind the real host-wide <code>AuthMiddleware</code>, and hit it with actual <code>curl.exe</code> for raw-wire proof.
+Did not reuse the Developer's binary or screenshots.</p>
+
+<h2>Acceptance Criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (own evidence)</th><th>Result</th></tr>
+
+<tr>
+<td>1</td>
+<td>200 with signedIn:true + decoded email/provider when the Gateway holds a valid (seeded) credential; identity matches the seeded token.</td>
+<td>200; <code>{"signedIn":true,"email":...,"provider":...}</code></td>
+<td>Live curl returned <code>200 {"signedIn":true,"email":"qa-verifier@example.com","provider":"github"}</code>. The email and provider exactly match the seeded JWT identity claims.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>200 with signedIn:false and NO identity fields when the Gateway has no credential.</td>
+<td>200; <code>{"signedIn":false}</code>, no email/provider keys</td>
+<td>Live curl returned <code>200 {"signedIn":false}</code>. The <code>email</code> and <code>provider</code> JSON keys are absent (omitted, not null) - confirmed by JSON parse in the unit test and by string-absence in the curl body.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>With Gateway auth enabled, the endpoint requires the Gateway token (401 without it); 200 with it - consistent with other endpoints.</td>
+<td>401 without token; 200 with token</td>
+<td>Auth-on, no token: live curl <code>401 Unauthorized {"error":"missing or invalid token"}</code>. Auth-on, with <code>Authorization: Bearer</code>: <code>200 {"signedIn":true,...}</code>. The endpoint path <code>/account/status</code> is NOT on <code>AuthMiddleware.PublicPaths</code>, so it inherits the same host-wide gate as the other endpoints; the test exercises the production <code>AuthMiddleware.Run</code> directly.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>The response NEVER includes the access or refresh token (only the boolean + identity).</td>
+<td>No JWT, no refresh token, no token field in body</td>
+<td>In the signed-in body, the seeded access JWT and the plaintext refresh marker (<code>QA-REFRESH-PLAINTEXT-MARKER-638</code>) are both absent; the substring "token" does not appear in the body. Confirmed structurally: the <code>AccountStatusResponse</code> record carries only <code>signedIn</code>/<code>email</code>/<code>provider</code> - it has NO token field, so a token cannot be serialized (security rule DT-05).</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>Unit tests cover signed-in, not-signed-in, and (auth enabled) the unauthorized path.</td>
+<td>Tests present and genuinely asserting each state</td>
+<td>5 HTTP wire tests in <code>AccountStatusEndpointTests.cs</code>, all passing: signed-in (200 + identity + no token), not-signed-in (200 + no identity keys), no-credential-service (200 signedIn:false), auth-enabled-unauthorized (401), auth-enabled-authorized (200 + identity). Read line-by-line - the assertions genuinely check status codes, the signedIn boolean, identity values, key absence, and token absence.</td>
+<td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Independent live-curl evidence (raw wire)</h2>
+<pre>=== AC1 + AC4 signed-in (auth off) ===
+HTTP/1.1 200 OK
+{"signedIn":true,"email":"qa-verifier@example.com","provider":"github"}
+  (access JWT absent; refresh marker QA-REFRESH-PLAINTEXT-MARKER-638 absent; "token" absent from body)
+
+=== AC2 signed-out (no credential) ===
+HTTP/1.1 200 OK
+{"signedIn":false}
+  (no email key, no provider key)
+
+=== AC3 unauthorized (auth on, no token) ===
+HTTP/1.1 401 Unauthorized
+{"error":"missing or invalid token"}
+
+=== AC3 authorized (auth on, with Bearer token) ===
+HTTP/1.1 200 OK
+{"signedIn":true,"email":"qa-verifier@example.com","provider":"github"}</pre>
+
+<h2>Local-only computation (no cloud/network call)</h2>
+<p>Confirmed in code: <code>DevThrottleAccountService.IsLoggedIn()</code> validates the cached token's
+signature/expiry locally; <code>GetIdentity()</code> decodes claims locally via <code>JwtIdentityReader</code>.
+The only network seam (the refresher) is never invoked on the status path. The endpoint comment and
+<code>GatewayHost</code> wiring both state "no cloud call" and the code bears this out.</p>
+
+<h2>Scope and out-of-scope</h2>
+<ul>
+<li>In scope, present: <code>CcDirector.Gateway/Api/AccountStatusEndpoint.cs</code> (new),
+<code>CcDirector.Gateway/GatewayHost.cs</code> (10-line wiring), <code>CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs</code> (new). Only these two projects (plus proof files) changed.</li>
+<li>Out of scope, correctly NOT done: no Director-side gate change (issue #641); no sign-in/refresh logic.</li>
+</ul>
+
+<h2>Regression and method checks</h2>
+<ul>
+<li>Full <code>CcDirector.Gateway.Tests</code> suite: 921 passed, 1 skipped, 0 failed.</li>
+<li>Pre-existing <code>VaultGatewayIntegrationTests.cs</code> is unchanged from <code>main</code> and passed locally; not regressed by this PR (red on CI main only, per the known unrelated issue).</li>
+<li><code>dotnet build cc-director.sln</code>: Build succeeded, 0 Warning(s), 0 Error(s).</li>
+<li>Honors security rule DT-05 (no token in response); no architecture/security-profile drift.</li>
+</ul>
+
+<h2 class="verdict">VERIFIED - all 5 acceptance criteria met. Issue #638 PASSES QA.</h2>
+</body>
+</html>

--- a/docs/cencon/proof/issue-638/report.html
+++ b/docs/cencon/proof/issue-638/report.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof - Issue #638: GET /account/status on the Gateway</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; max-width: 1000px; }
+  h1 { border-bottom: 2px solid #444; padding-bottom: .3rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0f0f0; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #f6f6f6; border: 1px solid #ddd; padding: .7rem; overflow-x: auto; }
+  .pass { color: #0a6b0a; font-weight: bold; }
+  .note { background: #fff8e1; border: 1px solid #e0d28a; padding: .6rem; }
+</style>
+</head>
+<body>
+<h1>Proof - Issue #638</h1>
+<p><strong>Title:</strong> [Gateway] GET /account/status (is the Gateway signed in, and who as)</p>
+<p><strong>Branch:</strong> issue-638-account-status &nbsp; | &nbsp; <strong>Affected containers:</strong> CcDirector.Gateway, CcDirector.Gateway.Tests</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li>New endpoint <code>GET /account/status</code> on the Gateway
+      (<code>src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs</code>), returning
+      <code>{ "signedIn": bool, "email"?: string, "provider"?: string }</code>.</li>
+  <li>The status is computed <strong>entirely locally</strong> from the Gateway-hosted credential service
+      (issue #636, <code>GatewayHost.Account</code> = the reused <code>DevThrottleAccountService</code>):
+      <code>IsLoggedIn()</code> for the boolean and <code>GetIdentity()</code> (backed by
+      <code>JwtIdentityReader</code>) for the email/provider. There is no cloud or network call.</li>
+  <li>Wired into <code>GatewayHost.StartAsync</code> after the telemetry endpoints, so it inherits the
+      existing host-wide Gateway token middleware (<code>AuthMiddleware</code>) exactly like the other
+      Gateway endpoints.</li>
+  <li>The response carries <strong>no token field</strong> - the response record has only the boolean +
+      identity, so the access/refresh token can never be returned (security rule DT-05). The identity
+      fields are <em>omitted</em> (not emitted as null) when not signed in.</li>
+  <li>Unit tests: <code>src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs</code>
+      (5 tests) cover signed-in, not-signed-in, no-credential-service, auth-enabled unauthorized (401),
+      and auth-enabled authorized (200).</li>
+</ul>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (proven)</th><th>Evidence</th></tr>
+  <tr>
+    <td>1</td>
+    <td>200 with signedIn:true and decoded email/provider when the Gateway holds a valid (seeded) credential</td>
+    <td>200; <code>{"signedIn":true,"email":...,"provider":...}</code></td>
+    <td class="pass">PASS - <code>{"signedIn":true,"email":"gateway-user@example.com","provider":"github"}</code></td>
+    <td><code>ac1-signedin-with-token.txt</code>, <code>ac1b-signedin-no-auth.txt</code></td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>200 with signedIn:false and NO identity fields when the Gateway has no credential</td>
+    <td>200; <code>{"signedIn":false}</code> only</td>
+    <td class="pass">PASS - <code>{"signedIn":false}</code> (no email/provider keys)</td>
+    <td><code>ac2-signedout.txt</code></td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>With Gateway auth enabled, the endpoint requires the token (401 without it), consistent with other endpoints</td>
+    <td>401 without token; 200 with token</td>
+    <td class="pass">PASS - 401 <code>{"error":"missing or invalid token"}</code> without the token; 200 with it</td>
+    <td><code>ac3-unauthorized-no-token.txt</code>, <code>ac1-signedin-with-token.txt</code></td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>The response never includes the access or refresh token (only boolean + identity)</td>
+    <td>No JWT, no refresh token in the body</td>
+    <td class="pass">PASS - refresh marker absent; no JWT-shaped string present</td>
+    <td><code>ac4-no-token-check.txt</code></td>
+  </tr>
+  <tr>
+    <td>5</td>
+    <td>Unit tests cover signed-in, not-signed-in, and the unauthorized path</td>
+    <td>All tests pass</td>
+    <td class="pass">PASS - 5 passed, 0 failed</td>
+    <td><code>unit-test-output.txt</code></td>
+  </tr>
+</table>
+
+<h2>Live curl evidence (against a running GatewayHost)</h2>
+<p>The proof Gateway was a throwaway harness that news up the real <code>GatewayHost</code> (the same
+<code>AccountStatusEndpoint.Map(_app, Account)</code> wiring and the same host-wide
+<code>AuthMiddleware</code>) with a seeded in-memory credential, so every state below is the production
+pipeline - not a stand-in.</p>
+
+<h3>Criterion 1 + 3 + 4 (auth enabled, with token)</h3>
+<pre>$ curl -i -H "Authorization: Bearer &lt;gateway-token&gt;" http://127.0.0.1:7981/account/status
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+{"signedIn":true,"email":"gateway-user@example.com","provider":"github"}</pre>
+
+<h3>Criterion 3 (auth enabled, no token -> 401)</h3>
+<pre>$ curl -i http://127.0.0.1:7981/account/status
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json; charset=utf-8
+
+{"error":"missing or invalid token"}</pre>
+
+<h3>Criterion 2 (no credential -> signedIn:false, no identity fields)</h3>
+<pre>$ curl -i http://127.0.0.1:7982/account/status
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+{"signedIn":false}</pre>
+
+<h3>Criterion 4 (no token in the body)</h3>
+<pre>Body: {"signedIn":true,"email":"gateway-user@example.com","provider":"github"}
+PASS: no refresh token in body
+PASS: no JWT/access-token in body</pre>
+
+<h2>Unit tests</h2>
+<pre>Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5 - CcDirector.Gateway.Tests.dll</pre>
+
+<h2>CenCon impact</h2>
+<p class="note">No architecture drift: one read-only Gateway endpoint over the existing #636 credential
+service. No security-profile change; the change honors DT-05 (tokens never logged or returned). No
+<code>docs/cencon/</code> files needed updating.</p>
+
+<h2>Build</h2>
+<pre>dotnet build cc-director.sln -> Build succeeded. 0 Warning(s) 0 Error(s)</pre>
+
+<p><strong>I believe this is finished.</strong> All five acceptance criteria are met and proven both by
+live curl against a running GatewayHost and by passing unit tests, the full solution builds clean with
+zero warnings, and the change is scoped to CcDirector.Gateway + CcDirector.Gateway.Tests only (the
+Director-side consumption / gate and any sign-in/refresh logic are out of scope, separate issues).</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-638/unit-test-output.txt
+++ b/docs/cencon/proof/issue-638/unit-test-output.txt
@@ -1,0 +1,4 @@
+Test run for D:\ReposFred\devthrottle-wt-638\src\CcDirector.Gateway.Tests\bin\Debug\net10.0\CcDirector.Gateway.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+
+Passed!  - Failed:     0, Passed:     5, Skipped:     0, Total:     5, Duration: 182 ms - CcDirector.Gateway.Tests.dll (net10.0)

--- a/src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Account;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// HTTP wire tests for <c>GET /account/status</c> (issue #638, Gateway Centralization Phase 2). Boots
+/// only <see cref="AccountStatusEndpoint"/> on an ephemeral port over a Gateway credential service built
+/// on an in-memory token store (no Windows Data Protection, no registry, no Tailscale), so the four
+/// states are provable cross-platform. Proves the issue's five acceptance criteria:
+/// <list type="number">
+/// <item>200 with <c>signedIn:true</c> and the decoded <c>email</c>/<c>provider</c> when the Gateway
+/// holds a valid (seeded) credential;</item>
+/// <item>200 with <c>signedIn:false</c> and NO identity fields when the Gateway has no credential;</item>
+/// <item>when Gateway auth is enabled the endpoint requires the Gateway token (401 without it) and
+/// passes (200) with it - using the SAME host-wide <see cref="AuthMiddleware"/> the real host applies;</item>
+/// <item>the response NEVER contains the access or refresh token (only the boolean + identity);</item>
+/// <item>(this whole class) the signed-in, not-signed-in, and unauthorized paths are covered.</item>
+/// </list>
+/// The status read is entirely local (no network call) - the credential service's only network seam is
+/// the refresher, which the status path never invokes.
+/// </summary>
+public sealed class AccountStatusEndpointTests
+{
+    private const string GatewayToken = "test-gateway-token-for-issue-638";
+
+    /// <summary>
+    /// An in-memory <see cref="IProtectedTokenStore"/> so the Gateway credential service can be built and
+    /// seeded without touching the Windows-only Data Protection store. The Gateway.Tests project does not
+    /// reference the Core.Tests in-memory store, so this mirrors it locally (the documented test pattern).
+    /// </summary>
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// Builds a Gateway credential service over an in-memory store, with the signing secret set so a
+    /// <see cref="GatewayTestJwt"/>-issued token validates. The env var is set and restored around
+    /// construction so the test is self-contained. Optionally seeds a stored credential.
+    /// </summary>
+    private static DevThrottleAccountService MakeAccount(DevThrottleTokens? seed)
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar);
+        Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, GatewayTestJwt.SigningSecret);
+        try
+        {
+            var authEventsLog = Path.Combine(Path.GetTempPath(), "cc-gw-acct-status-" + Guid.NewGuid().ToString("N") + ".jsonl");
+            var service = GatewayAccountFactory.Build(new InMemoryTokenStore(), authEventsLog);
+            if (seed is not null)
+                service.StoreTokens(seed);
+            return service;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, previous);
+        }
+    }
+
+    /// <summary>
+    /// Boots a minimal Kestrel host on an ephemeral port mapping ONLY the account-status endpoint over
+    /// <paramref name="account"/>. When <paramref name="authEnabled"/> is true the SAME host-wide
+    /// <see cref="AuthMiddleware"/> the real Gateway uses is applied, so the 401 path is exercised
+    /// against the production gate, not a stand-in.
+    /// </summary>
+    private static async Task<(WebApplication app, HttpClient http)> StartAsync(DevThrottleAccountService? account, bool authEnabled)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        if (authEnabled)
+        {
+            var requireToken = new AuthMiddleware.RequireToken { Token = GatewayToken, Devices = new DeviceRegistry(Path.Combine(Path.GetTempPath(), "cc-gw-acct-status-dev-" + Guid.NewGuid().ToString("N") + ".json")) };
+            app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
+        }
+
+        AccountStatusEndpoint.Map(app, account);
+        await app.StartAsync();
+
+        var baseUrl = app.Urls.First();
+        var http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        return (app, http);
+    }
+
+    // Acceptance criterion 1 + 4: a valid stored credential -> 200, signedIn:true, decoded email/provider,
+    // and the response body carries NO token (neither the access JWT nor the refresh token).
+    [Fact]
+    public async Task SignedIn_Returns200_WithIdentity_AndNoToken()
+    {
+        var jwt = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(1), "gateway-user@example.com", "github");
+        const string refreshToken = "REFRESH-TOKEN-PLAINTEXT-MARKER-638";
+        var account = MakeAccount(new DevThrottleTokens(jwt, refreshToken));
+
+        var (app, http) = await StartAsync(account, authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/account/status");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var body = await resp.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            Assert.True(root.GetProperty("signedIn").GetBoolean());
+            Assert.Equal("gateway-user@example.com", root.GetProperty("email").GetString());
+            Assert.Equal("github", root.GetProperty("provider").GetString());
+
+            // Criterion 4: the response must never include the access or refresh token.
+            Assert.DoesNotContain(jwt, body, StringComparison.Ordinal);
+            Assert.DoesNotContain(refreshToken, body, StringComparison.Ordinal);
+            Assert.DoesNotContain("token", body, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Acceptance criterion 2: no stored credential -> 200, signedIn:false, and NO identity fields present.
+    [Fact]
+    public async Task NotSignedIn_Returns200_SignedInFalse_NoIdentityFields()
+    {
+        var account = MakeAccount(seed: null);
+
+        var (app, http) = await StartAsync(account, authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/account/status");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var body = await resp.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            Assert.False(root.GetProperty("signedIn").GetBoolean());
+            Assert.False(root.TryGetProperty("email", out _), "email must be omitted when not signed in");
+            Assert.False(root.TryGetProperty("provider", out _), "provider must be omitted when not signed in");
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Acceptance criterion 2 (no credential service on this host): the endpoint still answers 200
+    // signedIn:false with no identity fields when the Gateway holds no credential service at all.
+    [Fact]
+    public async Task NoCredentialService_Returns200_SignedInFalse()
+    {
+        var (app, http) = await StartAsync(account: null, authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/account/status");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var body = await resp.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            Assert.False(doc.RootElement.GetProperty("signedIn").GetBoolean());
+            Assert.False(doc.RootElement.TryGetProperty("email", out _));
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Acceptance criterion 3: when Gateway auth is enabled the endpoint requires the Gateway token -
+    // a call with NO Authorization header is answered 401 by the host-wide middleware.
+    [Fact]
+    public async Task AuthEnabled_NoToken_Returns401()
+    {
+        var account = MakeAccount(new DevThrottleTokens(GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1)), "refresh-1"));
+
+        var (app, http) = await StartAsync(account, authEnabled: true);
+        try
+        {
+            var resp = await http.GetAsync("/account/status");
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Acceptance criterion 3 (the authorized path): with the Gateway token present the same auth-enabled
+    // endpoint passes (200) and returns the signed-in status.
+    [Fact]
+    public async Task AuthEnabled_WithToken_Returns200()
+    {
+        var jwt = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(1), "authed@example.com", "google");
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+
+        var (app, http) = await StartAsync(account, authEnabled: true);
+        try
+        {
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GatewayToken);
+            var resp = await http.GetAsync("/account/status");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.True(doc.RootElement.GetProperty("signedIn").GetBoolean());
+            Assert.Equal("authed@example.com", doc.RootElement.GetProperty("email").GetString());
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
@@ -1,0 +1,93 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Gateway Centralization Phase 2 (issue #638): the read-only <c>GET /account/status</c> endpoint that
+/// answers "is the Gateway signed in to DevThrottle, and as whom?". The answer is computed ENTIRELY
+/// LOCALLY from the Gateway-hosted credential service (issue #636, the reused
+/// <see cref="DevThrottleAccountService"/> exposed as <c>GatewayHost.Account</c>) - there is NO cloud or
+/// network call. A Director's future startup gate (a separate issue) reads this to decide whether its
+/// Gateway is signed in.
+///
+/// Wire contract: the response body is
+/// <c>{ "signedIn": bool, "email"?: string, "provider"?: string }</c>. When the Gateway holds a valid
+/// credential, <c>signedIn</c> is true and the <c>email</c>/<c>provider</c> identity fields are present
+/// (the same two values <see cref="JwtIdentityReader"/> extracts, surfaced through
+/// <see cref="DevThrottleAccountService.GetIdentity"/>). When the Gateway holds no credential,
+/// <c>signedIn</c> is false and the identity fields are OMITTED - never present, never fabricated.
+///
+/// Security (carries DT-05 from #636): the response NEVER includes the access or refresh token - only
+/// the boolean and the identity. The tokens are never written to the log on any path either; the log
+/// records only the outcome (signed in / not signed in).
+///
+/// When Gateway auth is enabled, this endpoint inherits the host-wide Gateway token middleware exactly
+/// like the other Gateway endpoints (it is not on the public-paths allow-list), so a call with no token
+/// is answered 401 by that middleware before this delegate runs.
+/// </summary>
+internal static class AccountStatusEndpoint
+{
+    /// <summary>
+    /// Maps <c>GET /account/status</c>. The Gateway token convention (when Gateway auth is enabled) is
+    /// applied by the host-wide auth middleware, exactly like the other Gateway endpoints.
+    /// </summary>
+    /// <param name="app">The route builder.</param>
+    /// <param name="account">
+    /// The Gateway-hosted DevThrottle credential service (issue #636). Null on a host that has no
+    /// credential service (a non-Windows host, where the operating-system credential store is not yet
+    /// implemented); the endpoint then truthfully reports not-signed-in.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account)
+    {
+        app.MapGet("/account/status", () =>
+        {
+            // No credential service on this host (a non-Windows host where the operating-system
+            // credential store is not yet implemented): the Gateway holds no account credential, so the
+            // truthful answer is not-signed-in with no identity.
+            if (account is null)
+            {
+                FileLog.Write("[AccountStatusEndpoint] GET /account/status: no credential service on this host -> signedIn=false");
+                return Results.Json(new AccountStatusResponse(false, null, null));
+            }
+
+            // Both reads are entirely local (no network call): IsLoggedIn validates the cached token's
+            // signature and expiry locally, and GetIdentity decodes the cached token's claims locally.
+            var signedIn = account.IsLoggedIn();
+            if (!signedIn)
+            {
+                FileLog.Write("[AccountStatusEndpoint] GET /account/status: signedIn=false (no valid credential)");
+                return Results.Json(new AccountStatusResponse(false, null, null));
+            }
+
+            var identity = account.GetIdentity();
+            // The identity is only logged as resolved / unavailable - the email itself is user identity,
+            // not a token, but we keep the log minimal and never log any credential material.
+            FileLog.Write($"[AccountStatusEndpoint] GET /account/status: signedIn=true (identity {(identity is null ? "unavailable" : "resolved")})");
+            return Results.Json(new AccountStatusResponse(true, identity?.Email, identity?.Provider));
+        });
+    }
+
+    /// <summary>
+    /// The <c>GET /account/status</c> response. <see cref="SignedIn"/> is always present;
+    /// <see cref="Email"/> and <see cref="Provider"/> are present only when signed in with a resolvable
+    /// identity, and are OMITTED from the JSON (not emitted as null) otherwise - so the not-signed-in
+    /// response carries no identity fields. This type intentionally carries NO token field, so the
+    /// response can never include the access or refresh token (security rule DT-05).
+    /// </summary>
+    /// <param name="SignedIn">Whether the Gateway holds a valid DevThrottle credential.</param>
+    /// <param name="Email">The signed-in user's email, or null (omitted) when not signed in / unavailable.</param>
+    /// <param name="Provider">The authentication provider, or null (omitted) when not signed in / unavailable.</param>
+    private sealed record AccountStatusResponse(
+        [property: System.Text.Json.Serialization.JsonPropertyName("signedIn")]
+        bool SignedIn,
+        [property: System.Text.Json.Serialization.JsonPropertyName("email")]
+        [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        string? Email,
+        [property: System.Text.Json.Serialization.JsonPropertyName("provider")]
+        [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        string? Provider);
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -686,6 +686,16 @@ public sealed class GatewayHost : IAsyncDisposable
         // (issues #628 / #629), adding no new forwarder. Inherits the host-wide token middleware above.
         DirectorStartupTelemetryEndpoint.Map(_app, _telemetryQueue);
 
+        // Gateway Centralization Phase 2 (issue #638): GET /account/status answers "is the Gateway
+        // signed in to DevThrottle, and as whom?" computed ENTIRELY LOCALLY from the Gateway-hosted
+        // credential service (issue #636, the reused DevThrottleAccountService exposed as Account) -
+        // no cloud call. A Director's future startup gate (a separate issue) reads this. The response
+        // carries only the boolean + identity, never the access/refresh token (security rule DT-05).
+        // Inherits the host-wide token middleware above (the existing gateway.token convention). On a
+        // host with no credential service (a non-Windows host, Account null) it truthfully reports
+        // not-signed-in.
+        AccountStatusEndpoint.Map(_app, Account);
+
         // Transcription routing (issue #506): the Gateway serves the WHOLE routing target
         // (mode + base URL + model + key) for its configured transcription mode, so a connected
         // Director stops hardcoding the URL/mode. Composes URL+key server-side from the one pure


### PR DESCRIPTION
Closes #638.

## Release Notes
The Gateway now answers `GET /account/status`, reporting whether it is signed in to DevThrottle and, if so, the signed-in email and provider. The answer is computed entirely locally from the Gateway-hosted credential service (issue #636) - there is no cloud or network call. This is the endpoint a Director's future startup gate (a separate issue) will read.

## Changes
- New `src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs`: `GET /account/status` returning `{ "signedIn": bool, "email"?: string, "provider"?: string }`. `signedIn` from `DevThrottleAccountService.IsLoggedIn()`; `email`/`provider` from `GetIdentity()` (backed by `JwtIdentityReader`). Identity fields are omitted (not null) when not signed in. The response record carries no token field, so the access/refresh token can never be returned (security rule DT-05); tokens are never logged.
- `src/CcDirector.Gateway/GatewayHost.cs`: wired the endpoint into `StartAsync` after the telemetry endpoints, so it inherits the existing host-wide Gateway token middleware exactly like the other endpoints.
- `src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs`: 5 HTTP wire tests covering signed-in, not-signed-in, no-credential-service, auth-enabled unauthorized (401), and auth-enabled authorized (200).

## How to Test
Run a Gateway with a seeded credential and `curl http://127.0.0.1:<port>/account/status`. Or run the unit tests:
`dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter "FullyQualifiedName~AccountStatusEndpointTests"`

## Expected Result
- Valid credential -> `200` `{"signedIn":true,"email":...,"provider":...}`
- No credential -> `200` `{"signedIn":false}` (no identity fields)
- Auth enabled, no token -> `401`; with token -> `200`
- The response never contains the access or refresh token.

## Before / After
Before: no way for a Director to ask the Gateway whether it is signed in. After: `GET /account/status` answers it locally.

Proof: `docs/cencon/proof/issue-638/report.html` (live curl against a running GatewayHost in every state, plus passing unit tests).

## CenCon impact
No architecture drift (one read-only Gateway endpoint over the existing #636 credential service). No security-profile change; honors DT-05.

Scope: `CcDirector.Gateway` + `CcDirector.Gateway.Tests` only. The Director-side consumption / gate change and any sign-in/refresh logic are out of scope (separate issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)