### PR TITLE
[Gateway] Token refresh owned by the Gateway (#640)

### DIFF
--- a/docs/cencon/proof/issue-640/proof-log-lines.txt
+++ b/docs/cencon/proof/issue-640/proof-log-lines.txt
@@ -1,0 +1,26 @@
+2026-06-22 12:32:42.681 [DevThrottleAccountService] RefreshIfNeededAsync: evaluating cached credential
+2026-06-22 12:32:42.681 [DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh
+2026-06-22 12:32:42.681 [GatewayHttpTokenRefresher] RefreshAsync: evaluating configured refresh endpoint
+2026-06-22 12:32:42.744 [GatewayHttpTokenRefresher] RefreshAsync: refreshed token pair received from the backend exchange
+2026-06-22 12:32:42.744 [DevThrottleAccountService] RefreshIfNeededAsync: refreshed access token stored
+2026-06-22 12:32:42.758 [DevThrottleAccountService] RefreshIfNeededAsync: evaluating cached credential
+2026-06-22 12:32:42.763 [DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh
+2026-06-22 12:32:42.763 [GatewayHttpTokenRefresher] RefreshAsync: evaluating configured refresh endpoint
+2026-06-22 12:32:42.763 [GatewayHttpTokenRefresher] RefreshAsync: no refresh endpoint configured (DEVTHROTTLE_REFRESH_URL unset) -> refresh unavailable (cached credential kept)
+2026-06-22 12:32:42.763 [DevThrottleAccountService] RefreshIfNeededAsync: refresh unavailable (offline or declined) -> keeping cached credential
+2026-06-22 12:32:42.765 [DevThrottleAccountService] RefreshIfNeededAsync: evaluating cached credential
+2026-06-22 12:32:42.770 [DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh
+2026-06-22 12:32:42.770 [GatewayHttpTokenRefresher] RefreshAsync: evaluating configured refresh endpoint
+2026-06-22 12:32:42.778 [GatewayHttpTokenRefresher] ExchangeAsync: refresh endpoint unreachable or unparseable -> refresh unavailable: The requested address is not valid in its context. (127.0.0.1:0)
+2026-06-22 12:32:42.778 [GatewayHttpTokenRefresher] RefreshAsync: refresh unavailable (endpoint unreachable or declined) -> cached credential kept
+2026-06-22 12:32:42.778 [DevThrottleAccountService] RefreshIfNeededAsync: refresh unavailable (offline or declined) -> keeping cached credential
+2026-06-22 12:32:42.792 [DevThrottleAccountService] RefreshIfNeededAsync: evaluating cached credential
+2026-06-22 12:32:42.798 [DevThrottleAccountService] RefreshIfNeededAsync: access token still valid -> no refresh needed
+2026-06-22 12:32:42.803 [GatewayTokenRefreshService] Start: background token refresh every 30s (first sweep in 0s)
+2026-06-22 12:32:43.008 [DevThrottleAccountService] RefreshIfNeededAsync: evaluating cached credential
+2026-06-22 12:32:43.009 [DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh
+2026-06-22 12:32:43.009 [GatewayHttpTokenRefresher] RefreshAsync: evaluating configured refresh endpoint
+2026-06-22 12:32:43.013 [GatewayHttpTokenRefresher] RefreshAsync: refreshed token pair received from the backend exchange
+2026-06-22 12:32:43.013 [DevThrottleAccountService] RefreshIfNeededAsync: refreshed access token stored
+2026-06-22 12:32:43.014 [GatewayTokenRefreshService] RefreshOnceAsync: access token renewed in the background
+2026-06-22 12:32:43.024 [GatewayTokenRefreshService] Dispose: stopping background token refresh

--- a/docs/cencon/proof/issue-640/proof-output.txt
+++ b/docs/cencon/proof/issue-640/proof-output.txt
@@ -1,0 +1,51 @@
+D:\ReposFred\devthrottle-wt-640\proof-harness\Program.cs(117,16): warning CA1416: This call site is reachable on all platforms. 'WindowsProtectedTokenStore.Load()' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [D:\ReposFred\devthrottle-wt-640\proof-harness\Issue640Proof.csproj]
+D:\ReposFred\devthrottle-wt-640\proof-harness\Program.cs(96,16): warning CA1416: This call site is reachable on all platforms. 'WindowsProtectedTokenStore.Load()' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [D:\ReposFred\devthrottle-wt-640\proof-harness\Issue640Proof.csproj]
+D:\ReposFred\devthrottle-wt-640\proof-harness\Program.cs(42,17): warning CA1416: This call site is reachable on all platforms. 'WindowsProtectedTokenStore' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [D:\ReposFred\devthrottle-wt-640\proof-harness\Issue640Proof.csproj]
+D:\ReposFred\devthrottle-wt-640\proof-harness\Program.cs(96,16): warning CA1416: This call site is reachable on all platforms. 'WindowsProtectedTokenStore' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [D:\ReposFred\devthrottle-wt-640\proof-harness\Issue640Proof.csproj]
+D:\ReposFred\devthrottle-wt-640\proof-harness\Program.cs(117,16): warning CA1416: This call site is reachable on all platforms. 'WindowsProtectedTokenStore' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [D:\ReposFred\devthrottle-wt-640\proof-harness\Issue640Proof.csproj]
+ISSUE 640 PROOF - Gateway-owned token refresh
+log file: C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-06-22-30384.log
+
+==== CRITERION 1: expired-but-well-formed token + stub endpoint -> exchanges and stores a fresh valid pair ====
+seeded access token expired? True
+signed-in before refresh (well-formed expired still counts)? True
+forwardable current token before refresh? True
+RefreshIfNeededAsync returned: True  (expected True)
+stub received exactly one exchange? True
+stub received the cached refresh token? True
+forwardable current (non-expired) token after refresh? True
+stored access token now non-expired? True
+RESULT: PASS
+
+==== CRITERION 2: NO refresh endpoint configured -> keeps the cached credential and logs unavailability ====
+RefreshIfNeededAsync returned: False  (expected False)
+cached credential kept unchanged (same expired access token)? True
+cached refresh token kept unchanged? True
+still reports signed-in on the kept (well-formed) token? True
+no crash (we got here) ? True
+RESULT: PASS
+
+==== CRITERION 2b: endpoint configured but UNREACHABLE -> keeps cached credential, no crash ====
+RefreshIfNeededAsync returned: False  (expected False)
+cached credential kept unchanged? True
+RESULT: PASS
+
+==== CRITERION 3: still-valid (unexpired) access token -> NO refresh exchange ====
+RefreshIfNeededAsync returned: False  (expected False)
+stub exchange request count: 0  (expected 0)
+RESULT: PASS
+
+==== CRITERION 4: refresh runs in the BACKGROUND via GatewayTokenRefreshService and never blocks ====
+Start() returned in 0 ms (immediate, did not block) - exchanges so far: 0 (expected 0 right after Start)
+token already refreshed at Start() time? False  (expected False - it runs LATER, in the background)
+background exchange happened after Start() returned? True
+token is now non-expired after the background refresh? True
+RESULT: PASS
+
+==== SECURITY + LOGGING: tokens absent from the log; unavailability is logged ====
+seed refresh token marker absent from log? True
+rotated refresh token marker absent from log? True
+unavailability clearly logged (criterion 2)? True
+RESULT: PASS
+
+PROOF COMPLETE

--- a/docs/cencon/proof/issue-640/qa-report.html
+++ b/docs/cencon/proof/issue-640/qa-report.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>QA Proof Report - Issue #640 (Gateway-owned token refresh)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; line-height: 1.5; }
+  h1 { border-bottom: 2px solid #333; padding-bottom: .4rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #bbb; padding: .5rem .7rem; vertical-align: top; text-align: left; }
+  th { background: #f0f0f0; }
+  .pass { color: #0a7d00; font-weight: bold; }
+  .fail { color: #b00000; font-weight: bold; }
+  code { background: #f4f4f4; padding: .1rem .3rem; border-radius: 3px; }
+  .verdict { background: #e8f7e8; border: 1px solid #0a7d00; padding: 1rem; margin: 1.5rem 0; font-size: 1.1rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #640</h1>
+<p><strong>Title:</strong> [Gateway] Token refresh owned by the Gateway<br/>
+<strong>Pull request:</strong> #674 (branch <code>issue-640-gateway-token-refresh</code>)<br/>
+<strong>QA identity:</strong> independent verifier (separate from the Developer Agent)<br/>
+<strong>Method:</strong> own git worktree from the PR branch, own clean build, own test runs, plus an
+independent DT-05 leak probe against a QA-owned stub. The Developer Agent's report and screenshots were
+NOT trusted as proof.</p>
+
+<h2>Build and regression</h2>
+<ul>
+  <li><code>dotnet build cc-director.sln</code> -&gt; <span class="pass">Build succeeded. 0 Warning(s) 0 Error(s)</span></li>
+  <li>Full Gateway test suite (<code>CcDirector.Gateway.Tests</code>) -&gt; <span class="pass">934 passed, 1 skipped, 0 failed</span> (the 3 VaultGatewayIntegrationTests known red on continuous-integration main passed locally, as expected).</li>
+</ul>
+
+<h2>Acceptance criteria</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (independently verified)</th><th>Result</th></tr>
+  <tr>
+    <td>1</td>
+    <td>Expired-but-well-formed access token + configured refresh endpoint (stub) -&gt; Gateway exchanges the refresh token and stores a fresh valid pair; signed-in flips back to non-expired.</td>
+    <td>Exchange occurs; stub receives the cached refresh token; stored access token becomes non-expired and forwardable.</td>
+    <td>Verified by <code>RefreshIfNeeded_ExpiredTokenWithStubEndpoint_StoresFreshValidPair</code> AND by an independent QA probe driving the full path against a QA-owned stub: <code>stub.LastRefreshToken</code> equals the cached refresh token, and <code>GetAccessTokenForForwarding()</code> returns a non-expired token after the call.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>No refresh endpoint configured OR endpoint unreachable -&gt; Gateway keeps the cached credential and logs the unavailability; no crash; no fallback that hides the failure.</td>
+    <td>Both paths return "no renewal"; cached credential unchanged on disk; unavailability logged; no fabricated token.</td>
+    <td>Unset path: <code>RefreshIfNeeded_ExpiredTokenNoEndpoint_KeepsCachedCredential</code> - the stored access and refresh tokens are byte-for-byte unchanged. Unreachable path: <code>RefreshIfNeeded_ExpiredTokenUnreachableEndpoint_KeepsCachedCredential</code> - same kept-cached outcome. Code returns <code>null</code> (the same explicit "refresh unavailable" signal) and logs the reason; no token is fabricated.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>A still-valid (unexpired) access token triggers NO refresh call.</td>
+    <td>Stub receives zero requests.</td>
+    <td><code>RefreshIfNeeded_ValidToken_TriggersNoExchange</code> asserts <code>stub.RequestCount == 0</code>. <code>RefreshIfNeededAsync</code> short-circuits on a valid token before any network call.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>Refresh runs in the background and never blocks Gateway startup or request handling.</td>
+    <td><code>Start()</code> returns immediately; first sweep deferred; disposed on shutdown.</td>
+    <td><code>GatewayTokenRefreshService.Start()</code> arms a <code>System.Threading.Timer</code> (first sweep after a delay) and returns; each sweep is fire-and-forget with a boundary try/catch. Constructed in <code>GatewayHost</code> (non-blocking), <code>Start()</code> called at the end of <code>StartAsync</code>, disposed in <code>StopAsync</code>. Confirmed by code inspection.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>5</td>
+    <td>Unit tests cover refresh-on-expiry (stub), no-endpoint kept-cached, and valid-token no-op.</td>
+    <td>Tests exist and genuinely assert the behavior; all pass.</td>
+    <td>Five tests in <code>GatewayTokenRefreshTests</code> read in full and confirmed to assert the outcomes (not vacuous). Filtered run: <span class="pass">5 passed, 0 failed</span>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Security - DT-05 (tokens never written to the log)</h2>
+<p>Code review: no <code>FileLog.Write</code> in the new code interpolates a token value - only constant strings,
+HTTP status codes, and exception messages (which carry no token). Independent live-log probe: drove the full
+refresh path with a distinctive access-token email marker and distinctive refresh tokens, with the real
+<code>FileLog</code> writer running, then read the actual log file and asserted none of the markers appear in it.
+<span class="pass">PASS</span></p>
+
+<h2>Scope and method checks</h2>
+<ul>
+  <li>In-scope only: <code>CcDirector.Gateway</code> (refresher, background service, host wiring, factory), <code>CcDirector.Gateway.Tests</code>. The <code>ITokenRefresher</code> contract in <code>CcDirector.Core</code> was reused unchanged.</li>
+  <li>Out-of-scope correctly NOT done: no sign-in change, no Director-side change.</li>
+  <li>No-fallback rule honored: an unavailable refresh returns the explicit <code>null</code> signal and keeps the cached credential - it never fabricates a token.</li>
+</ul>
+
+<div class="verdict">VERIFIED - all 5 acceptance criteria met, DT-05 confirmed, build clean, Gateway regression suite green.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-640/report.html
+++ b/docs/cencon/proof/issue-640/report.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Proof - Issue #640: Gateway-owned token refresh</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1e1e1e; background: #fafafa; line-height: 1.5; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #007ACC; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 1.8rem; color: #007ACC; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; background: #fff; }
+  th, td { border: 1px solid #d0d0d0; padding: .55rem .7rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: #eef4fa; }
+  .pass { color: #137333; font-weight: bold; }
+  .pill { display: inline-block; background: #137333; color: #fff; border-radius: 10px; padding: .1rem .6rem; font-size: .8rem; }
+  pre { background: #1e1e1e; color: #d4d4d4; padding: 1rem; overflow-x: auto; border-radius: 4px; font-size: .82rem; }
+  code { background: #eee; padding: .1rem .3rem; border-radius: 3px; }
+  .note { background: #fff8e1; border-left: 4px solid #f0ad4e; padding: .7rem 1rem; margin: 1rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Proof - Issue #640: Token refresh owned by the Gateway</h1>
+
+<p><strong>Outcome:</strong> <span class="pill">I believe this is finished</span> &nbsp; All five acceptance criteria proven.</p>
+
+<p>
+Token refresh is now the Gateway's job. A real <code>ITokenRefresher</code> implementation
+(<code>GatewayHttpTokenRefresher</code>) replaces the no-op <code>BackendUnavailableTokenRefresher</code> that
+was wired into the Gateway-hosted credential service. When the cached access token is expired-but-well-formed
+and a refresh endpoint is configured (<code>DEVTHROTTLE_REFRESH_URL</code>), the Gateway exchanges the refresh
+token for a fresh access-plus-refresh pair and stores it through the credential service - in the background,
+never blocking startup or request handling. When no endpoint is configured, or it is unreachable, the cached
+credential is kept and the unavailability is logged clearly (no fallback that hides the failure).
+</p>
+
+<h2>What was implemented</h2>
+<table>
+  <tr><th>File</th><th>Change</th></tr>
+  <tr>
+    <td><code>src/CcDirector.Gateway/Account/GatewayHttpTokenRefresher.cs</code> (new)</td>
+    <td>The real <code>ITokenRefresher</code> on the Gateway. Gated on <code>DEVTHROTTLE_REFRESH_URL</code>:
+    when set, POSTs <code>{ "refresh_token": "..." }</code> and parses <code>{ "access_token", "refresh_token" }</code>;
+    when unset it reports refresh unavailable (returns null). A connectivity error / non-success status / response
+    missing either token is treated as "refresh unavailable" (null) and logged WITHOUT the token values.</td>
+  </tr>
+  <tr>
+    <td><code>src/CcDirector.Gateway/Account/GatewayTokenRefreshService.cs</code> (new)</td>
+    <td>The background refresh loop: a timer that periodically calls
+    <code>DevThrottleAccountService.RefreshIfNeededAsync</code> fire-and-forget. <code>Start()</code> returns
+    immediately (first sweep after a short delay), so it never blocks Gateway startup or request handling. The
+    timer callback owns its try/catch so a refresh failure never crashes the timer thread.</td>
+  </tr>
+  <tr>
+    <td><code>src/CcDirector.Gateway/Account/GatewayAccountFactory.cs</code></td>
+    <td>Wires <code>GatewayHttpTokenRefresher</code> (short-timeout <code>HttpClient</code>) into the credential
+    service in place of the no-op refresher. Adds the <code>RefreshUrlEnvVar</code> constant.</td>
+  </tr>
+  <tr>
+    <td><code>src/CcDirector.Gateway/GatewayHost.cs</code></td>
+    <td>Constructs the background refresh service when a credential service exists, starts it in
+    <code>StartAsync</code> (after the host is listening, non-blocking), and disposes it in <code>StopAsync</code>.</td>
+  </tr>
+  <tr>
+    <td><code>src/CcDirector.Gateway.Tests/Account/GatewayTokenRefreshTests.cs</code> (new)</td>
+    <td>Five unit tests covering refresh-on-expiry against a local stub, no-endpoint kept-cached,
+    unreachable-endpoint kept-cached, valid-token no-op (zero exchanges), and the refresher's no-endpoint null.</td>
+  </tr>
+</table>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (proof harness against a local stub)</th><th>Result</th></tr>
+  <tr>
+    <td>1</td>
+    <td>Expired-but-well-formed token + refresh endpoint configured -> exchange and store a fresh valid pair (signed-in flips back to a non-expired token).</td>
+    <td><code>RefreshIfNeededAsync</code> returns true; stub receives the cached refresh token once; stored token is non-expired afterward.</td>
+    <td>Returned True; stub received exactly one exchange carrying the seed refresh token; forwardable current (non-expired) token present after refresh.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>No refresh endpoint configured (or unreachable) -> keep the cached credential and log unavailability; no crash, no hiding fallback.</td>
+    <td>Returns false; cached access + refresh tokens unchanged; an unavailability line is logged.</td>
+    <td>Returned False; cached credential unchanged (same expired access + seed refresh token); still reports signed-in on the kept token; log line <code>no refresh endpoint configured (DEVTHROTTLE_REFRESH_URL unset) -&gt; refresh unavailable</code>. Unreachable-endpoint variant (2b) also kept the credential with an explicit log line and no crash.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>A still-valid (unexpired) access token triggers NO refresh call.</td>
+    <td>Returns false; the stub backend receives zero requests.</td>
+    <td>Returned False; stub exchange request count = 0. Log shows <code>access token still valid -&gt; no refresh needed</code> (the refresher is never reached).</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>Refresh runs in the BACKGROUND and never blocks Gateway startup or request handling.</td>
+    <td><code>Start()</code> returns immediately (0 exchanges at that instant); the exchange happens later, on the background timer.</td>
+    <td><code>Start()</code> returned in 0 ms with 0 exchanges; ~200 ms later the background sweep fired and renewed the token (log: <code>GatewayTokenRefreshService ... access token renewed in the background</code>).</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>5</td>
+    <td>Unit tests cover refresh-on-expiry (stub), no-endpoint kept-cached, and valid-token no-op.</td>
+    <td>New tests pass.</td>
+    <td>5 tests in <code>GatewayTokenRefreshTests</code> - all passing (refresh-on-expiry, no-endpoint, unreachable-endpoint, valid-token-no-op, refresher-no-endpoint-null).</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>SEC</td>
+    <td>Tokens (access/refresh) must never be written to the Gateway log (DT-05 carry-over).</td>
+    <td>No token text in the log.</td>
+    <td>Seed and rotated refresh-token plaintext markers both ABSENT from the log file; only outcomes are logged.</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Proof harness output</h2>
+<p>Run against a local in-process Kestrel stub of the backend refresh-exchange endpoint, exercising the real
+<code>GatewayHttpTokenRefresher</code> + <code>DevThrottleAccountService</code> + <code>GatewayTokenRefreshService</code>.
+Full capture in <code>proof-output.txt</code>.</p>
+<pre>CRITERION 1: PASS - expired token + stub endpoint -> exchanged, stored a fresh non-expired pair (stub got the cached refresh token once)
+CRITERION 2: PASS - no endpoint configured -> cached credential kept unchanged, unavailability logged, no crash
+CRITERION 2b: PASS - configured-but-unreachable endpoint -> cached credential kept, no crash
+CRITERION 3: PASS - valid (unexpired) token -> no exchange (stub request count 0)
+CRITERION 4: PASS - Start() returned in 0 ms (0 exchanges); background sweep refreshed the token ~200 ms later
+SECURITY + LOGGING: PASS - seed + rotated refresh-token markers absent from the log; unavailability logged</pre>
+
+<h2>Log evidence (tokens never appear; outcomes do)</h2>
+<p>Selected lines from the run log. Full capture in <code>proof-log-lines.txt</code>.</p>
+<pre>[DevThrottleAccountService] RefreshIfNeededAsync: access token expired, attempting background refresh
+[GatewayHttpTokenRefresher] RefreshAsync: refreshed token pair received from the backend exchange
+[DevThrottleAccountService] RefreshIfNeededAsync: refreshed access token stored
+
+[GatewayHttpTokenRefresher] RefreshAsync: no refresh endpoint configured (DEVTHROTTLE_REFRESH_URL unset) -> refresh unavailable (cached credential kept)
+[DevThrottleAccountService] RefreshIfNeededAsync: refresh unavailable (offline or declined) -> keeping cached credential
+
+[GatewayHttpTokenRefresher] ExchangeAsync: refresh endpoint unreachable or unparseable -> refresh unavailable: ... (127.0.0.1:0)
+
+[DevThrottleAccountService] RefreshIfNeededAsync: access token still valid -> no refresh needed
+
+[GatewayTokenRefreshService] Start: background token refresh every 30s (first sweep in 0s)
+[GatewayTokenRefreshService] RefreshOnceAsync: access token renewed in the background
+[GatewayTokenRefreshService] Dispose: stopping background token refresh</pre>
+
+<div class="note">
+<strong>Backend dependency (provisional contract).</strong> The backend refresh-exchange endpoint is a flagged
+dependency (the issue's stated assumption). The refresh is therefore GATED on configuration
+(<code>DEVTHROTTLE_REFRESH_URL</code>) and proven against a local stub, exactly as the issue's proof target asks.
+The wire shape (<code>{ refresh_token }</code> in, <code>{ access_token, refresh_token }</code> out) is Supabase-shaped
+and provisional; it is isolated in <code>GatewayHttpTokenRefresher</code> and easy to adjust when the backend contract lands.
+</div>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security drift. The single network-touching seam (<code>ITokenRefresher</code>) already exists
+in the manifest; this only supplies a real implementation of it - no new container. Security rule DT-05 (never log
+the token) is upheld and proven above. Verdict: No drift.</p>
+
+<h2>Build and tests</h2>
+<pre>dotnet build cc-director.sln   -> Build succeeded. 0 Warning(s) 0 Error(s)
+dotnet test  (GatewayTokenRefreshTests) -> Passed: 5, Failed: 0, Skipped: 0</pre>
+
+</body>
+</html>

--- a/src/CcDirector.Gateway.Tests/Account/GatewayTokenRefreshTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/GatewayTokenRefreshTests.cs
@@ -1,0 +1,272 @@
+using System.Net;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Account;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Tests the Gateway-owned token refresh (issue #640, Gateway Centralization Phase 2). Verifies the
+/// acceptance criteria: with an expired-but-well-formed access token and a refresh endpoint configured
+/// (a local stub), the Gateway exchanges the refresh token and stores a fresh valid pair so the install
+/// flips back to a non-expired signed-in token (criterion 1); with NO refresh endpoint configured the
+/// Gateway keeps the cached credential, no exchange happens, and it does not crash (criterion 2); a
+/// still-valid access token triggers NO refresh call at all (criterion 3). The refresh-on-expiry and
+/// no-op paths are driven through <see cref="DevThrottleAccountService.RefreshIfNeededAsync"/> (the exact
+/// path the background sweep runs), so the decision logic is exercised end-to-end against the real
+/// <see cref="GatewayHttpTokenRefresher"/>.
+///
+/// The credential store under test is the real Windows Data Protection store, so the store/load round-trip
+/// of the renewed pair is exercised on disk (the facts no-op on a non-Windows host - the operating-system
+/// credential store is Windows-only for now, the #636 assumption). The class is annotated
+/// [SupportedOSPlatform("windows")] so the platform-compatibility analyzer is satisfied.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class GatewayTokenRefreshTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _blobPath;
+    private readonly string _authEventsPath;
+
+    public GatewayTokenRefreshTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-gw-refresh-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _blobPath = Path.Combine(_tempDir, "devthrottle-credential.bin");
+        _authEventsPath = Path.Combine(_tempDir, "devthrottle-auth-events.jsonl");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static bool OnWindows => OperatingSystem.IsWindows();
+
+    /// <summary>
+    /// Builds a Gateway credential service over the real Windows Data Protection store at the temp blob
+    /// path, wired with the supplied refresher, so the refresh decision runs end-to-end. The signing
+    /// secret env var is set and restored around construction so test-issued tokens validate.
+    /// </summary>
+    private DevThrottleAccountService MakeService(ITokenRefresher refresher)
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar);
+        Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, GatewayTestJwt.SigningSecret);
+        try
+        {
+            var store = new WindowsProtectedTokenStore(_blobPath);
+            var validator = new JwtAccessTokenValidator(GatewayTestJwt.SigningSecret);
+            var eventLog = new AuthEventLog(_authEventsPath);
+            return new DevThrottleAccountService(store, validator, eventLog, refresher);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, previous);
+        }
+    }
+
+    // Criterion 1: with an expired-but-well-formed access token and a refresh endpoint configured (a local
+    // stub), the Gateway exchanges the refresh token and stores a fresh valid pair - the install flips from
+    // expired back to a non-expired, signed-in token.
+    [Fact]
+    public async Task RefreshIfNeeded_ExpiredTokenWithStubEndpoint_StoresFreshValidPair()
+    {
+        if (!OnWindows) return;
+
+        await using var stub = await RefreshStub.StartAsync(requestRefreshToken =>
+        {
+            // The backend issues a brand-new, unexpired access token plus a rotated refresh token.
+            var freshAccess = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+            return (freshAccess, "rotated-refresh-token");
+        });
+
+        var refresher = new GatewayHttpTokenRefresher(new HttpClient(), () => stub.Url);
+        var service = MakeService(refresher);
+
+        // Seed an EXPIRED but correctly-signed access token (well-formed -> renewable).
+        var expiredAccess = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(-1));
+        service.StoreTokens(new DevThrottleTokens(expiredAccess, "seed-refresh-token"));
+        Assert.True(service.IsLoggedIn());                 // expired-but-well-formed still reports signed-in
+        Assert.True(IsExpired(expiredAccess));             // the seeded token is genuinely past its expiry
+
+        var refreshed = await service.RefreshIfNeededAsync();
+
+        Assert.True(refreshed);
+        Assert.Equal("seed-refresh-token", stub.LastRefreshToken);   // the backend received the cached refresh token
+        // The stored access token is now non-expired: signed-in AND forwardable as a current token.
+        var forwardable = service.GetAccessTokenForForwarding();
+        Assert.NotNull(forwardable);
+        Assert.False(IsExpired(forwardable));
+    }
+
+    // Criterion 2: with NO refresh endpoint configured, the Gateway keeps the cached credential (the expired
+    // token is untouched), no exchange happens, and nothing crashes.
+    [Fact]
+    public async Task RefreshIfNeeded_ExpiredTokenNoEndpoint_KeepsCachedCredential()
+    {
+        if (!OnWindows) return;
+
+        // The refresher resolves NO endpoint (the DEVTHROTTLE_REFRESH_URL-unset path), so it reports refresh
+        // unavailable without any network call.
+        var refresher = new GatewayHttpTokenRefresher(new HttpClient(), () => null);
+        var service = MakeService(refresher);
+
+        var expiredAccess = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(-1));
+        service.StoreTokens(new DevThrottleTokens(expiredAccess, "seed-refresh-token"));
+
+        var refreshed = await service.RefreshIfNeededAsync();
+
+        Assert.False(refreshed);                            // no renewal performed
+        // The cached credential is kept unchanged - still signed-in (well-formed) on the SAME expired token.
+        var store = new WindowsProtectedTokenStore(_blobPath);
+        var kept = store.Load();
+        Assert.NotNull(kept);
+        Assert.Equal(expiredAccess, kept.AccessToken);
+        Assert.Equal("seed-refresh-token", kept.RefreshToken);
+    }
+
+    // Criterion 2 (unreachable endpoint variant): a configured-but-unreachable endpoint also keeps the
+    // cached credential and does not crash - the same null "refresh unavailable" signal, no hiding fallback.
+    [Fact]
+    public async Task RefreshIfNeeded_ExpiredTokenUnreachableEndpoint_KeepsCachedCredential()
+    {
+        if (!OnWindows) return;
+
+        // A configured URL that nothing is listening on. A short timeout keeps the test fast.
+        var unreachableUrl = "http://127.0.0.1:0/refresh";
+        var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        var refresher = new GatewayHttpTokenRefresher(http, () => unreachableUrl);
+        var service = MakeService(refresher);
+
+        var expiredAccess = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(-1));
+        service.StoreTokens(new DevThrottleTokens(expiredAccess, "seed-refresh-token"));
+
+        var refreshed = await service.RefreshIfNeededAsync();
+
+        Assert.False(refreshed);
+        var store = new WindowsProtectedTokenStore(_blobPath);
+        var kept = store.Load();
+        Assert.NotNull(kept);
+        Assert.Equal(expiredAccess, kept.AccessToken);
+    }
+
+    // Criterion 3: a still-valid (unexpired) access token triggers NO refresh call - the stub never receives
+    // a request.
+    [Fact]
+    public async Task RefreshIfNeeded_ValidToken_TriggersNoExchange()
+    {
+        if (!OnWindows) return;
+
+        await using var stub = await RefreshStub.StartAsync(_ =>
+            (GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1)), "rotated-refresh-token"));
+
+        var refresher = new GatewayHttpTokenRefresher(new HttpClient(), () => stub.Url);
+        var service = MakeService(refresher);
+
+        var validAccess = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        service.StoreTokens(new DevThrottleTokens(validAccess, "seed-refresh-token"));
+
+        var refreshed = await service.RefreshIfNeededAsync();
+
+        Assert.False(refreshed);                            // no renewal
+        Assert.Equal(0, stub.RequestCount);                 // the backend was never called
+    }
+
+    // The refresher itself, no endpoint configured: returns null directly (the unit beneath the service).
+    [Fact]
+    public async Task GatewayHttpTokenRefresher_NoEndpoint_ReturnsNull()
+    {
+        var refresher = new GatewayHttpTokenRefresher(new HttpClient(), () => null);
+
+        var result = await refresher.RefreshAsync("any-refresh-token");
+
+        Assert.Null(result);
+    }
+
+    /// <summary>True when the access token's exp claim is in the past (used to assert expiry flips).</summary>
+    private static bool IsExpired(string accessToken)
+    {
+        var parts = accessToken.Split('.');
+        var payloadJson = DecodeSegment(parts[1]);
+        using var doc = JsonDocument.Parse(payloadJson);
+        var exp = doc.RootElement.GetProperty("exp").GetInt64();
+        return DateTimeOffset.FromUnixTimeSeconds(exp).UtcDateTime <= DateTime.UtcNow;
+    }
+
+    private static string DecodeSegment(string segment)
+    {
+        var normalized = segment.Replace('-', '+').Replace('_', '/');
+        switch (normalized.Length % 4)
+        {
+            case 2: normalized += "=="; break;
+            case 3: normalized += "="; break;
+        }
+        return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(normalized));
+    }
+
+    /// <summary>
+    /// A local in-process stub of the backend refresh-exchange endpoint. Stands up a Kestrel server on a
+    /// loopback port that answers the refresh POST with a caller-supplied { access_token, refresh_token }
+    /// pair, recording how many times it was called and the last refresh token it received - so the tests
+    /// can assert the exchange happened (or did not) without the live backend.
+    /// </summary>
+    private sealed class RefreshStub : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+
+        public string Url { get; }
+        public int RequestCount { get; private set; }
+        public string? LastRefreshToken { get; private set; }
+
+        private RefreshStub(WebApplication app, string url)
+        {
+            _app = app;
+            Url = url;
+        }
+
+        public static async Task<RefreshStub> StartAsync(Func<string, (string AccessToken, string RefreshToken)> issue)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));   // OS-assigned free port
+            var app = builder.Build();
+
+            RefreshStub? self = null;
+            app.MapPost("/refresh", async (HttpContext ctx) =>
+            {
+                using var doc = await JsonDocument.ParseAsync(ctx.Request.Body);
+                var receivedRefresh = doc.RootElement.GetProperty("refresh_token").GetString() ?? "";
+                if (self is not null)
+                {
+                    self.RequestCount++;
+                    self.LastRefreshToken = receivedRefresh;
+                }
+                var (access, refresh) = issue(receivedRefresh);
+                return Results.Json(new Dictionary<string, string>
+                {
+                    ["access_token"] = access,
+                    ["refresh_token"] = refresh,
+                });
+            });
+
+            await app.StartAsync();
+            var address = app.Urls.First();
+            self = new RefreshStub(app, address.TrimEnd('/') + "/refresh");
+            return self;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
+++ b/src/CcDirector.Gateway/Account/GatewayAccountFactory.cs
@@ -31,6 +31,13 @@ public static class GatewayAccountFactory
     public const string TestSeedTokenEnvVar = "DEVTHROTTLE_TEST_SEED_TOKEN";
 
     /// <summary>
+    /// The environment variable that configures the backend refresh-exchange endpoint the Gateway-owned
+    /// token refresher (issue #640) uses. Mirrors <see cref="GatewayHttpTokenRefresher.RefreshUrlEnvVar"/>;
+    /// when unset the refresher reports refresh unavailable and the cached credential is kept.
+    /// </summary>
+    public const string RefreshUrlEnvVar = GatewayHttpTokenRefresher.RefreshUrlEnvVar;
+
+    /// <summary>
     /// Creates the Gateway-hosted credential service on Windows, using Windows Data Protection as the
     /// credential store under the Gateway config directory. Honors the signing-secret and test-seed
     /// environment variables (see the type summary) so the "credential present" outcomes can be proven
@@ -63,7 +70,13 @@ public static class GatewayAccountFactory
 
         var validator = new JwtAccessTokenValidator(ResolveSigningSecret());
         var eventLog = new AuthEventLog(authEventsLogPath);
-        var refresher = new BackendUnavailableTokenRefresher();
+        // Issue #640: the real Gateway-owned token refresher replaces the no-op
+        // BackendUnavailableTokenRefresher. It exchanges an expired token's refresh token for a fresh
+        // pair against the backend ONLY when DEVTHROTTLE_REFRESH_URL is configured; with no endpoint
+        // configured (or it unreachable) it reports refresh unavailable and the caller keeps the cached
+        // credential (no fallback that hides the failure). A short timeout keeps a slow/unreachable
+        // backend from holding a background refresh pass open. Tokens are never logged.
+        var refresher = new GatewayHttpTokenRefresher(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
 
         FileLog.Write("[GatewayAccountFactory] Build: Gateway credential service constructed");
         return new DevThrottleAccountService(store, validator, eventLog, refresher);

--- a/src/CcDirector.Gateway/Account/GatewayHttpTokenRefresher.cs
+++ b/src/CcDirector.Gateway/Account/GatewayHttpTokenRefresher.cs
@@ -1,0 +1,152 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Account;
+
+/// <summary>
+/// The real <see cref="ITokenRefresher"/> on the Gateway (issue #640, Gateway Centralization Phase 2):
+/// it exchanges an expired-but-well-formed access token's refresh token for a fresh access-plus-refresh
+/// pair against the DevThrottle backend, so the fleet stays authorized without a re-sign-in. It replaces
+/// the no-op <see cref="BackendUnavailableTokenRefresher"/> that was wired in until the backend exchange
+/// existed.
+///
+/// The refresh exchange is GATED ON CONFIGURATION: it runs only when a refresh endpoint is configured via
+/// the <c>DEVTHROTTLE_REFRESH_URL</c> environment variable. The backend refresh-exchange contract is a
+/// flagged dependency (the issue's stated assumption), so until an operator points the Gateway at a real
+/// endpoint this refresher reports refresh as unavailable (returns null) and the caller keeps running on
+/// the cached credential. That is the project's explicit no-fallback behaviour - the SAME null signal the
+/// refresher returns when the endpoint is unreachable - never a fallback that hides a failure.
+///
+/// Wire contract (PROVISIONAL, Supabase-shaped, pending the backend contract): a POST whose JSON body is
+/// <c>{ "refresh_token": "..." }</c>, answered with <c>{ "access_token": "...", "refresh_token": "..." }</c>.
+/// A non-success status, an unreachable endpoint, or a response missing either token is treated as
+/// "refresh unavailable" (null), logged without the token values.
+///
+/// Security rule DT-05 (carried over from #636/#637): the access and refresh tokens are NEVER written to
+/// the log on any path - only the outcome (exchanged / unavailable-with-reason) is logged.
+/// </summary>
+public sealed class GatewayHttpTokenRefresher : ITokenRefresher
+{
+    /// <summary>The environment variable that configures the backend refresh-exchange endpoint on the Gateway.</summary>
+    public const string RefreshUrlEnvVar = "DEVTHROTTLE_REFRESH_URL";
+
+    private readonly HttpClient _http;
+    private readonly Func<string?> _resolveRefreshUrl;
+
+    /// <summary>
+    /// Creates the refresher over an HTTP client and a refresh-URL resolver.
+    /// </summary>
+    /// <param name="http">
+    /// The HTTP client used for the exchange. A short timeout is the caller's responsibility so a
+    /// slow/unreachable backend never holds a refresh pass open (the background loop is best-effort).
+    /// </param>
+    /// <param name="resolveRefreshUrl">
+    /// Resolves the configured refresh endpoint, or null when none is configured. Defaults to
+    /// <see cref="ResolveRefreshUrl"/> (reads <see cref="RefreshUrlEnvVar"/>); tests inject a fixed
+    /// resolver so the configured and unconfigured paths are both provable.
+    /// </param>
+    public GatewayHttpTokenRefresher(HttpClient http, Func<string?>? resolveRefreshUrl = null)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _resolveRefreshUrl = resolveRefreshUrl ?? ResolveRefreshUrl;
+    }
+
+    /// <summary>
+    /// Resolves the configured backend refresh endpoint: the <see cref="RefreshUrlEnvVar"/> environment
+    /// value when set (trimmed, non-empty), otherwise null. There is no default - forwarding only happens
+    /// when an operator has explicitly pointed the Gateway at a refresh endpoint (the backend contract is a
+    /// flagged dependency, the same gating the startup-telemetry endpoint uses).
+    /// </summary>
+    public static string? ResolveRefreshUrl()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable(RefreshUrlEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv.Trim();
+        return null;
+    }
+
+    /// <summary>
+    /// Exchanges the refresh token for a fresh pair against the configured endpoint. Returns the new pair
+    /// when the exchange succeeds, or null when no endpoint is configured, the endpoint is unreachable, the
+    /// backend declines, or the response is missing either token - in which case the caller keeps running
+    /// on the cached credential. The tokens are never logged.
+    /// </summary>
+    public async Task<DevThrottleTokens?> RefreshAsync(string refreshToken, CancellationToken ct = default)
+    {
+        FileLog.Write("[GatewayHttpTokenRefresher] RefreshAsync: evaluating configured refresh endpoint");
+
+        var url = _resolveRefreshUrl();
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            // No endpoint configured: report refresh unavailable. This is the expected Phase 2 state until
+            // the backend exchange contract is provided - not a fallback that hides a failure. The caller
+            // keeps the cached credential.
+            FileLog.Write($"[GatewayHttpTokenRefresher] RefreshAsync: no refresh endpoint configured ({RefreshUrlEnvVar} unset) -> refresh unavailable (cached credential kept)");
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(refreshToken))
+        {
+            FileLog.Write("[GatewayHttpTokenRefresher] RefreshAsync: no refresh token on the cached credential -> cannot exchange (cached credential kept)");
+            return null;
+        }
+
+        var renewed = await ExchangeAsync(url, refreshToken, ct).ConfigureAwait(false);
+        FileLog.Write(renewed is null
+            ? "[GatewayHttpTokenRefresher] RefreshAsync: refresh unavailable (endpoint unreachable or declined) -> cached credential kept"
+            : "[GatewayHttpTokenRefresher] RefreshAsync: refreshed token pair received from the backend exchange");
+        return renewed;
+    }
+
+    /// <summary>
+    /// Performs the single refresh exchange POST and parses the renewed pair. Returns null on any expected
+    /// failure - a connectivity error, a non-success status, or a response missing either token - so the
+    /// caller keeps the cached credential. Owns its try/catch because it is the network boundary; the
+    /// failure is logged WITHOUT the token values (DT-05).
+    /// </summary>
+    private async Task<DevThrottleTokens?> ExchangeAsync(string url, string refreshToken, CancellationToken ct)
+    {
+        try
+        {
+            using var response = await _http.PostAsJsonAsync(
+                url,
+                new RefreshRequest(refreshToken),
+                ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                FileLog.Write($"[GatewayHttpTokenRefresher] ExchangeAsync: backend declined the refresh (status {(int)response.StatusCode}) -> refresh unavailable");
+                return null;
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<RefreshResponse>(ct).ConfigureAwait(false);
+            if (payload is null
+                || string.IsNullOrWhiteSpace(payload.AccessToken)
+                || string.IsNullOrWhiteSpace(payload.RefreshToken))
+            {
+                FileLog.Write("[GatewayHttpTokenRefresher] ExchangeAsync: backend response was missing the access or refresh token -> refresh unavailable");
+                return null;
+            }
+
+            return new DevThrottleTokens(payload.AccessToken, payload.RefreshToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            // Connectivity failure, timeout, or an unparseable response: report refresh unavailable so the
+            // caller keeps the cached credential. The exception message is safe to log (it carries no token).
+            FileLog.Write($"[GatewayHttpTokenRefresher] ExchangeAsync: refresh endpoint unreachable or unparseable -> refresh unavailable: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>The refresh-exchange request body (Supabase-shaped, provisional).</summary>
+    private sealed record RefreshRequest(
+        [property: System.Text.Json.Serialization.JsonPropertyName("refresh_token")] string RefreshToken);
+
+    /// <summary>The refresh-exchange response body (Supabase-shaped, provisional).</summary>
+    private sealed record RefreshResponse(
+        [property: System.Text.Json.Serialization.JsonPropertyName("access_token")] string? AccessToken,
+        [property: System.Text.Json.Serialization.JsonPropertyName("refresh_token")] string? RefreshToken);
+}

--- a/src/CcDirector.Gateway/Account/GatewayTokenRefreshService.cs
+++ b/src/CcDirector.Gateway/Account/GatewayTokenRefreshService.cs
@@ -1,0 +1,116 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Account;
+
+/// <summary>
+/// Runs the Gateway-owned token refresh in the BACKGROUND (issue #640, Gateway Centralization Phase 2):
+/// a small timer that periodically asks the Gateway-hosted credential service to renew its access token
+/// when it has expired. It NEVER blocks Gateway startup or request handling - <see cref="Start"/> returns
+/// immediately, the first sweep runs after a short delay, and each sweep is fire-and-forget with the
+/// boundary try/catch the timer callback owns so a refresh failure never crashes the timer thread.
+///
+/// The decision of WHETHER to refresh lives entirely in <see cref="DevThrottleAccountService.RefreshIfNeededAsync"/>:
+/// a still-valid access token is a no-op (no exchange, no network call), an expired-but-well-formed token
+/// triggers the backend exchange via the configured <see cref="GatewayHttpTokenRefresher"/>, and a
+/// tampered token is left alone. When the refresh endpoint is unconfigured or unreachable the service keeps
+/// the cached credential and logs the unavailability - never a fallback that hides the failure.
+///
+/// Security rule DT-05 (carried over from #636/#637): the access and refresh tokens are never written to
+/// the log - only the outcome (refreshed / no-op / unavailable) is, all of it inside the account service.
+/// </summary>
+public sealed class GatewayTokenRefreshService : IDisposable
+{
+    /// <summary>How long after <see cref="Start"/> the first background refresh sweep runs.</summary>
+    public static readonly TimeSpan DefaultStartDelay = TimeSpan.FromSeconds(10);
+
+    /// <summary>How often the background refresh sweep re-evaluates the cached credential.</summary>
+    public static readonly TimeSpan DefaultSweepInterval = TimeSpan.FromMinutes(5);
+
+    private readonly DevThrottleAccountService _account;
+    private readonly TimeSpan _startDelay;
+    private readonly TimeSpan _sweepInterval;
+    private Timer? _timer;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates the background refresh service over the Gateway-hosted credential service.
+    /// </summary>
+    /// <param name="account">The Gateway-hosted DevThrottle credential service whose token is refreshed. Required.</param>
+    /// <param name="startDelay">Delay before the first sweep; defaults to <see cref="DefaultStartDelay"/>. Tests pass a short delay.</param>
+    /// <param name="sweepInterval">Interval between sweeps; defaults to <see cref="DefaultSweepInterval"/>. Tests pass a short interval.</param>
+    public GatewayTokenRefreshService(DevThrottleAccountService account, TimeSpan? startDelay = null, TimeSpan? sweepInterval = null)
+    {
+        _account = account ?? throw new ArgumentNullException(nameof(account));
+        _startDelay = startDelay ?? DefaultStartDelay;
+        _sweepInterval = sweepInterval ?? DefaultSweepInterval;
+    }
+
+    /// <summary>
+    /// Starts the background refresh timer. Returns immediately - the first sweep runs after the start
+    /// delay, then every sweep interval - so this never blocks the caller (Gateway startup). A second call
+    /// is a no-op (the timer is already running).
+    /// </summary>
+    public void Start()
+    {
+        FileLog.Write($"[GatewayTokenRefreshService] Start: background token refresh every {_sweepInterval.TotalSeconds:0}s (first sweep in {_startDelay.TotalSeconds:0}s)");
+        if (_timer is not null)
+        {
+            FileLog.Write("[GatewayTokenRefreshService] Start: already started -> no-op");
+            return;
+        }
+
+        _timer = new Timer(_ => Sweep(), null, _startDelay, _sweepInterval);
+    }
+
+    /// <summary>
+    /// The timer callback (a boundary - it owns the try/catch so a refresh failure never crashes the timer
+    /// thread). Fires the background refresh fire-and-forget; the decision to actually exchange (and all
+    /// token handling) is the account service's, never blocking and never logging the tokens.
+    /// </summary>
+    private void Sweep()
+    {
+        try
+        {
+            _ = RefreshOnceAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayTokenRefreshService] Sweep FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Runs a single background refresh pass. Awaits the account service's refresh decision and logs the
+    /// outcome; any error is contained here (the sweep is best-effort) so it never propagates into the
+    /// timer thread. The tokens are never logged.
+    /// </summary>
+    private async Task RefreshOnceAsync()
+    {
+        try
+        {
+            var refreshed = await _account.RefreshIfNeededAsync(CancellationToken.None).ConfigureAwait(false);
+            FileLog.Write(refreshed
+                ? "[GatewayTokenRefreshService] RefreshOnceAsync: access token renewed in the background"
+                : "[GatewayTokenRefreshService] RefreshOnceAsync: no renewal performed (token still valid, or refresh unavailable -> cached credential kept)");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayTokenRefreshService] RefreshOnceAsync FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Stops the background refresh timer. Safe to call more than once.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        FileLog.Write("[GatewayTokenRefreshService] Dispose: stopping background token refresh");
+        _timer?.Dispose();
+        _timer = null;
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -116,6 +116,16 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     public Account.GatewaySignInService? SignIn { get; }
 
+    /// <summary>
+    /// Issue #640 (Gateway Centralization Phase 2): the background token refresh service. Built over
+    /// <see cref="Account"/>, it periodically renews the Gateway's access token when it has expired by
+    /// exchanging the refresh token against the configured backend endpoint - in the background, never
+    /// blocking startup or request handling. Null on a host with no credential service (a non-Windows host,
+    /// where <see cref="Account"/> is null). Started in <see cref="StartAsync"/>, disposed in
+    /// <see cref="StopAsync"/>. Tokens are never logged.
+    /// </summary>
+    private Account.GatewayTokenRefreshService? _tokenRefresh;
+
     private readonly DirectorEndpointClient _client;
     private readonly TailscaleServeProvisioner _serveProvisioner;
     private readonly GatewayTurnBriefStore _turnBriefStore;
@@ -321,6 +331,15 @@ public sealed class GatewayHost : IAsyncDisposable
             SignIn = new Account.GatewaySignInService(Account);
         else
             FileLog.Write("[GatewayHost] DevThrottle sign-in flow not built: no credential service on this host");
+
+        // The Gateway-owned background token refresh (issue #640, Gateway Centralization Phase 2). Built
+        // over the credential service, so it exists only when that service does - on a host with no
+        // credential service there is no token to refresh. Constructed here; the timer is started in
+        // StartAsync (so it never blocks construction) and disposed in StopAsync.
+        if (Account is not null)
+            _tokenRefresh = new Account.GatewayTokenRefreshService(Account);
+        else
+            FileLog.Write("[GatewayHost] DevThrottle token refresh not built: no credential service on this host");
     }
 
     /// <summary>
@@ -782,6 +801,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // delivers) and every event the relay enqueues going forward, in FIFO order, retrying with
         // backoff while the backend is unreachable.
         _telemetryQueue.StartFlushing();
+
+        // Issue #640: start the Gateway-owned background token refresh. Start() returns immediately (the
+        // first sweep runs after a short delay), so this never blocks startup. When the cached access
+        // token has expired and a refresh endpoint is configured, the sweep exchanges the refresh token
+        // for a fresh pair; otherwise it is a no-op or keeps the cached credential. Null on a host with no
+        // credential service.
+        _tokenRefresh?.Start();
     }
 
     /// <summary>
@@ -811,6 +837,10 @@ public sealed class GatewayHost : IAsyncDisposable
 
         try { _endpointMonitor?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] endpoint monitor dispose error: {ex.Message}"); }
         _endpointMonitor = null;
+
+        // Issue #640: stop the background token refresh timer.
+        try { _tokenRefresh?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] token refresh dispose error: {ex.Message}"); }
+        _tokenRefresh = null;
 
         // Issue #629: stop the telemetry retry-queue flusher. The queue file is written through on
         // every mutation, so any undelivered events are already on disk and reload on the next start -


### PR DESCRIPTION
Closes #640.

## Release Notes
Token refresh is now the Gateway's job. When the Gateway's cached DevThrottle access token has expired, the Gateway exchanges the refresh token for a fresh pair in the background so the fleet stays authorized without a re-sign-in. The exchange is gated on a configured refresh endpoint; with none configured (or unreachable) the cached credential is kept and the unavailability is logged.

## Changes
- New `GatewayHttpTokenRefresher` (real `ITokenRefresher`) replaces the no-op `BackendUnavailableTokenRefresher` in the Gateway credential service. Gated on `DEVTHROTTLE_REFRESH_URL`; POSTs `{ refresh_token }` and parses `{ access_token, refresh_token }`. A connectivity error / non-success status / missing-token response is treated as "refresh unavailable" (null) and logged without the token values.
- New `GatewayTokenRefreshService`: background timer that calls `DevThrottleAccountService.RefreshIfNeededAsync` fire-and-forget. `Start()` returns immediately, so it never blocks startup or request handling. Started in `GatewayHost.StartAsync`, disposed in `StopAsync`.
- `GatewayAccountFactory` wires the real refresher (short-timeout `HttpClient`).
- `GatewayTokenRefreshTests`: five unit tests.

## How to Test
- `dotnet build cc-director.sln` -> clean.
- `dotnet test src/CcDirector.Gateway.Tests` filtered to `GatewayTokenRefreshTests` -> 5 pass.
- Proof harness output and log evidence: `docs/cencon/proof/issue-640/report.html`.

## Expected Result
- Criterion 1: expired token + configured stub endpoint -> exchanged, stored a fresh non-expired pair (signed-in flips back to non-expired). PASS
- Criterion 2: no endpoint / unreachable -> cached credential kept, unavailability logged, no crash, no hiding fallback. PASS
- Criterion 3: valid token -> no exchange (zero backend requests). PASS
- Criterion 4: refresh runs in the background; `Start()` returns immediately and the sweep refreshes later. PASS
- Criterion 5: unit tests cover all three required cases. PASS
- Security: access/refresh tokens never written to the log (DT-05). PASS

## Before / After
- Before: `BackendUnavailableTokenRefresher` always returned null - the Gateway never renewed an expired token.
- After: the Gateway renews an expired token in the background against the configured backend endpoint, and keeps the cached credential with a clear log line when no endpoint is configured or it is unreachable.

Proof: docs/cencon/proof/issue-640/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)