### PR TITLE
Installer: skip the Sign-in step for the Workstation role

### DIFF
--- a/scripts/test/drive-workstation-install.ps1
+++ b/scripts/test/drive-workstation-install.ps1
@@ -1,0 +1,132 @@
+# Non-destructive UI test of the installer's Workstation path (skip Sign-in).
+# Launches the built cc-director-setup.exe, selects the "I already have a gateway" (Workstation) card,
+# and asserts the step rail drops the Sign-in step and that advancing past Prerequisites lands on the
+# Privacy step ("A quick, honest note"), NOT the Sign-in step ("Sign in to DevThrottle").
+# It NEVER reaches the Install step, so nothing is installed. It then closes the installer it launched.
+$ErrorActionPreference = "Stop"
+
+$exe    = "D:\ReposFred\devthrottle\tools\cc-director-setup\bin\Release\net10.0-windows\win-x64\publish\cc-director-setup.exe"
+$shotDir = Join-Path $env:TEMP "cc-setup-wstest"
+$capture = "D:\ReposFred\devthrottle\scripts\capture-window.ps1"
+New-Item -ItemType Directory -Force -Path $shotDir | Out-Null
+
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+$AE = [System.Windows.Automation.AutomationElement]
+$TS = [System.Windows.Automation.TreeScope]
+
+function Get-Window([int]$procId) {
+    $cond = New-Object System.Windows.Automation.PropertyCondition($AE::ProcessIdProperty, $procId)
+    for ($i = 0; $i -lt 40; $i++) {
+        $w = $AE::RootElement.FindFirst($TS::Children, $cond)
+        if ($w) { return $w }
+        Start-Sleep -Milliseconds 300
+    }
+    return $null
+}
+function ById($root, [string]$id) {
+    $cond = New-Object System.Windows.Automation.PropertyCondition($AE::AutomationIdProperty, $id)
+    return $root.FindFirst($TS::Descendants, $cond)
+}
+function ByName($root, [string]$name) {
+    $cond = New-Object System.Windows.Automation.PropertyCondition($AE::NameProperty, $name)
+    return $root.FindFirst($TS::Descendants, $cond)
+}
+function Invoke-El($el) { $el.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke() }
+function Select-El($el) { $el.GetCurrentPattern([System.Windows.Automation.SelectionItemPattern]::Pattern).Select() }
+function Shot([int]$procId, [string]$name) {
+    & $capture -TargetPid $procId -OutPath (Join-Path $shotDir $name) | Out-Null
+    Write-Host "  shot: $name"
+}
+function VisibleSteps($win) {
+    # Read the rail circle numbers that are present (collapsed rows are absent from the UIA tree).
+    $nums = @()
+    foreach ($n in 2..7) {
+        $el = ById $win "Step$($n)Num"
+        if ($el) { $nums += $el.Current.Name }
+    }
+    return ,$nums
+}
+function StepLabels($win) {
+    $labels = @()
+    foreach ($n in 1..7) {
+        $el = ById $win "Step$($n)Label"
+        if ($el) { $labels += $el.Current.Name }
+    }
+    return ,$labels
+}
+
+# Force fresh-install mode so the role picker appears (this machine already has a real install).
+# The override changes ONLY the wizard's install DETECTION, pointed at an empty scratch root; it never
+# redirects an actual install, and this test never reaches the Install step anyway.
+$freshRoot = Join-Path $env:TEMP "cc-setup-wstest-emptyroot"
+New-Item -ItemType Directory -Force -Path $freshRoot | Out-Null
+$env:CC_DIRECTOR_SETUP_INSTALL_ROOT = $freshRoot
+
+$proc = Start-Process -FilePath $exe -PassThru
+$procId = $proc.Id
+Write-Host "Launched installer pid=$procId"
+$win = Get-Window $procId
+if (-not $win) { Write-Host "RESULT: FAIL - no installer window"; Stop-Process -Id $procId -Force; exit 1 }
+Start-Sleep -Milliseconds 900
+
+$fail = @()
+
+# --- Welcome, default (Gateway pre-selected): rail should INCLUDE Sign in ---
+Shot $procId "01-welcome-default-gateway.png"
+$labelsDefault = StepLabels $win
+Write-Host "Welcome (default) rail labels: $($labelsDefault -join ' | ')"
+if ($labelsDefault -notcontains "Sign in") { $fail += "Default Gateway rail is missing the 'Sign in' step." }
+
+# --- Select Workstation: 'I already have a gateway' ---
+$ws = ById $win "HaveGatewayRadio"
+if (-not $ws) { Write-Host "RESULT: FAIL - HaveGatewayRadio not found"; Stop-Process -Id $procId -Force; exit 1 }
+Select-El $ws
+Start-Sleep -Milliseconds 700
+Shot $procId "02-welcome-workstation.png"
+$labelsWs = StepLabels $win
+$numsWs   = VisibleSteps $win
+Write-Host "Welcome (workstation) rail labels: $($labelsWs -join ' | ')"
+Write-Host "Welcome (workstation) circle numbers (steps 2..n): $($numsWs -join ' ')"
+if ($labelsWs -contains "Sign in") { $fail += "Workstation rail STILL shows the 'Sign in' step." }
+# After dropping Sign-in, the six visible steps renumber 1..6, so circles 2..7's rendered numbers are 2..6.
+if (($numsWs -join ' ') -ne "2 3 4 5 6") { $fail += "Workstation rail numbers not renumbered cleanly (got '$($numsWs -join ' ')', expected '2 3 4 5 6')." }
+
+# --- Welcome -> Prerequisites ---
+Invoke-El (ById $win "NextButton")
+Start-Sleep -Milliseconds 1500
+Shot $procId "03-prerequisites.png"
+$onPrereq = (ByName $win "Sign in to DevThrottle") -eq $null
+if (-not $onPrereq) { $fail += "Landed on the Sign-in step right after Welcome on the Workstation path." }
+
+# --- Prerequisites -> next visible step (must be Privacy, not Sign in) ---
+$next = ById $win "NextButton"
+$prereqNextEnabled = $next.Current.IsEnabled
+Write-Host "Prerequisites Next enabled: $prereqNextEnabled"
+if ($prereqNextEnabled) {
+    Invoke-El $next
+    Start-Sleep -Milliseconds 1200
+    Shot $procId "04-after-prereq.png"
+    $onPrivacy = (ByName $win "A quick, honest note") -ne $null
+    $onSignIn  = (ByName $win "Sign in to DevThrottle") -ne $null
+    Write-Host "After Prerequisites -> Privacy heading present: $onPrivacy ; Sign-in heading present: $onSignIn"
+    if ($onSignIn) { $fail += "Workstation path showed the Sign-in step after Prerequisites." }
+    if (-not $onPrivacy) { $fail += "Workstation path did NOT land on the Privacy step after Prerequisites." }
+} else {
+    Write-Host "NOTE: a required prerequisite is missing on this machine, so Next is disabled at step 2."
+    Write-Host "      The rail assertions above already prove Sign-in is dropped for the Workstation role."
+}
+
+# --- Close the installer we launched (this is cc-director-setup.exe, NOT cc-director.exe) ---
+Stop-Process -Id $procId -Force
+Write-Host ""
+if ($fail.Count -eq 0) {
+    Write-Host "RESULT: PASS - Workstation install skips the Sign-in step."
+    Write-Host "Screenshots: $shotDir"
+    exit 0
+} else {
+    Write-Host "RESULT: FAIL"
+    $fail | ForEach-Object { Write-Host "  - $_" }
+    Write-Host "Screenshots: $shotDir"
+    exit 1
+}

