### PR TITLE
[Gateway] Forward telemetry with the Gateway's own account token (#639)

### DIFF
--- a/docs/cencon/proof/issue-639/issue639-tests.txt
+++ b/docs/cencon/proof/issue-639/issue639-tests.txt
@@ -1,0 +1,8 @@
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.Forward_WhenSignedIn_AttachesTheGatewayToken [44 ms]
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.InboundDirectorBearer_IsIgnored_GatewayTokenUsedInstead [3 ms]
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.NotSignedIn_QueuesEventsThenFlushesAfterSignIn_InOrder [10 ms]
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.Forward_NeverWritesTheGatewayTokenToTheLog [25 s]
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.PostLogin_WithoutAuthorizationHeader_ForwardsWithGatewayToken [196 ms]
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.PostLogin_WhenGatewayNotSignedIn_QueuesThenFlushesAfterSignIn [693 ms]
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.NoTokenSource_FallsBackToTheStoredPerEventBearer [2 ms]
+  Passed CcDirector.Gateway.Tests.Issue639GatewayTelemetryTokenTests.PostLogin_WithInboundDirectorBearer_ForwardsGatewayTokenAndNotTheDirectorToken [134 ms]

--- a/docs/cencon/proof/issue-639/log-excerpt-token-absent.txt
+++ b/docs/cencon/proof/issue-639/log-excerpt-token-absent.txt
@@ -1,0 +1,17 @@
+=== Issue #639 log evidence ===
+The forward path logs only target URL, queue depth, bearer-PRESENCE (true/false), and outcome.
+It NEVER logs a token value. Source: the cc-director director FileLog sink the unit tests assert against.
+
+--- Representative forward-path lines (issue #639 test run) ---
+2026-06-22 11:49:43.701 [TelemetryRetryQueue] forward DEFERRED (gateway not signed in): http://127.0.0.1:51364/api/v1/telemetry/login, id=f97a303294634348ae690b0f41aaaee0 (kept queued, will flush after sign-in)
+2026-06-22 11:49:43.810 [TelemetryRetryQueue] forward DEFERRED (gateway not signed in): http://127.0.0.1:51364/api/v1/telemetry/login, id=f97a303294634348ae690b0f41aaaee0 (kept queued, will flush after sign-in)
+2026-06-22 11:49:43.944 [TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for http://127.0.0.1:51368/api/v1/telemetry/login (inboundAuthPresent=True; ignored, gateway token attached on forward)
+2026-06-22 11:49:44.202 [TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for http://127.0.0.1:51372/api/v1/telemetry/login (inboundAuthPresent=True; ignored, gateway token attached on forward)
+2026-06-22 11:49:45.234 [TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for http://127.0.0.1:51376/api/v1/telemetry/login (inboundAuthPresent=True; ignored, gateway token attached on forward)
+2026-06-22 11:49:45.243 [TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for http://127.0.0.1:51379/api/v1/telemetry/login (inboundAuthPresent=True; ignored, gateway token attached on forward)
+2026-06-22 11:50:03.699 [TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for http://127.0.0.1:51340/api/v1/telemetry/login (inboundAuthPresent=True; ignored, gateway token attached on forward)
+2026-06-22 11:50:18.990 [TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for http://127.0.0.1:61958/api/v1/telemetry/login (inboundAuthPresent=True; ignored, gateway token attached on forward)
+
+--- Token-value scan ---
+Occurrences of the test Gateway token or Director token in ANY director log line: 0
+RESULT: OK - neither token value appears in any director log line (AC4 satisfied).

--- a/docs/cencon/proof/issue-639/qa-report.html
+++ b/docs/cencon/proof/issue-639/qa-report.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #639 (Gateway forwards telemetry with its own account token)</title>
+<style>
+ body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; line-height: 1.5; }
+ h1 { border-bottom: 3px solid #2c5aa0; padding-bottom: .4rem; }
+ h2 { margin-top: 2rem; color: #2c5aa0; }
+ table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+ th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+ th { background: #f0f4fa; }
+ .pass { color: #157347; font-weight: bold; }
+ .verdict { background: #e6f4ea; border: 2px solid #157347; padding: 1rem; margin: 1.5rem 0; font-size: 1.1rem; }
+ code { background: #f4f4f4; padding: .1rem .3rem; border-radius: 3px; font-family: Consolas, monospace; }
+ pre { background: #f4f4f4; padding: .8rem; border-radius: 5px; overflow-x: auto; }
+ .meta { color: #555; font-size: .9rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #639</h1>
+<p class="meta">
+ Title: [Gateway] Forward telemetry with the Gateway's own account token<br>
+ PR: #673 (branch <code>issue-639-gateway-telemetry-token</code>)<br>
+ Verified independently by the QA Agent in an isolated worktree (<code>dt-639</code>) on the PR branch.<br>
+ Method: own build, own xUnit verification harness with QA-distinctive tokens (NOT the developer's
+ fixtures), exercising both telemetry endpoints over real HTTP plus direct inspection of the real
+ Gateway log.
+</p>
+
+<div class="verdict">VERIFIED - all 5 acceptance criteria met. PASS.</div>
+
+<h2>Independent verification harness</h2>
+<p>
+ The QA Agent wrote and ran its OWN xUnit test class (<code>QaIndependent639Tests</code>) using
+ distinctive tokens <code>QA-GATEWAY-TOKEN-ZZZ-639-DISTINCT-DO-NOT-LOG</code> and
+ <code>QA-DIRECTOR-LEFTOVER-BEARER-ZZZ-639-MUST-NOT-LEAK</code> so the evidence cannot be confused
+ with the developer's constants. It boots the real <code>TelemetryRelayEndpoint</code> and the real
+ <code>DirectorStartupTelemetryEndpoint</code> over the real <code>TelemetryRetryQueue</code> wired
+ with a Gateway token source, plus a local stub cloud backend it controls, and posts over real HTTP.
+ (The harness was a QA evidence fixture and was removed after the run to keep the tree clean; the
+ result is recorded below.)
+</p>
+<pre>Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5  (QaIndependent639Tests)</pre>
+
+<h2>Acceptance criteria</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-observed)</th><th>Result</th></tr>
+
+<tr>
+<td>1</td>
+<td>Tokenless inbound POST is forwarded carrying the Gateway's account token.</td>
+<td>Stub receives <code>Bearer &lt;Gateway token&gt;</code>, not a Director token.</td>
+<td>QA stub recorded <code>Bearer QA-GATEWAY-TOKEN-ZZZ-639...</code> for a tokenless
+ <code>POST /telemetry/login</code>. (QaIndependent: Login_TokenlessAndDirectorBearer...)</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>When the Gateway is NOT signed in, a posted event is queued (not forwarded), then flushed in
+ order after sign-in.</td>
+<td>Nothing reaches the stub while signed out; after seeding the token all events arrive in FIFO
+ order with the Gateway token.</td>
+<td>3 events posted while signed out: stub stayed EMPTY after a 700ms wait (queue depth held). After
+ setting SignedIn, all 3 arrived in order [0,1,2], each with <code>Bearer QA-GATEWAY-TOKEN...</code>.
+ (QaIndependent: Login_NotSignedIn_QueuesThenFlushesInOrderAfterSignIn)</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>An inbound Director Bearer is ignored in favour of the Gateway's token; no Director token leaks.</td>
+<td>Stub receives the Gateway token; the distinctive Director token never appears.</td>
+<td>Posted <code>POST /telemetry/login</code> with <code>Bearer QA-DIRECTOR-LEFTOVER-BEARER-ZZZ...</code>;
+ stub recorded the Gateway token and the Director token appeared nowhere. Same proven on the
+ director-startup endpoint. (QaIndependent: Login_... and DirectorStartup_...)</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>The Gateway's token is never written to the log.</td>
+<td>After a real forward (through both the deferred not-signed-in pass and the signed-in pass), the
+ token value appears in no new log line.</td>
+<td>Read the real Gateway log (<code>director-*.log</code>) before/after a real
+ forward of the QA token. Neither <code>QA-GATEWAY-TOKEN...</code> nor
+ <code>QA-DIRECTOR-...</code> appeared in any new line.
+ (QaIndependent: GatewayToken_NeverAppearsInTheRealLog)</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>Unit tests cover forward-with-gateway-token, queue-when-not-signed-in + flush-after-sign-in, and
+ inbound-bearer-ignored.</td>
+<td>Tests exist and genuinely assert these behaviours.</td>
+<td>Read and ran the developer's <code>Issue639GatewayTelemetryTokenTests</code> (8 tests, all pass):
+ explicit assertions <code>ReceivedAuth[0] == "Bearer GATEWAY..."</code>, FIFO sequence assertions
+ after sign-in, and <code>DoesNotContain(... DirectorToken)</code>. The pre-existing
+ <code>TelemetryRelayEndpointTests</code> was updated to assert the inbound bearer is now ignored
+ (<code>Assert.Null(fwd.Authorization)</code>). Plus the 5 independent QA tests above.</td>
+<td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Both endpoints (login relay AND director-startup)</h2>
+<p>
+ QA proved the gateway-token behaviour applies to BOTH <code>/telemetry/login</code> AND
+ <code>/telemetry/director-startup</code> end to end (own tests
+ <code>DirectorStartup_TokenlessAndDirectorBearer_ForwardGatewayToken</code> and
+ <code>DirectorStartup_NotSignedIn_QueuesThenFlushesAfterSignIn</code>). The shared
+ <code>TelemetryRetryQueue.TryForwardAsync</code> attaches the Gateway token for every queued event
+ regardless of which endpoint enqueued it.
+</p>
+
+<h2>Scope check</h2>
+<ul>
+<li>Production code changed: <code>CcDirector.Gateway</code> (relay, startup endpoint, retry queue,
+ new token-source abstraction + adapter, host wiring) and one small ADDITIVE accessor
+ <code>GetAccessTokenForForwarding()</code> in <code>CcDirector.Core</code> (the Gateway-hosted
+ credential service lives in Core). No existing Core method changed (diff is additive-only).</li>
+<li>OUT-of-scope items confirmed NOT done: no Director-side Bearer removal (#642 - inbound bearer is
+ made optional/ignored, the Director still sends it); no sign-in / refresh logic.</li>
+</ul>
+
+<h2>Regression and build</h2>
+<ul>
+<li><code>dotnet build cc-director.sln</code>: <strong>Build succeeded. 0 Warning(s), 0 Error(s).</strong></li>
+<li>Developer's issue-639 tests: <strong>8/8 pass.</strong></li>
+<li>Full <code>CcDirector.Gateway.Tests</code> suite: <strong>929 pass, 1 skip, 0 fail</strong> on a clean
+ re-run.</li>
+<li><code>CcDirector.Core.Tests</code> (Account filter): <strong>90/90 pass.</strong></li>
+<li>Note on flaky log-timing tests: one full-suite pass showed 3 transient failures
+ (<code>Forward_NeverWritesTheGatewayTokenToTheLog</code>,
+ <code>PostLogin_NeverWritesAccessTokenToTheGatewayLog</code>,
+ <code>PostDirectorStartup_NoCloudUrl_RecordsLocallyAndDoesNotForward</code>). All three pass in
+ isolation and on a re-run. The failing assertion was the "logging is wired" precondition
+ (<code>Assert.Contains(newLines, ... [marker])</code>), NOT the security assertion - the
+ token-never-logged check never failed. The cause is the process-wide async FileLog writer racing
+ the per-test baseline window under parallel load, a pre-existing test-infrastructure
+ characteristic that exists on <code>main</code> for the two pre-existing tests. Not a #639 defect.</li>
+</ul>
+
+<p class="meta">Independent QA verification complete. All acceptance criteria met with QA-produced proof.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-639/report.html
+++ b/docs/cencon/proof/issue-639/report.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Issue #639 - Gateway forwards telemetry with its own account token - Proof</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1e1e1e; line-height: 1.5; }
+  h1 { border-bottom: 2px solid #007ACC; padding-bottom: .3rem; }
+  h2 { margin-top: 2rem; color: #007ACC; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0f6fb; }
+  code, pre { font-family: Consolas, monospace; background: #f5f5f5; }
+  pre { padding: .8rem; overflow-x: auto; border: 1px solid #ddd; }
+  .pass { color: #1a7f37; font-weight: bold; }
+  .crit { font-weight: bold; }
+  .note { background: #fffbe6; border: 1px solid #e6d780; padding: .6rem .9rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #639 - Gateway forwards telemetry with its own account token</h1>
+
+<p><strong>Branch:</strong> issue-639-gateway-telemetry-token &nbsp;|&nbsp;
+   <strong>Containers touched:</strong> CcDirector.Gateway, CcDirector.Gateway.Tests
+   (plus a small read-only accessor on CcDirector.Core.Account.DevThrottleAccountService).</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li><strong>The Gateway is now the single egress and attaches its OWN account token.</strong>
+      A new <code>IGatewayTelemetryTokenSource</code> supplies the Gateway's stored account token, read
+      from the Gateway credential service (<code>DevThrottleAccountService</code>, issue #636) via the new
+      <code>GatewayAccountTelemetryTokenSource</code> adapter. The credential service gained one read-only
+      accessor, <code>GetAccessTokenForForwarding()</code>, which returns the stored access token when the
+      Gateway is signed in (same local valid-or-renewable check as <code>IsLoggedIn</code>) and null
+      otherwise. The token value is never logged.</li>
+  <li><strong>The token is resolved at forward time, inside <code>TelemetryRetryQueue.TryForwardAsync</code>.</strong>
+      When a token source is wired: signed in -&gt; attach the Gateway token (any leftover per-event stored
+      Bearer is ignored); not signed in -&gt; the forward is DEFERRED (the event stays at the head of the
+      queue, FIFO preserved) and flushes once the Gateway signs in. When no token source is wired (a host
+      with no credential service) the queue keeps its Phase 1 behaviour (forward the stored per-event
+      Bearer), so nothing on non-Windows hosts regresses.</li>
+  <li><strong>The login relay (<code>POST /telemetry/login</code>) no longer requires or forwards an inbound
+      Authorization header.</strong> An inbound Director Bearer, if still present, is ignored (logged only as
+      present/absent, never its value) and the event is enqueued with no stored bearer.</li>
+  <li><strong>The director-startup forward (<code>POST /telemetry/director-startup</code>) shares the same
+      queue</strong>, so it too now attaches the Gateway token at forward time and defers while not signed in.</li>
+  <li><strong>GatewayHost wiring:</strong> the credential service (<code>Account</code>) is resolved before the
+      telemetry queue is built, and when present the queue is constructed with a
+      <code>GatewayAccountTelemetryTokenSource</code>.</li>
+</ul>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Proving test(s)</th><th>Expected</th><th>Actual</th></tr>
+  <tr>
+    <td class="crit">1</td>
+    <td>An event posted WITHOUT an Authorization header is forwarded to the cloud (stub) carrying the
+        GATEWAY's token, not a Director token.</td>
+    <td><code>PostLogin_WithoutAuthorizationHeader_ForwardsWithGatewayToken</code> (end-to-end through the
+        real relay + local stub backend); <code>Forward_WhenSignedIn_AttachesTheGatewayToken</code>
+        (queue level).</td>
+    <td>Stub records <code>Authorization: Bearer GATEWAY-OWN-ACCOUNT-TOKEN-639...</code>.</td>
+    <td class="pass">PASS - stub received the Gateway token; 202 to the caller.</td>
+  </tr>
+  <tr>
+    <td class="crit">2</td>
+    <td>When the Gateway is NOT signed in, a posted event is QUEUED (not forwarded) and is flushed to the
+        stub after the Gateway signs in (seeded token), in order.</td>
+    <td><code>PostLogin_WhenGatewayNotSignedIn_QueuesThenFlushesAfterSignIn</code> (end-to-end);
+        <code>NotSignedIn_QueuesEventsThenFlushesAfterSignIn_InOrder</code> (queue level, FIFO over 4 events).</td>
+    <td>Nothing reaches the stub while signed out; after sign-in the queued event(s) flush in enqueue order
+        carrying the Gateway token.</td>
+    <td class="pass">PASS - stub stayed empty while signed out; flushed in FIFO order after sign-in.</td>
+  </tr>
+  <tr>
+    <td class="crit">3</td>
+    <td>An inbound Director Bearer, if still present, is IGNORED in favour of the Gateway's token (no
+        double-auth, no Director-token leakage to the cloud).</td>
+    <td><code>PostLogin_WithInboundDirectorBearer_ForwardsGatewayTokenAndNotTheDirectorToken</code>
+        (end-to-end); <code>InboundDirectorBearer_IsIgnored_GatewayTokenUsedInstead</code> (queue level);
+        plus the updated <code>TelemetryRelayEndpointTests.PostLogin_ForwardsExactlyOnce_IgnoringInboundBearer_WithSourceApp</code>.</td>
+    <td>Stub sees only the Gateway token; the Director token never appears in any forwarded Authorization.</td>
+    <td class="pass">PASS - Gateway token forwarded; Director token absent from the forward.</td>
+  </tr>
+  <tr>
+    <td class="crit">4</td>
+    <td>The Gateway's token is NEVER written to the log.</td>
+    <td><code>Forward_NeverWritesTheGatewayTokenToTheLog</code> (asserts neither the Gateway token nor the
+        ignored Director token appears in any new log line, while confirming the forward path logged).</td>
+    <td>No log line contains the Gateway token (nor the Director token); the path still logs (target + depth
+        + outcome).</td>
+    <td class="pass">PASS - tokens absent from the log; log lines present.</td>
+  </tr>
+  <tr>
+    <td class="crit">5</td>
+    <td>Unit tests cover forward-with-gateway-token, queue-when-not-signed-in + flush-after-sign-in, and
+        inbound-bearer-ignored.</td>
+    <td>The whole <code>Issue639GatewayTelemetryTokenTests</code> suite (8 tests) plus the updated existing
+        relay test.</td>
+    <td>All three behaviours covered at both the queue level and end-to-end through the HTTP relay.</td>
+    <td class="pass">PASS - 8/8 new tests green.</td>
+  </tr>
+</table>
+
+<h2>Test run (the local stub backend is the "cloud stub" the issue references)</h2>
+<p>The end-to-end tests boot the real <code>TelemetryRelayEndpoint</code> over a durable
+   <code>TelemetryRetryQueue</code> wired with the Gateway token source, plus a local stub backend that
+   records the exact body and Authorization header of every forwarded request. The queue-level tests drive
+   delivery deterministically through <code>FlushOnceAsync</code> with a fake token source.</p>
+<pre>
+Passed Issue639GatewayTelemetryTokenTests.Forward_WhenSignedIn_AttachesTheGatewayToken [44 ms]
+Passed Issue639GatewayTelemetryTokenTests.InboundDirectorBearer_IsIgnored_GatewayTokenUsedInstead [3 ms]
+Passed Issue639GatewayTelemetryTokenTests.NotSignedIn_QueuesEventsThenFlushesAfterSignIn_InOrder [10 ms]
+Passed Issue639GatewayTelemetryTokenTests.Forward_NeverWritesTheGatewayTokenToTheLog [25 s]
+Passed Issue639GatewayTelemetryTokenTests.PostLogin_WithoutAuthorizationHeader_ForwardsWithGatewayToken [196 ms]
+Passed Issue639GatewayTelemetryTokenTests.PostLogin_WhenGatewayNotSignedIn_QueuesThenFlushesAfterSignIn [693 ms]
+Passed Issue639GatewayTelemetryTokenTests.NoTokenSource_FallsBackToTheStoredPerEventBearer [2 ms]
+Passed Issue639GatewayTelemetryTokenTests.PostLogin_WithInboundDirectorBearer_ForwardsGatewayTokenAndNotTheDirectorToken [134 ms]
+
+Telemetry + account regression set (Issue639 + TelemetryRelayEndpoint + TelemetryRetryQueue
+  + DirectorStartupTelemetryEndpoint + GatewayAccountService):
+Passed!  - Failed: 0, Passed: 38, Skipped: 0, Total: 38
+
+GatewayHostTests:  Passed! - Failed: 0, Passed: 13
+Core account tests: Passed! - Failed: 0, Passed: 90
+
+Full solution build: Build succeeded. 0 Warning(s). 0 Error(s).
+</pre>
+
+<p class="note"><strong>Why no running Director screenshot:</strong> these acceptance criteria are HTTP/telemetry
+   forwarding behaviours with no user-visible surface. The proof is the local cloud stub recording exactly
+   what the Gateway forwarded (the Authorization header it received) and the queue's signed-out/signed-in
+   delivery order - which the end-to-end relay tests and queue tests demonstrate deterministically. The AC4
+   test reads the real FileLog output and asserts the token is absent.</p>
+
+<h2>CenCon impact</h2>
+<p>No architecture drift: the containers (Gateway, Gateway.Tests) and the cloud wire contract
+   (Bearer + <code>source:"app"</code>) are unchanged - only <em>whose</em> token is attached changes. The
+   security posture is preserved and reinforced: the Gateway token is never logged (rule DT-05), and a
+   Director token is no longer forwarded to the cloud, removing a credential-leakage path.</p>
+
+<h2>Conclusion</h2>
+<p class="pass">I believe this is finished. All five acceptance criteria are met and proven, the full
+   solution builds clean with zero warnings, and the existing telemetry tests were updated to the new
+   contract (the inbound Director Bearer is ignored).</p>
+
+</body>
+</html>

--- a/src/CcDirector.Core/Account/DevThrottleAccountService.cs
+++ b/src/CcDirector.Core/Account/DevThrottleAccountService.cs
@@ -173,6 +173,35 @@ public sealed class DevThrottleAccountService
     }
 
     /// <summary>
+    /// Returns the stored access token to attach when this install acts as the single egress to the
+    /// cloud (the Gateway forwarding telemetry on the Director's behalf, issue #639), or null when the
+    /// install is not signed in. "Signed in" here is the same local check <see cref="IsLoggedIn"/>
+    /// applies - a stored token whose signature verifies and is valid-or-renewable - so a tampered or
+    /// absent credential yields null and the caller must NOT forward. The returned token value is for
+    /// attaching to an outbound request ONLY and is NEVER written to the log; this method logs only
+    /// whether a token was available, never the token itself (security rule DT-05).
+    /// </summary>
+    public string? GetAccessTokenForForwarding()
+    {
+        DevThrottleTokens? tokens;
+        lock (_gate)
+        {
+            tokens = _store.Load();
+        }
+
+        if (tokens is null)
+        {
+            FileLog.Write("[DevThrottleAccountService] GetAccessTokenForForwarding: no stored credential -> no token (caller must not forward)");
+            return null;
+        }
+
+        var validation = _validator.Validate(tokens.AccessToken);
+        var available = validation.IsValid || validation.IsExpiredButWellFormed;
+        FileLog.Write($"[DevThrottleAccountService] GetAccessTokenForForwarding: tokenAvailable={available} (no network call)");
+        return available ? tokens.AccessToken : null;
+    }
+
+    /// <summary>
     /// Clears the stored credential and records a "logout" event. After this the next
     /// <see cref="IsLoggedIn"/> returns false.
     /// </summary>

--- a/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
@@ -1,0 +1,444 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Centralization Phase 2 (issue #639): the Gateway forwards telemetry with its OWN account
+/// token instead of the Director's. These tests cover the issue's five acceptance criteria:
+/// <list type="number">
+///   <item>A telemetry event posted WITHOUT an Authorization header is forwarded carrying the GATEWAY's
+///     token (stub sees the Gateway token, not a Director token).</item>
+///   <item>When the Gateway is NOT signed in, a posted event is QUEUED (not forwarded) and is then
+///     flushed to the stub after the Gateway signs in (seeded token), in order.</item>
+///   <item>An inbound Director Bearer, if still present, is IGNORED in favour of the Gateway's token
+///     (no double-auth, no Director-token leakage to the cloud).</item>
+///   <item>The Gateway's token is NEVER written to the Gateway log.</item>
+///   <item>(this whole file is the unit coverage required by criterion 5.)</item>
+/// </list>
+///
+/// The queue-level cases drive delivery deterministically through a fake
+/// <see cref="IGatewayTelemetryTokenSource"/> + the public <see cref="TelemetryRetryQueue.FlushOnceAsync"/>
+/// (no timers, no network). The end-to-end cases boot the real <see cref="TelemetryRelayEndpoint"/> over a
+/// queue wired with the same fake token source, plus a local stub backend, so the tokenless-inbound ->
+/// gateway-token-out path is exercised across the actual HTTP relay.
+/// </summary>
+public sealed class Issue639GatewayTelemetryTokenTests
+{
+    private const string TargetUrl = "http://backend.test/api/v1/telemetry/login";
+    private const string GatewayToken = "GATEWAY-OWN-ACCOUNT-TOKEN-639-DO-NOT-LOG";
+    private const string DirectorToken = "DIRECTOR-LEFTOVER-BEARER-639-SHOULD-NOT-LEAK";
+
+    /// <summary>
+    /// A fake Gateway token source whose signed-in state and token the test flips. Returns the configured
+    /// token while <see cref="SignedIn"/> is true; returns false (not signed in) otherwise.
+    /// </summary>
+    private sealed class FakeGatewayTokenSource : IGatewayTelemetryTokenSource
+    {
+        public volatile bool SignedIn;
+        public string Token = GatewayToken;
+
+        public bool TryGetAccessToken(out string? accessToken)
+        {
+            if (!SignedIn)
+            {
+                accessToken = null;
+                return false;
+            }
+            accessToken = Token;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// A fake backend that records, in order, the body and Authorization header of every request it
+    /// receives. Reachable is true by default (these tests gate delivery on sign-in, not reachability).
+    /// </summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public readonly List<string> ReceivedBodies = new();
+        public readonly List<string?> ReceivedAuth = new();
+        private readonly object _lock = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(cancellationToken);
+            lock (_lock)
+            {
+                ReceivedBodies.Add(body);
+                ReceivedAuth.Add(request.Headers.Authorization?.ToString());
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private static (TelemetryRetryQueue queue, RecordingHandler handler, FakeGatewayTokenSource source, string path) NewQueue()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"telemetry-queue-639-{Guid.NewGuid():N}.json");
+        var handler = new RecordingHandler();
+        var source = new FakeGatewayTokenSource();
+        var queue = new TelemetryRetryQueue(
+            path,
+            new HttpClient(handler),
+            TimeSpan.FromMilliseconds(50),
+            maxSize: 1000,
+            gatewayTokenSource: source);
+        return (queue, handler, source, path);
+    }
+
+    private static string BodyFor(int i) => JsonSerializer.Serialize(new { source = "app", seq = i });
+
+    private static void Cleanup(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* temp cleanup */ }
+    }
+
+    // ----- AC1: forward carries the GATEWAY's token -----
+
+    [Fact]
+    public async Task Forward_WhenSignedIn_AttachesTheGatewayToken()
+    {
+        var (queue, handler, source, path) = NewQueue();
+        try
+        {
+            source.SignedIn = true;
+            // Enqueued with NO per-event bearer (the relay path): the Gateway token must still be attached.
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: null);
+
+            var delivered = await queue.FlushOnceAsync();
+
+            Assert.Equal(1, delivered);
+            Assert.Equal(0, queue.Depth);
+            Assert.Single(handler.ReceivedAuth);
+            Assert.Equal($"Bearer {GatewayToken}", handler.ReceivedAuth[0]);
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+
+    // ----- AC2: not signed in -> queued; then flushed after sign-in, in order -----
+
+    [Fact]
+    public async Task NotSignedIn_QueuesEventsThenFlushesAfterSignIn_InOrder()
+    {
+        var (queue, handler, source, path) = NewQueue();
+        try
+        {
+            source.SignedIn = false; // Gateway not signed in yet
+            for (var i = 0; i < 4; i++)
+                queue.Enqueue(TargetUrl, BodyFor(i), bearer: null);
+
+            // Not forwarded while not signed in - the events stay queued.
+            Assert.Equal(4, queue.Depth);
+            var deliveredWhileSignedOut = await queue.FlushOnceAsync();
+            Assert.Equal(0, deliveredWhileSignedOut);
+            Assert.Equal(4, queue.Depth);
+            Assert.Empty(handler.ReceivedBodies);
+
+            // The Gateway signs in (seeded token); the next flush drains everything in FIFO order.
+            source.SignedIn = true;
+            var delivered = await queue.FlushOnceAsync();
+
+            Assert.Equal(4, delivered);
+            Assert.Equal(0, queue.Depth);
+            Assert.Equal(4, handler.ReceivedBodies.Count);
+            for (var i = 0; i < 4; i++)
+            {
+                using var doc = JsonDocument.Parse(handler.ReceivedBodies[i]);
+                Assert.Equal(i, doc.RootElement.GetProperty("seq").GetInt32());
+            }
+            // Every forward carried the Gateway token.
+            Assert.All(handler.ReceivedAuth, a => Assert.Equal($"Bearer {GatewayToken}", a));
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+
+    // ----- AC3: an inbound Director Bearer (stored per-event) is IGNORED in favour of the Gateway token -----
+
+    [Fact]
+    public async Task InboundDirectorBearer_IsIgnored_GatewayTokenUsedInstead()
+    {
+        var (queue, handler, source, path) = NewQueue();
+        try
+        {
+            source.SignedIn = true;
+            // Simulate a leftover Director Bearer that somehow reached the queue: it must NOT be forwarded.
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken);
+
+            var delivered = await queue.FlushOnceAsync();
+
+            Assert.Equal(1, delivered);
+            Assert.Single(handler.ReceivedAuth);
+            // The Gateway's token was attached, not the Director's - and the Director token never went out.
+            Assert.Equal($"Bearer {GatewayToken}", handler.ReceivedAuth[0]);
+            Assert.DoesNotContain(handler.ReceivedAuth, a => a is not null && a.Contains(DirectorToken));
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+
+    // ----- AC4: the Gateway token is never written to the Gateway log on the forward path -----
+
+    [Fact]
+    public async Task Forward_NeverWritesTheGatewayTokenToTheLog()
+    {
+        var logDir = CcStorage.ToolLogs("director");
+        var baseline = new Dictionary<string, int>();
+        if (Directory.Exists(logDir))
+            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
+                baseline[f] = ReadAllLinesShared(f).Count;
+
+        FileLog.Start();
+        var (queue, handler, source, path) = NewQueue();
+        try
+        {
+            source.SignedIn = false;
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken);
+            // A deferred (not-signed-in) pass logs, then a signed-in pass forwards and logs - both paths
+            // touch the token-bearing code; neither may write a token value.
+            Assert.Equal(0, await queue.FlushOnceAsync());
+            source.SignedIn = true;
+            Assert.Equal(1, await queue.FlushOnceAsync());
+            Assert.Single(handler.ReceivedBodies);
+        }
+        finally
+        {
+            await queue.DisposeAsync();
+            Cleanup(path);
+            await Task.Delay(500); // let the background writer flush our lines
+        }
+
+        var newLines = new List<string>();
+        if (Directory.Exists(logDir))
+            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
+            {
+                var lines = ReadAllLinesShared(f);
+                var start = baseline.TryGetValue(f, out var n) ? n : 0;
+                for (var i = start; i < lines.Count; i++)
+                    newLines.Add(lines[i]);
+            }
+
+        // The queue logged on this path (proves logging is wired)...
+        Assert.Contains(newLines, l => l.Contains("[TelemetryRetryQueue]"));
+        // ...and NEITHER the Gateway token NOR the (ignored) Director token appears anywhere in the log.
+        Assert.DoesNotContain(newLines, l => l.Contains(GatewayToken));
+        Assert.DoesNotContain(newLines, l => l.Contains(DirectorToken));
+    }
+
+    // ----- Back-compat: with NO token source the queue keeps the Phase 1 behaviour (per-event bearer) -----
+
+    [Fact]
+    public async Task NoTokenSource_FallsBackToTheStoredPerEventBearer()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"telemetry-queue-639-nofb-{Guid.NewGuid():N}.json");
+        var handler = new RecordingHandler();
+        // No gatewayTokenSource argument: Phase 1 behaviour - forward the stored bearer unchanged.
+        var queue = new TelemetryRetryQueue(path, new HttpClient(handler), TimeSpan.FromMilliseconds(50));
+        try
+        {
+            queue.Enqueue(TargetUrl, BodyFor(0), bearer: DirectorToken);
+            var delivered = await queue.FlushOnceAsync();
+
+            Assert.Equal(1, delivered);
+            Assert.Single(handler.ReceivedAuth);
+            Assert.Equal($"Bearer {DirectorToken}", handler.ReceivedAuth[0]);
+        }
+        finally { await queue.DisposeAsync(); Cleanup(path); }
+    }
+
+    // ----- AC1 end-to-end: tokenless inbound POST -> forwarded to the stub with the Gateway token -----
+
+    [Fact]
+    public async Task PostLogin_WithoutAuthorizationHeader_ForwardsWithGatewayToken()
+    {
+        var (relay, captured, dispose) = await StartRelayAsync(signedIn: true);
+        try
+        {
+            // No Authorization header on the inbound request at all.
+            var req = new HttpRequestMessage(HttpMethod.Post, "telemetry/login")
+            {
+                Content = JsonContent.Create(new { source = "app", app_version = "1.2.3" }),
+            };
+            var resp = await relay.SendAsync(req);
+            Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+
+            await WaitForCapturedAsync(captured, 1);
+            Assert.Single(captured);
+            Assert.True(captured.TryDequeue(out var fwd));
+            Assert.NotNull(fwd);
+            // The forward carried the GATEWAY's token (not a Director token).
+            Assert.Equal($"Bearer {GatewayToken}", fwd.Authorization);
+            using var doc = JsonDocument.Parse(fwd.Body);
+            Assert.Equal("app", doc.RootElement.GetProperty("source").GetString());
+        }
+        finally { await dispose(); }
+    }
+
+    // ----- AC3 end-to-end: an inbound Director Bearer on the request is ignored -----
+
+    [Fact]
+    public async Task PostLogin_WithInboundDirectorBearer_ForwardsGatewayTokenAndNotTheDirectorToken()
+    {
+        var (relay, captured, dispose) = await StartRelayAsync(signedIn: true);
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Post, "telemetry/login")
+            {
+                Content = JsonContent.Create(new { source = "app" }),
+            };
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", DirectorToken);
+
+            var resp = await relay.SendAsync(req);
+            Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+
+            await WaitForCapturedAsync(captured, 1);
+            Assert.Single(captured);
+            Assert.True(captured.TryDequeue(out var fwd));
+            Assert.NotNull(fwd);
+            // The Gateway token went out; the Director token did NOT leak to the cloud.
+            Assert.Equal($"Bearer {GatewayToken}", fwd.Authorization);
+            Assert.DoesNotContain(DirectorToken, fwd.Authorization ?? "");
+        }
+        finally { await dispose(); }
+    }
+
+    // ----- AC2 end-to-end: not signed in -> queued; sign in -> flushed -----
+
+    [Fact]
+    public async Task PostLogin_WhenGatewayNotSignedIn_QueuesThenFlushesAfterSignIn()
+    {
+        var source = new FakeGatewayTokenSource { SignedIn = false };
+        var (relay, captured, dispose) = await StartRelayAsync(source);
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Post, "telemetry/login")
+            {
+                Content = JsonContent.Create(new { source = "app", app_version = "2.0.0" }),
+            };
+            var resp = await relay.SendAsync(req);
+            Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+
+            // Not signed in: nothing reaches the stub even after a generous wait.
+            await Task.Delay(600);
+            Assert.Empty(captured);
+
+            // The Gateway signs in: the queued event now flushes (the background flusher delivers it).
+            source.SignedIn = true;
+            await WaitForCapturedAsync(captured, 1);
+            Assert.Single(captured);
+            Assert.True(captured.TryDequeue(out var fwd));
+            Assert.NotNull(fwd);
+            Assert.Equal($"Bearer {GatewayToken}", fwd.Authorization);
+        }
+        finally { await dispose(); }
+    }
+
+    // ----- relay boot helpers -----
+
+    private sealed record CapturedRequest(string Method, string Path, string? Authorization, string Body);
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static Task<(HttpClient relay, ConcurrentQueue<CapturedRequest> captured, Func<Task> dispose)>
+        StartRelayAsync(bool signedIn) =>
+        StartRelayAsync(new FakeGatewayTokenSource { SignedIn = signedIn });
+
+    /// <summary>
+    /// Boots the real login relay over a durable queue wired with <paramref name="source"/> as its
+    /// Gateway token source, plus a local stub backend that records every forwarded request. Short retry
+    /// interval so the asynchronous flush completes within the test poll window.
+    /// </summary>
+    private static async Task<(HttpClient relay, ConcurrentQueue<CapturedRequest> captured, Func<Task> dispose)>
+        StartRelayAsync(FakeGatewayTokenSource source)
+    {
+        var captured = new ConcurrentQueue<CapturedRequest>();
+
+        var stubPort = AllocateFreePort();
+        var stubBuilder = WebApplication.CreateBuilder();
+        stubBuilder.Logging.ClearProviders();
+        var stub = stubBuilder.Build();
+        stub.Urls.Add($"http://127.0.0.1:{stubPort}");
+        stub.MapPost("/api/v1/telemetry/login", async (HttpContext ctx) =>
+        {
+            using var reader = new StreamReader(ctx.Request.Body);
+            var body = await reader.ReadToEndAsync();
+            captured.Enqueue(new CapturedRequest(
+                ctx.Request.Method,
+                ctx.Request.Path.Value ?? "",
+                ctx.Request.Headers.Authorization.ToString() is { Length: > 0 } a ? a : null,
+                body));
+            return Results.StatusCode(200);
+        });
+        await stub.StartAsync();
+        var targetUrl = $"http://127.0.0.1:{stubPort}/api/v1/telemetry/login";
+
+        var prev = Environment.GetEnvironmentVariable(TelemetryRelayEndpoint.TargetUrlEnvVar);
+        Environment.SetEnvironmentVariable(TelemetryRelayEndpoint.TargetUrlEnvVar, targetUrl);
+
+        var relayPort = AllocateFreePort();
+        var relayBuilder = WebApplication.CreateBuilder();
+        relayBuilder.Logging.ClearProviders();
+        var relayApp = relayBuilder.Build();
+        relayApp.Urls.Add($"http://127.0.0.1:{relayPort}");
+
+        var queuePath = Path.Combine(Path.GetTempPath(), $"telemetry-queue-639-e2e-{Guid.NewGuid():N}.json");
+        var queue = new TelemetryRetryQueue(
+            queuePath,
+            new HttpClient { Timeout = TimeSpan.FromSeconds(3) },
+            retryInterval: TimeSpan.FromMilliseconds(100),
+            maxSize: TelemetryRetryQueue.DefaultMaxSize,
+            gatewayTokenSource: source);
+        TelemetryRelayEndpoint.Map(relayApp, queue);
+        queue.StartFlushing();
+        await relayApp.StartAsync();
+
+        var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{relayPort}/") };
+
+        Func<Task> dispose = async () =>
+        {
+            client.Dispose();
+            await queue.DisposeAsync();
+            await relayApp.DisposeAsync();
+            await stub.DisposeAsync();
+            Cleanup(queuePath);
+            Environment.SetEnvironmentVariable(TelemetryRelayEndpoint.TargetUrlEnvVar, prev);
+        };
+
+        return (client, captured, dispose);
+    }
+
+    private static async Task WaitForCapturedAsync(ConcurrentQueue<CapturedRequest> captured, int count, int timeoutMs = 5000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (captured.Count < count && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+    }
+
+    private static List<string> ReadAllLinesShared(string path)
+    {
+        var lines = new List<string>();
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+            lines.Add(line);
+        return lines;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TelemetryRelayEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/TelemetryRelayEndpointTests.cs
@@ -20,10 +20,15 @@ namespace CcDirector.Gateway.Tests;
 /// points the relay at the stub (or, for the unreachable case, at a dead port). Each test sets and
 /// then restores the env var, so they are self-contained.
 ///
-/// Covers: the forward happy-path (exactly one backend POST, correct URL, POST method, the SAME
-/// Bearer token, a body with <c>source:"app"</c>, and a 202 to the caller); backend 5xx and backend
-/// unreachable (the caller still gets a non-5xx and the failure is logged); and that the access token
-/// is never written to the Gateway log.
+/// Covers: the forward happy-path (exactly one backend POST, correct URL, POST method, a body with
+/// <c>source:"app"</c>, and a 202 to the caller); backend 5xx and backend unreachable (the caller still
+/// gets a non-5xx and the failure is logged); and that the access token is never written to the Gateway
+/// log.
+///
+/// Gateway Centralization Phase 2 (issue #639): the relay no longer forwards an inbound Director Bearer.
+/// These tests boot the queue with NO Gateway token source (the Phase 1 forwarder shape), so a forwarded
+/// request carries NO Authorization header - the inbound Bearer is ignored and the Gateway attaches its
+/// own token only when a token source is wired (covered by Issue639GatewayTelemetryTokenTests).
 /// </summary>
 public sealed class TelemetryRelayEndpointTests
 {
@@ -154,7 +159,7 @@ public sealed class TelemetryRelayEndpointTests
     }
 
     [Fact]
-    public async Task PostLogin_ForwardsExactlyOnce_WithSameBearerAndSourceApp()
+    public async Task PostLogin_ForwardsExactlyOnce_IgnoringInboundBearer_WithSourceApp()
     {
         var (relay, captured, dispose) = await StartAsync(startStub: true);
         try
@@ -173,8 +178,9 @@ public sealed class TelemetryRelayEndpointTests
             Assert.Equal("POST", fwd!.Method);
             Assert.Equal("/api/v1/telemetry/login", fwd.Path);
 
-            // The SAME Bearer token, unchanged.
-            Assert.Equal($"Bearer {AccessToken}", fwd.Authorization);
+            // Issue #639: the inbound Director Bearer is IGNORED. With no Gateway token source wired here,
+            // the forward carries NO Authorization header at all - and the Director token never leaked.
+            Assert.Null(fwd.Authorization);
 
             // A body carrying source:"app".
             using var doc = JsonDocument.Parse(fwd.Body);

--- a/src/CcDirector.Gateway/Api/DirectorStartupTelemetryEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/DirectorStartupTelemetryEndpoint.cs
@@ -21,9 +21,13 @@ namespace CcDirector.Gateway.Api;
 ///
 /// Reuse (issues #628 / #629): when a startup URL IS configured the event is enqueued into the same
 /// durable <see cref="TelemetryRetryQueue"/> the login relay uses, so delivery, retry-with-backoff,
-/// FIFO flush, the bound, and restart survival are shared - this endpoint adds no new forwarder. Unlike
-/// the login relay, a startup event carries NO inbound Bearer token (Phase 1 startup is unauthenticated
-/// to the cloud per the provisional contract), so the enqueued bearer is always null.
+/// FIFO flush, the bound, and restart survival are shared - this endpoint adds no new forwarder. The
+/// enqueued per-event bearer is always null: this endpoint never carried an inbound Director token.
+///
+/// Gateway Centralization Phase 2 (issue #639): like the login relay, when the shared queue is wired
+/// with the Gateway's token source the Gateway attaches its OWN account token at forward time, and a
+/// startup forward is deferred (kept queued) until the Gateway is signed in. So the Gateway is the
+/// single egress here too, and no Director token is ever attached.
 /// </summary>
 internal static class DirectorStartupTelemetryEndpoint
 {

--- a/src/CcDirector.Gateway/Api/GatewayAccountTelemetryTokenSource.cs
+++ b/src/CcDirector.Gateway/Api/GatewayAccountTelemetryTokenSource.cs
@@ -1,0 +1,34 @@
+using CcDirector.Core.Account;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The production <see cref="IGatewayTelemetryTokenSource"/>: reads the Gateway's own account token
+/// from the Gateway-hosted credential service (issue #636, the reused
+/// <see cref="DevThrottleAccountService"/> exposed as <c>GatewayHost.Account</c>) so the Gateway can
+/// attach it when forwarding telemetry to the cloud (issue #639). Entirely local - no network call.
+///
+/// "Signed in" is the credential service's own local check: a stored access token whose signature
+/// verifies and is valid-or-renewable yields the token; an absent or tampered credential yields null,
+/// and the queue then leaves the event queued rather than forwarding it without the Gateway's token.
+/// The token value is NEVER logged (security rule DT-05) - that guarantee lives in the credential
+/// service's accessor, and this adapter adds no logging of its own.
+/// </summary>
+public sealed class GatewayAccountTelemetryTokenSource : IGatewayTelemetryTokenSource
+{
+    private readonly DevThrottleAccountService _account;
+
+    /// <param name="account">The Gateway-hosted DevThrottle credential service. Required.</param>
+    /// <exception cref="ArgumentNullException">account is null.</exception>
+    public GatewayAccountTelemetryTokenSource(DevThrottleAccountService account)
+    {
+        _account = account ?? throw new ArgumentNullException(nameof(account));
+    }
+
+    /// <inheritdoc />
+    public bool TryGetAccessToken(out string? accessToken)
+    {
+        accessToken = _account.GetAccessTokenForForwarding();
+        return accessToken is not null;
+    }
+}

--- a/src/CcDirector.Gateway/Api/IGatewayTelemetryTokenSource.cs
+++ b/src/CcDirector.Gateway/Api/IGatewayTelemetryTokenSource.cs
@@ -1,0 +1,28 @@
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Supplies the GATEWAY's own account token to attach when it forwards telemetry to the cloud
+/// (Gateway Centralization Phase 2, issue #639). Phase 1 forwarded whatever Bearer the Director sent
+/// inbound; from this issue the Gateway is the single egress and attaches its OWN stored account token
+/// instead, so the Director no longer needs a token at all.
+///
+/// The source is consulted at FORWARD time (not enqueue time) so a sign-in that completes AFTER an
+/// event was queued is picked up on the next flush pass. Two outcomes:
+/// <list type="bullet">
+///   <item>Signed in -> <see cref="TryGetAccessToken"/> returns true and yields the token to attach.</item>
+///   <item>Not signed in -> returns false; the queue must NOT forward and leaves the event queued for a
+///     later pass (issue #639 acceptance criterion 2: queue-when-not-signed-in, flush-after-sign-in).</item>
+/// </list>
+///
+/// Security (rule DT-05): the token value is for attaching to the outbound request ONLY and is NEVER
+/// written to the log on any path - implementations log only whether a token was available.
+/// </summary>
+public interface IGatewayTelemetryTokenSource
+{
+    /// <summary>
+    /// Tries to read the Gateway's current account access token to attach to an outbound forward.
+    /// </summary>
+    /// <param name="accessToken">The token to attach when the Gateway is signed in; null otherwise.</param>
+    /// <returns>True when the Gateway is signed in and a token is available; false otherwise.</returns>
+    bool TryGetAccessToken(out string? accessToken);
+}

--- a/src/CcDirector.Gateway/Api/TelemetryRelayEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TelemetryRelayEndpoint.cs
@@ -10,21 +10,28 @@ namespace CcDirector.Gateway.Api;
 /// login-telemetry event here instead of calling the cloud directly, and the Gateway forwards it to
 /// the backend so the Gateway becomes the single egress to the cloud.
 ///
-/// Wire contract: the inbound request carries the body <c>{ "source": "app", "app_version"?: "..." }</c>
-/// and an <c>Authorization: Bearer &lt;access token&gt;</c> header. The Gateway forwards BOTH the body
-/// and the Bearer token UNCHANGED to the backend login endpoint
+/// Wire contract: the inbound request carries the body <c>{ "source": "app", "app_version"?: "..." }</c>.
+/// The Gateway forwards the body UNCHANGED to the backend login endpoint
 /// (default <c>https://devthrottle.com/api/v1/telemetry/login</c>, overridable on the Gateway via the
 /// <c>DEVTHROTTLE_TELEMETRY_URL</c> environment variable).
 ///
-/// Issue #629 - durable retry queue: the relay no longer forwards inline. It ENQUEUES every accepted
-/// event into the <see cref="TelemetryRetryQueue"/> (durable, bounded, restart-surviving) and answers
-/// the caller 202 Accepted immediately. The queue owns delivery: it flushes in FIFO order, retries
-/// with backoff while the backend is unreachable, survives a Gateway restart, and is bounded (the
-/// oldest event is evicted when full). The relay therefore NEVER throws back to the Director and a
-/// backend outage queues events instead of dropping them.
+/// Gateway Centralization Phase 2 (issue #639): the relay no longer requires - and no longer forwards -
+/// an inbound <c>Authorization</c> header from the Director. The Gateway is now the single egress, so it
+/// attaches its OWN stored account token (from the Gateway credential service, issue #636) when it
+/// forwards to the cloud; that token is resolved at forward time by the <see cref="TelemetryRetryQueue"/>
+/// from its configured Gateway token source. A Director Bearer, if still present on the inbound request,
+/// is therefore IGNORED here (no double-auth, no Director token leaked to the cloud). When the Gateway is
+/// not signed in, the queue holds the event and flushes it once the Gateway signs in.
 ///
-/// Security: the inbound access token (the Bearer) is NEVER written to the Gateway log on this path.
-/// Every log line records only the target URL and whether a token was present - never the token value.
+/// Issue #629 - durable retry queue: the relay does not forward inline. It ENQUEUES every accepted event
+/// into the <see cref="TelemetryRetryQueue"/> (durable, bounded, restart-surviving) and answers the
+/// caller 202 Accepted immediately. The queue owns delivery: it flushes in FIFO order, retries with
+/// backoff while the backend is unreachable (or while the Gateway is not yet signed in), survives a
+/// Gateway restart, and is bounded (the oldest event is evicted when full). The relay therefore NEVER
+/// throws back to the Director and a backend outage queues events instead of dropping them.
+///
+/// Security: no token value is written to the Gateway log on this path. Every log line records only the
+/// target URL - never a token, neither the (ignored) inbound Director Bearer nor the Gateway's token.
 /// </summary>
 internal static class TelemetryRelayEndpoint
 {
@@ -67,34 +74,22 @@ internal static class TelemetryRelayEndpoint
             using (var reader = new StreamReader(ctx.Request.Body))
                 body = await reader.ReadToEndAsync(ctx.RequestAborted);
 
-            // Pull the inbound Bearer token. It is forwarded UNCHANGED; it is NEVER logged.
-            var bearer = ExtractBearer(ctx.Request.Headers.Authorization.ToString());
+            // Issue #639: the inbound Authorization header (a Director Bearer, if still present) is
+            // IGNORED - it is neither required nor forwarded. The Gateway attaches its OWN account token
+            // at forward time (resolved by the queue's Gateway token source). We record only whether an
+            // inbound header was present (never its value) so the ignore is observable in the log.
+            var inboundAuthPresent = !string.IsNullOrEmpty(ctx.Request.Headers.Authorization.ToString());
 
-            // Enqueue for durable delivery. The queue logs the target + depth (never the token value)
-            // and owns the retry / persistence / bound-eviction behaviour; the relay just hands off.
-            FileLog.Write($"[TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for {targetUrl} (bearerPresent={(bearer is not null)})");
-            queue.Enqueue(targetUrl, body, bearer);
+            // Enqueue for durable delivery with NO stored Bearer - the Gateway token is attached when the
+            // queue forwards. The queue logs the target + depth (never any token value) and owns the
+            // retry / persistence / bound-eviction behaviour; the relay just hands off.
+            FileLog.Write($"[TelemetryRelayEndpoint] POST /telemetry/login -> enqueue for {targetUrl} (inboundAuthPresent={inboundAuthPresent}; ignored, gateway token attached on forward)");
+            queue.Enqueue(targetUrl, body, bearer: null);
 
-            // The relay accepts the event regardless of the backend's current reachability (the queue
-            // delivers it when the backend is up). 202 Accepted is the truthful answer: "received and
-            // queued for delivery", never a guarantee the cloud has it yet.
+            // The relay accepts the event regardless of the backend's current reachability or whether the
+            // Gateway is signed in yet (the queue delivers it once both are ready). 202 Accepted is the
+            // truthful answer: "received and queued for delivery", never a guarantee the cloud has it yet.
             return Results.StatusCode(StatusCodes.Status202Accepted);
         });
-    }
-
-    /// <summary>
-    /// Extracts the token from an <c>Authorization: Bearer &lt;token&gt;</c> header value, or null when
-    /// the header is absent or not a Bearer credential. The token value is returned for forwarding only
-    /// and must never be logged.
-    /// </summary>
-    private static string? ExtractBearer(string authorizationHeader)
-    {
-        if (string.IsNullOrWhiteSpace(authorizationHeader))
-            return null;
-        const string prefix = "Bearer ";
-        if (!authorizationHeader.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return null;
-        var token = authorizationHeader.Substring(prefix.Length).Trim();
-        return string.IsNullOrEmpty(token) ? null : token;
     }
 }

--- a/src/CcDirector.Gateway/Api/TelemetryRetryQueue.cs
+++ b/src/CcDirector.Gateway/Api/TelemetryRetryQueue.cs
@@ -44,6 +44,7 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
     private readonly string _path;
     private readonly HttpClient _client;
     private readonly TimeSpan _retryInterval;
+    private readonly IGatewayTelemetryTokenSource? _gatewayTokenSource;
     private readonly LinkedList<QueuedEvent> _events = new();
 
     private readonly CancellationTokenSource _flushCts = new();
@@ -70,10 +71,24 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
     /// idle poll interval when the queue is empty).
     /// </param>
     /// <param name="maxSize">The bound; the oldest event is evicted once the queue exceeds this.</param>
+    /// <param name="gatewayTokenSource">
+    /// Gateway Centralization Phase 2 (issue #639): the source of the GATEWAY's own account token,
+    /// attached at FORWARD time when the Gateway acts as the single egress to the cloud. When supplied:
+    /// the Gateway's token is attached and any per-event stored <see cref="QueuedEvent.Bearer"/> (a
+    /// leftover inbound Director token) is IGNORED; and when the Gateway is NOT signed in the forward is
+    /// deferred (the event stays queued, FIFO preserved, and flushes once the Gateway signs in). When
+    /// null (a host with no credential service, or Phase 1 callers) the queue falls back to the stored
+    /// per-event Bearer - the original #628/#629 behaviour, unchanged.
+    /// </param>
     /// <exception cref="ArgumentException">The path is null/empty/whitespace.</exception>
     /// <exception cref="ArgumentNullException">The client is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxSize or retryInterval is not positive.</exception>
-    public TelemetryRetryQueue(string path, HttpClient client, TimeSpan retryInterval, int maxSize = DefaultMaxSize)
+    public TelemetryRetryQueue(
+        string path,
+        HttpClient client,
+        TimeSpan retryInterval,
+        int maxSize = DefaultMaxSize,
+        IGatewayTelemetryTokenSource? gatewayTokenSource = null)
     {
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("queue path is required", nameof(path));
@@ -87,6 +102,7 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
         _path = path;
         _client = client;
         _retryInterval = retryInterval;
+        _gatewayTokenSource = gatewayTokenSource;
         MaxSize = maxSize;
         Load();
     }
@@ -190,19 +206,39 @@ public sealed class TelemetryRetryQueue : IAsyncDisposable
     }
 
     /// <summary>
-    /// Forward one event to its backend URL with the stored body + Bearer. Returns true on a 2xx,
-    /// false on any non-2xx or transport failure. The token value is never logged.
+    /// Forward one event to its backend URL with the stored body and the token to attach. Returns true
+    /// on a 2xx, false on any non-2xx or transport failure - and false WITHOUT forwarding when a Gateway
+    /// token source is configured but the Gateway is not signed in, so the event stays queued for a later
+    /// pass (issue #639). The token value is never logged.
     /// </summary>
     private async Task<bool> TryForwardAsync(QueuedEvent item, CancellationToken cancellationToken)
     {
+        // Issue #639: when a Gateway token source is wired, the Gateway attaches its OWN account token
+        // and the per-event stored Bearer (a leftover inbound Director token) is ignored. If the Gateway
+        // is not signed in, the forward is DEFERRED (event stays queued) - never sent without the token.
+        string? tokenToAttach;
+        if (_gatewayTokenSource is not null)
+        {
+            if (!_gatewayTokenSource.TryGetAccessToken(out tokenToAttach) || tokenToAttach is null)
+            {
+                FileLog.Write($"[TelemetryRetryQueue] forward DEFERRED (gateway not signed in): {item.TargetUrl}, id={item.Id} (kept queued, will flush after sign-in)");
+                return false;
+            }
+        }
+        else
+        {
+            // Phase 1 / no-credential-service host: fall back to the stored per-event Bearer unchanged.
+            tokenToAttach = item.Bearer;
+        }
+
         try
         {
             using var forward = new HttpRequestMessage(HttpMethod.Post, item.TargetUrl)
             {
                 Content = new StringContent(item.Body, System.Text.Encoding.UTF8, "application/json"),
             };
-            if (item.Bearer is not null)
-                forward.Headers.Authorization = new AuthenticationHeaderValue("Bearer", item.Bearer);
+            if (tokenToAttach is not null)
+                forward.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenToAttach);
 
             using var resp = await _client.SendAsync(forward, cancellationToken);
             if (resp.IsSuccessStatusCode)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -249,17 +249,39 @@ public sealed class GatewayHost : IAsyncDisposable
         // target Director from the registry and starts a session over the shared client (the same
         // path the work-list runner uses). The background sweep timer is started in StartAsync.
         _cronRuns = new CronRunHistoryStore(cronRunsPath ?? Path.Combine(CcStorage.Root(), "cronruns.json"));
+        // The Gateway-hosted DevThrottle credential service (issue #636, Gateway Centralization Phase 2
+        // foundation). Tests inject their own service over an isolated store; production builds the
+        // Windows Data Protection-backed service rooted under the Gateway config directory. The
+        // operating-system credential store is Windows-only for now (the issue's assumption), so on a
+        // non-Windows host Account stays null until the macOS Keychain store is added - the platform
+        // guard also satisfies the platform-compatibility analyzer. Resolved BEFORE the telemetry queue
+        // so the queue can attach the Gateway's own account token when forwarding (issue #639).
+        if (account is not null)
+            Account = account;
+        else if (OperatingSystem.IsWindows())
+            Account = CcDirector.Gateway.Account.GatewayAccountFactory.CreateForWindows();
+        else
+            FileLog.Write("[GatewayHost] DevThrottle credential service not built: operating-system credential store is Windows-only for now");
+
         // Durable telemetry retry queue (issue #629): one JSON file under the Gateway config directory
         // (the DeviceRegistry / gateway-token precedent), loaded here so events a previous run left
         // undelivered survive a restart. A short-timeout forwarder client keeps a slow/unreachable
         // backend from holding a flush pass open. Tests pass an isolated path + a small bound + a short
         // retry interval so they never touch the real store and can exercise eviction quickly.
+        // Issue #639: when the Gateway has a credential service the queue is wired with a Gateway token
+        // source, so it attaches the GATEWAY's own account token at forward time (and holds events while
+        // the Gateway is not signed in). On a host with no credential service the source stays null and
+        // the queue keeps its Phase 1 behaviour (forward with the per-event stored bearer, unchanged).
         var telemetryForwardClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        var gatewayTelemetryTokenSource = Account is not null
+            ? new Api.GatewayAccountTelemetryTokenSource(Account)
+            : null;
         _telemetryQueue = new Api.TelemetryRetryQueue(
             telemetryQueuePath ?? Path.Combine(CcStorage.Config(), "director", "telemetry-queue.json"),
             telemetryForwardClient,
             telemetryRetryInterval ?? TimeSpan.FromSeconds(30),
-            telemetryQueueMaxSize ?? Api.TelemetryRetryQueue.DefaultMaxSize);
+            telemetryQueueMaxSize ?? Api.TelemetryRetryQueue.DefaultMaxSize,
+            gatewayTelemetryTokenSource);
         // A cron job targets a MACHINE (#503): resolve it to a Director at fire time, launching one
         // via the launcher (the shipped /machines/{m}/director/start relay, #331) if none is running.
         var cronTargetResolver = new Running.RegistryDirectorTargetResolver(
@@ -290,19 +312,6 @@ public sealed class GatewayHost : IAsyncDisposable
         _cronEngine = new Running.CronEngine(
             _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(_client, cronTargetResolver),
             cronWorkListRunner, cronNotifier, new Running.SystemClock());
-
-        // The Gateway-hosted DevThrottle credential service (issue #636, Gateway Centralization Phase 2
-        // foundation). Tests inject their own service over an isolated store; production builds the
-        // Windows Data Protection-backed service rooted under the Gateway config directory. The
-        // operating-system credential store is Windows-only for now (the issue's assumption), so on a
-        // non-Windows host Account stays null until the macOS Keychain store is added - the platform
-        // guard also satisfies the platform-compatibility analyzer.
-        if (account is not null)
-            Account = account;
-        else if (OperatingSystem.IsWindows())
-            Account = CcDirector.Gateway.Account.GatewayAccountFactory.CreateForWindows();
-        else
-            FileLog.Write("[GatewayHost] DevThrottle credential service not built: operating-system credential store is Windows-only for now");
 
         // The browser loopback sign-in flow relocated onto the Gateway (issue #637). It is built over
         // the credential service, so it exists only when that service does - on a host with no


### PR DESCRIPTION
Closes #639 (Gateway Centralization Phase 2).

## Release Notes
The Gateway is now the single egress to the cloud for telemetry: it attaches its OWN stored account token when forwarding, so Directors no longer need a token. The telemetry relay no longer requires or forwards an inbound Authorization header from the Director.

## Changes
- New `IGatewayTelemetryTokenSource` + `GatewayAccountTelemetryTokenSource` adapter, reading the Gateway credential service (`DevThrottleAccountService`, issue #636).
- New read-only accessor `DevThrottleAccountService.GetAccessTokenForForwarding()` - returns the stored access token when the Gateway is signed in (same local valid-or-renewable check as `IsLoggedIn`), null otherwise. The token value is never logged.
- `TelemetryRetryQueue` resolves the Gateway token at FORWARD time: signed in attaches the Gateway token (any leftover per-event stored bearer is ignored); not signed in DEFERS the forward (the event stays at the head of the queue, FIFO preserved) and flushes once the Gateway signs in. With no token source wired the queue keeps its Phase 1 behaviour, so non-Windows hosts do not regress.
- The login relay (`POST /telemetry/login`) and the director-startup forward (`POST /telemetry/director-startup`) both ignore an inbound Director Bearer and let the queue attach the Gateway token.
- `GatewayHost` resolves the credential service before building the queue and wires the token source when a credential service exists.

## How to Test
`dotnet build cc-director.sln` (clean: 0 warnings, 0 errors), then:
`dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter "FullyQualifiedName~Issue639GatewayTelemetryTokenTests"`

## Expected Result
All 8 issue-639 tests pass; the local cloud stub records the Gateway token (never a Director token); a not-signed-in Gateway queues then flushes in order after sign-in; the Gateway token never appears in the log.

## Before / After
- Before (Phase 1): the relay forwarded the Director's inbound Bearer to the cloud.
- After: the relay ignores the inbound Bearer; the Gateway attaches its own account token at forward time, or queues until it is signed in.

## CenCon impact
No architecture drift - same containers (Gateway, Gateway.Tests) and same cloud wire contract (Bearer + `source:"app"`); only WHOSE token is attached changes. Security posture reinforced: the Gateway token is never logged (rule DT-05) and a Director token is no longer forwarded to the cloud, removing a credential-leakage path. Security profile last_verified 2026-06-09 is within the 30-day threshold.

Proof: docs/cencon/proof/issue-639/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)