--- a/tools/cc-director-setup.Tests/WizardStepFlowTests.cs
+++ b/tools/cc-director-setup.Tests/WizardStepFlowTests.cs
@@ -1,0 +1,85 @@
+using CcDirector.Setup.Engine;
+using CcDirectorSetup.Services;
+using Xunit;
+
+namespace CcDirectorSetup.Tests;
+
+/// <summary>
+/// Tests for the wizard's role-aware step ordering. The in-wizard Sign-in step (step 3) applies only to a
+/// Gateway install; a Workstation connects to an existing Gateway and signs in there, so the wizard skips
+/// step 3 entirely for the Workstation role. These tests pin that the visible-step list, the forward/back
+/// navigation, and the SignInApplies predicate all agree on dropping Sign-in for a Workstation while a
+/// Gateway keeps the full 7-step flow.
+/// </summary>
+public sealed class WizardStepFlowTests
+{
+    [Fact]
+    public void VisibleSteps_Gateway_KeepsAllSevenStepsInOrder()
+    {
+        var steps = WizardStepFlow.VisibleSteps(InstallRole.Gateway);
+        Assert.Equal([1, 2, 3, 4, 5, 6, 7], steps);
+    }
+
+    [Fact]
+    public void VisibleSteps_Workstation_DropsSignInAndHasNoGap()
+    {
+        var steps = WizardStepFlow.VisibleSteps(InstallRole.Workstation);
+
+        // Sign-in (3) is gone and the remaining steps stay in order: 2 flows straight into Privacy (4).
+        Assert.Equal([1, 2, 4, 5, 6, 7], steps);
+        Assert.DoesNotContain(WizardStepFlow.StepSignIn, steps);
+    }
+
+    [Fact]
+    public void SignInApplies_OnlyForGateway()
+    {
+        Assert.True(WizardStepFlow.SignInApplies(InstallRole.Gateway));
+        Assert.False(WizardStepFlow.SignInApplies(InstallRole.Workstation));
+    }
+
+    [Fact]
+    public void NextStep_Workstation_SkipsSignInGoingForward()
+    {
+        // Leaving Prerequisites (2) lands on Privacy (4), not Sign-in (3).
+        Assert.Equal(4, WizardStepFlow.NextStep(2, InstallRole.Workstation));
+    }
+
+    [Fact]
+    public void NextStep_Gateway_LandsOnSignIn()
+    {
+        // The Gateway path still shows Sign-in (3) right after Prerequisites (2).
+        Assert.Equal(3, WizardStepFlow.NextStep(2, InstallRole.Gateway));
+    }
+
+    [Fact]
+    public void PrevStep_Workstation_SkipsSignInGoingBack()
+    {
+        // Back from Privacy (4) lands on Prerequisites (2), not Sign-in (3).
+        Assert.Equal(2, WizardStepFlow.PrevStep(4, InstallRole.Workstation));
+    }
+
+    [Fact]
+    public void PrevStep_Gateway_LandsOnSignIn()
+    {
+        Assert.Equal(3, WizardStepFlow.PrevStep(4, InstallRole.Gateway));
+    }
+
+    [Theory]
+    [InlineData(InstallRole.Gateway)]
+    [InlineData(InstallRole.Workstation)]
+    public void NextStep_WalkingForwardFromWelcome_VisitsExactlyTheVisibleSteps(InstallRole role)
+    {
+        var visible = WizardStepFlow.VisibleSteps(role);
+
+        // Walk from the first step using NextStep and confirm it reproduces the visible-step sequence.
+        var walked = new List<int> { visible[0] };
+        var step = visible[0];
+        while (step < visible[^1])
+        {
+            step = WizardStepFlow.NextStep(step, role);
+            walked.Add(step);
+        }
+
+        Assert.Equal(visible, walked);
+    }
+}

--- a/tools/cc-director-setup/MainWindow.xaml
+++ b/tools/cc-director-setup/MainWindow.xaml
@@ -41,7 +41,7 @@
                 <!-- Step indicators -->
                 <StackPanel x:Name="StepIndicators" VerticalAlignment="Top">
                     <!-- Step 1: Welcome -->
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="Step1Row" Orientation="Horizontal">
                         <Border x:Name="Step1Circle" Width="28" Height="28" CornerRadius="14"
                                 Background="{StaticResource AccentBrush}">
                             <TextBlock Text="1" Foreground="White" FontSize="13"
@@ -60,7 +60,7 @@
                             x:Name="Line12" />
 
                     <!-- Step 2: Prerequisites -->
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="Step2Row" Orientation="Horizontal">
                         <Border x:Name="Step2Circle" Width="28" Height="28" CornerRadius="14"
                                 Background="{StaticResource StepInactive}">
                             <TextBlock Text="2" Foreground="{StaticResource DimText}" FontSize="13"
@@ -80,7 +80,7 @@
                             x:Name="Line23" />
 
                     <!-- Step 3: Sign in (forced first-run sign-in, issue #657) -->
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="Step3Row" Orientation="Horizontal">
                         <Border x:Name="Step3Circle" Width="28" Height="28" CornerRadius="14"
                                 Background="{StaticResource StepInactive}">
                             <TextBlock Text="3" Foreground="{StaticResource DimText}" FontSize="13"
@@ -100,7 +100,7 @@
                             x:Name="Line34" />
 
                     <!-- Step 4: Privacy (telemetry consent, issue #659) -->
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="Step4Row" Orientation="Horizontal">
                         <Border x:Name="Step4Circle" Width="28" Height="28" CornerRadius="14"
                                 Background="{StaticResource StepInactive}">
                             <TextBlock Text="4" Foreground="{StaticResource DimText}" FontSize="13"
@@ -120,7 +120,7 @@
                             x:Name="Line45" />
 
                     <!-- Step 5: Skills -->
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="Step5Row" Orientation="Horizontal">
                         <Border x:Name="Step5Circle" Width="28" Height="28" CornerRadius="14"
                                 Background="{StaticResource StepInactive}">
                             <TextBlock Text="5" Foreground="{StaticResource DimText}" FontSize="13"
@@ -140,7 +140,7 @@
                             x:Name="Line56" />
 
                     <!-- Step 6: Install -->
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="Step6Row" Orientation="Horizontal">
                         <Border x:Name="Step6Circle" Width="28" Height="28" CornerRadius="14"
                                 Background="{StaticResource StepInactive}">
                             <TextBlock Text="6" Foreground="{StaticResource DimText}" FontSize="13"
@@ -160,7 +160,7 @@
                             x:Name="Line67" />
 
                     <!-- Step 7: Complete -->
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel x:Name="Step7Row" Orientation="Horizontal">
                         <Border x:Name="Step7Circle" Width="28" Height="28" CornerRadius="14"
                                 Background="{StaticResource StepInactive}">
                             <TextBlock Text="7" Foreground="{StaticResource DimText}" FontSize="13"

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -17,7 +17,10 @@ public partial class MainWindow : Window
     private int _skippedCount;
     private string _installPath = "";
     private string _directorExePath = "";
-    private InstallRole _role = InstallRole.Workstation;
+    // Default to Gateway so a fresh install's step rail matches the pre-selected "first machine" card
+    // (issue #645). Update mode overrides this from disk in the constructor; the live RoleSelected handler
+    // tracks the user toggling cards. The committed value is read from the Welcome step when leaving step 1.
+    private InstallRole _role = InstallRole.Gateway;
     private string? _gatewayResultMessage;
 
     private readonly bool _isUpdate;
@@ -38,11 +41,18 @@ public partial class MainWindow : Window
 
     // Wizard steps: 1 Welcome, 2 Prerequisites, 3 Sign in, 4 Privacy, 5 Skills, 6 Install, 7 Complete.
     // The forced sign-in (issue #657) and the Privacy step (issue #659) slot in after the prerequisite
-    // Checks; Privacy comes right after Sign in.
-    private const int StepSignIn = 3;
+    // Checks; Privacy comes right after Sign in. Sign in applies only to a Gateway install - a Workstation
+    // signs in through its Gateway, so the wizard skips step 3 entirely for the Workstation role.
+    private const int StepSignIn = WizardStepFlow.StepSignIn;
     private const int StepPrivacy = 4;
     private const int StepInstall = 6;
     private const int StepComplete = 7;
+
+    // Role-aware step ordering (skip Sign-in for a Workstation) lives in WizardStepFlow so it is
+    // unit-testable without constructing this WPF window. These thin members bind it to the current role.
+    private List<int> VisibleSteps() => WizardStepFlow.VisibleSteps(_role);
+    private int NextStep(int step) => WizardStepFlow.NextStep(step, _role);
+    private int PrevStep(int step) => WizardStepFlow.PrevStep(step, _role);
 
     public MainWindow()
     {
@@ -92,8 +102,14 @@ public partial class MainWindow : Window
         // they do. (Update mode hides the picker and never fires this.)
         step.RoleSelected += (_, _) =>
         {
-            if (_currentStep == 1)
-                NextButton.IsEnabled = true;
+            if (_currentStep != 1)
+                return;
+            NextButton.IsEnabled = true;
+            // Keep the step rail honest as the user toggles cards: the Sign-in step applies only to a
+            // Gateway install, so switching to "I already have a gateway" (Workstation) drops it live and
+            // switching back restores it.
+            _role = _welcomeStep?.SelectedRole ?? _role;
+            UpdateSidebar();
         };
         return step;
     }
@@ -180,6 +196,9 @@ public partial class MainWindow : Window
 
     private Border[] GetLines() => [Line12, Line23, Line34, Line45, Line56, Line67];
 
+    private Panel[] GetStepRows() =>
+        [Step1Row, Step2Row, Step3Row, Step4Row, Step5Row, Step6Row, Step7Row];
+
     private void ShowStep(int step)
     {
         SetupLog.Write($"[MainWindow] ShowStep: step={step}");
@@ -213,24 +232,43 @@ public partial class MainWindow : Window
     private void UpdateSidebar()
     {
         var stepUIs = GetStepUIs();
+        var rows = GetStepRows();
         var lines = GetLines();
+        var visible = VisibleSteps();
         var accentBrush = (SolidColorBrush)FindResource("AccentBrush");
         var successBrush = (SolidColorBrush)FindResource("SuccessBrush");
         var inactiveBrush = (SolidColorBrush)FindResource("StepInactive");
         var dimBrush = (SolidColorBrush)FindResource("DimText");
+        var doneLabelBrush = new SolidColorBrush(Color.FromRgb(0xCC, 0xCC, 0xCC));
+
+        // Progress is measured by position within the visible steps, not the absolute step id, so a
+        // skipped step never throws off the highlighting.
+        var currentPos = visible.IndexOf(_currentStep);
 
         for (int i = 0; i < stepUIs.Count; i++)
         {
-            var stepNum = i + 1;
+            var stepId = i + 1;
             var ui = stepUIs[i];
+            var pos = visible.IndexOf(stepId);
 
-            if (stepNum < _currentStep)
+            // A step not in the visible set (Sign-in on a Workstation) is hidden entirely.
+            if (pos < 0)
+            {
+                rows[i].Visibility = Visibility.Collapsed;
+                continue;
+            }
+
+            rows[i].Visibility = Visibility.Visible;
+            // Renumber the visible circles 1..N so a skipped step leaves no gap (e.g. "...2, 4...").
+            if (ui.Number != null) ui.Number.Text = (pos + 1).ToString();
+
+            if (pos < currentPos)
             {
                 ui.Circle.Background = successBrush;
-                ui.Label.Foreground = new SolidColorBrush(Color.FromRgb(0xCC, 0xCC, 0xCC));
+                ui.Label.Foreground = doneLabelBrush;
                 if (ui.Number != null) ui.Number.Foreground = Brushes.White;
             }
-            else if (stepNum == _currentStep)
+            else if (pos == currentPos)
             {
                 ui.Circle.Background = accentBrush;
                 ui.Label.Foreground = Brushes.White;
@@ -242,11 +280,20 @@ public partial class MainWindow : Window
                 ui.Label.Foreground = dimBrush;
                 if (ui.Number != null) ui.Number.Foreground = dimBrush;
             }
+        }
 
-            if (i < lines.Length)
+        // A line sits after step (i+1). Hide the line that trails a hidden step so the rail stays
+        // continuous (Workstation: step 2's line runs straight into Privacy).
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var pos = visible.IndexOf(i + 1);
+            if (pos < 0)
             {
-                lines[i].Background = stepNum < _currentStep ? successBrush : inactiveBrush;
+                lines[i].Visibility = Visibility.Collapsed;
+                continue;
             }
+            lines[i].Visibility = Visibility.Visible;
+            lines[i].Background = pos < currentPos ? successBrush : inactiveBrush;
         }
     }
 
@@ -527,7 +574,7 @@ public partial class MainWindow : Window
     private void BackButton_Click(object sender, RoutedEventArgs e)
     {
         if (_currentStep > 1)
-            ShowStep(_currentStep - 1);
+            ShowStep(PrevStep(_currentStep));
     }
 
     private void NextButton_Click(object sender, RoutedEventArgs e)
@@ -561,6 +608,9 @@ public partial class MainWindow : Window
                         ?? throw new InvalidOperationException("Next reached on Welcome with no role selected.");
                 SetupLog.Write($"[MainWindow] role selected: {_role}");
                 _prerequisitesStep = null;
+                // Drop any captured sign-in if the role changed: a Workstation skips Sign-in entirely, and a
+                // re-entry as Gateway should start the sign-in fresh.
+                _signInStep = null;
                 _privacyStep = null;
                 _skillsStep = null;
                 _installStep = null;
@@ -578,7 +628,7 @@ public partial class MainWindow : Window
             if (_currentStep == StepInstall)
                 _completeStep = null;
 
-            ShowStep(_currentStep + 1);
+            ShowStep(NextStep(_currentStep));
         }
     }
 

--- a/tools/cc-director-setup/Services/InstallDetector.cs
+++ b/tools/cc-director-setup/Services/InstallDetector.cs
@@ -11,8 +11,22 @@ namespace CcDirectorSetup.Services;
 /// </summary>
 public static class InstallDetector
 {
-    private static readonly string Root = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "cc-director");
+    private static readonly string Root = ResolveRoot();
+
+    /// <summary>
+    /// The per-user install root used for detection. A non-empty <c>CC_DIRECTOR_SETUP_INSTALL_ROOT</c>
+    /// environment variable overrides it so QA/CI can exercise the wizard in fresh-install mode on a
+    /// machine that already has a real install. The override changes ONLY what the wizard detects; it
+    /// never redirects where an actual install is written.
+    /// </summary>
+    private static string ResolveRoot()
+    {
+        var overrideRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_SETUP_INSTALL_ROOT");
+        if (!string.IsNullOrWhiteSpace(overrideRoot))
+            return overrideRoot;
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "cc-director");
+    }
 
     private static readonly string AppExe = Path.Combine(Root, "app", "cc-director.exe");
     private static readonly string LegacyExe = Path.Combine(Root, "bin", "cc-director.exe");

--- a/tools/cc-director-setup/Services/WizardStepFlow.cs
+++ b/tools/cc-director-setup/Services/WizardStepFlow.cs
@@ -1,0 +1,51 @@
+using CcDirector.Setup.Engine;
+
+namespace CcDirectorSetup.Services;
+
+/// <summary>
+/// Pure navigation policy for the install wizard's step rail. Separated from the WPF
+/// <see cref="MainWindow"/> so the role-aware step ordering is unit-testable without a UI.
+///
+/// The step ids match MainWindow's wizard step numbers: 1 Welcome, 2 Prerequisites, 3 Sign in,
+/// 4 Privacy, 5 Skills, 6 Install, 7 Complete. The Sign-in step applies only to a Gateway install -
+/// a Workstation connects to an existing Gateway and signs in there - so the wizard skips step 3
+/// entirely for the Workstation role.
+/// </summary>
+public static class WizardStepFlow
+{
+    /// <summary>The Sign-in step id. Gateway-only; skipped for a Workstation.</summary>
+    public const int StepSignIn = 3;
+
+    private static readonly int[] AllSteps = [1, 2, StepSignIn, 4, 5, 6, 7];
+
+    /// <summary>True when the in-wizard Sign-in step applies to the given role (Gateway only).</summary>
+    public static bool SignInApplies(InstallRole role) => role == InstallRole.Gateway;
+
+    /// <summary>The step ids shown for the given role, in order. The Sign-in step (3) is dropped for a
+    /// Workstation, so the rail flows 2 -> Privacy with no gap.</summary>
+    public static List<int> VisibleSteps(InstallRole role)
+    {
+        var steps = new List<int>(AllSteps);
+        if (!SignInApplies(role))
+            steps.Remove(StepSignIn);
+        return steps;
+    }
+
+    /// <summary>The next visible step after <paramref name="step"/>, skipping Sign-in for a Workstation.</summary>
+    public static int NextStep(int step, InstallRole role)
+    {
+        var next = step + 1;
+        if (next == StepSignIn && !SignInApplies(role))
+            next++;
+        return next;
+    }
+
+    /// <summary>The previous visible step before <paramref name="step"/>, skipping Sign-in for a Workstation.</summary>
+    public static int PrevStep(int step, InstallRole role)
+    {
+        var prev = step - 1;
+        if (prev == StepSignIn && !SignInApplies(role))
+            prev--;
+        return prev;
+    }
+}


### PR DESCRIPTION
## What and why

The installer wizard forced the first-run sign-in step on every install, including a plain Workstation. Sign-in belongs only on the Gateway, which holds the account; a Workstation connects to an existing Gateway and signs in there. This makes the wizard skip the Sign-in step entirely for the Workstation role.

## Changes

- Add `WizardStepFlow`, a pure helper that owns the role-aware step ordering (visible steps, next/previous, sign-in-applies) so the navigation policy is unit-testable without constructing the WPF window.
- `MainWindow` navigates forward and back through the visible steps, hides the Sign-in row in the step rail and renumbers the remaining circles for a Workstation, tracks the chosen role live as the user toggles the Welcome cards, and defaults the role to Gateway to match the pre-selected card.
- The Privacy step already handles the absence of a sign-in token (it defaults the usage-sharing choice on and mirrors it to the local config), so the Workstation path reaches Privacy with no token and no error.
- Add a detection seam to `InstallDetector`: a `CC_DIRECTOR_SETUP_INSTALL_ROOT` environment variable redirects only the wizard's install detection to a scratch root, so the fresh-install role picker can be exercised on a machine that already has a real install. It never redirects an actual install.
- Add `WizardStepFlowTests` (nine tests) and a non-destructive user-interface driver script that walks the real built installer through the Workstation path.

## Testing

- `WizardStepFlowTests` (9 tests) and the full setup test suite (30 tests) pass.
- Built the installer self-contained for win-x64 and drove the real binary through the Workstation path with Windows UI Automation:
  - Gateway (default) rail includes Sign-in.
  - Selecting "I already have a gateway" (Workstation) drops the Sign-in step and renumbers the rail 1 through 6 with no gap.
  - Advancing past Prerequisites lands on Privacy ("A quick, honest note"), not Sign-in.
  - The Privacy pre-fill works with no sign-in token (no error).
  - The test stops before the Install step, so no real install is performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)